### PR TITLE
perf(native): tighten keyed invalidation + impacted-source indexing

### DIFF
--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -5175,63 +5175,7 @@ fn native_update_compile_session_post_build_state(
     }
 }
 
-#[cfg(feature = "native-compile")]
-fn native_impacted_contract_indices(
-    module_paths: &[String],
-    contract_source_paths: &[Option<String>],
-    changed_files: &[String],
-    removed_files: &[String],
-    contract_source_dependencies: &BTreeMap<String, BTreeSet<String>>,
-) -> Option<Vec<usize>> {
-    if changed_files.is_empty() && removed_files.is_empty() {
-        return Some(Vec::new());
-    }
-    let changed_sources: HashSet<&str> = changed_files
-        .iter()
-        .chain(removed_files.iter())
-        .map(String::as_str)
-        .collect();
-    let mut unmatched_sources = changed_sources.clone();
-    let mut impacted = BTreeSet::new();
-    let mut dependency_index_complete = true;
-    for (index, module_path) in module_paths.iter().enumerate() {
-        if let Some(dependencies) = contract_source_dependencies.get(module_path) {
-            if dependencies.is_empty() {
-                dependency_index_complete = false;
-            }
-            let mut contract_impacted = false;
-            for dependency in dependencies {
-                if changed_sources.contains(dependency.as_str()) {
-                    contract_impacted = true;
-                    unmatched_sources.remove(dependency.as_str());
-                }
-            }
-            if contract_impacted {
-                impacted.insert(index);
-            }
-            continue;
-        }
-        dependency_index_complete = false;
-        if let Some(Some(source_path)) = contract_source_paths.get(index) {
-            if changed_sources.contains(source_path.as_str()) {
-                impacted.insert(index);
-                unmatched_sources.remove(source_path.as_str());
-            }
-        }
-    }
-    if !dependency_index_complete && !unmatched_sources.is_empty() {
-        tracing::debug!(
-            changed_files = changed_files.len(),
-            removed_files = removed_files.len(),
-            indexed_sources = changed_sources.len().saturating_sub(unmatched_sources.len()),
-            "native impacted subset index is incomplete for changed file set; falling back to full compile"
-        );
-        return None;
-    }
-    Some(impacted.into_iter().collect())
-}
-
-#[cfg(feature = "native-compile")]
+#[cfg(all(feature = "native-compile", test))]
 fn native_contract_dependency_index_complete(
     contract_output_plans: &[NativeContractOutputPlan],
     contract_source_dependencies: &BTreeMap<String, BTreeSet<String>>,
@@ -5247,6 +5191,91 @@ fn native_contract_dependency_index_complete(
 }
 
 #[cfg(feature = "native-compile")]
+fn native_contract_source_index_for_module_paths(
+    module_paths: &[String],
+    contract_source_dependencies: &BTreeMap<String, BTreeSet<String>>,
+) -> (HashMap<String, Vec<usize>>, bool) {
+    let mut by_source_sets: HashMap<String, BTreeSet<usize>> = HashMap::new();
+    let mut dependency_index_complete = !module_paths.is_empty();
+    for (index, module_path) in module_paths.iter().enumerate() {
+        let Some(dependencies) = contract_source_dependencies.get(module_path) else {
+            dependency_index_complete = false;
+            continue;
+        };
+        if dependencies.is_empty() {
+            dependency_index_complete = false;
+            continue;
+        }
+        for dependency in dependencies {
+            by_source_sets
+                .entry(dependency.clone())
+                .or_default()
+                .insert(index);
+        }
+    }
+    let by_source = by_source_sets
+        .into_iter()
+        .map(|(source, indices)| (source, indices.into_iter().collect::<Vec<_>>()))
+        .collect();
+    (by_source, dependency_index_complete)
+}
+
+#[cfg(feature = "native-compile")]
+fn native_contract_source_index(
+    contract_output_plans: &[NativeContractOutputPlan],
+    contract_source_dependencies: &BTreeMap<String, BTreeSet<String>>,
+) -> (HashMap<String, Vec<usize>>, bool) {
+    let module_paths = contract_output_plans
+        .iter()
+        .map(|plan| plan.module_path.clone())
+        .collect::<Vec<_>>();
+    native_contract_source_index_for_module_paths(&module_paths, contract_source_dependencies)
+}
+
+#[cfg(feature = "native-compile")]
+fn native_collect_impacted_contract_indices_from_source_index(
+    by_source: &HashMap<String, Vec<usize>>,
+    changed_files: &[String],
+    removed_files: &[String],
+) -> (BTreeSet<usize>, BTreeSet<String>) {
+    let mut impacted = BTreeSet::new();
+    let mut unmatched_sources = BTreeSet::new();
+    for source in changed_files.iter().chain(removed_files.iter()) {
+        let Some(indices) = by_source.get(source) else {
+            unmatched_sources.insert(source.clone());
+            continue;
+        };
+        for index in indices {
+            impacted.insert(*index);
+        }
+    }
+    (impacted, unmatched_sources)
+}
+
+#[cfg(feature = "native-compile")]
+fn native_filter_changed_files_to_contract_source_index(
+    changed_files: &[String],
+    removed_files: &[String],
+    by_source: &HashMap<String, Vec<usize>>,
+    dependency_index_complete: bool,
+) -> (Vec<String>, Vec<String>) {
+    if !dependency_index_complete {
+        return (changed_files.to_vec(), removed_files.to_vec());
+    }
+    let scoped_changed = changed_files
+        .iter()
+        .filter(|source| by_source.contains_key(source.as_str()))
+        .cloned()
+        .collect();
+    let scoped_removed = removed_files
+        .iter()
+        .filter(|source| by_source.contains_key(source.as_str()))
+        .cloned()
+        .collect();
+    (scoped_changed, scoped_removed)
+}
+
+#[cfg(all(feature = "native-compile", test))]
 fn native_changed_files_affect_tracked_contracts(
     changed_files: &[String],
     removed_files: &[String],
@@ -5256,23 +5285,16 @@ fn native_changed_files_affect_tracked_contracts(
     if changed_files.is_empty() && removed_files.is_empty() {
         return false;
     }
-    if !native_contract_dependency_index_complete(
-        contract_output_plans,
-        contract_source_dependencies,
-    ) {
+    let (by_source, dependency_index_complete) =
+        native_contract_source_index(contract_output_plans, contract_source_dependencies);
+    if !dependency_index_complete {
         // Keep the conservative behavior when dependency coverage is incomplete.
         return true;
     }
-    let changed_sources: HashSet<&str> = changed_files
+    changed_files
         .iter()
         .chain(removed_files.iter())
-        .map(String::as_str)
-        .collect();
-    contract_source_dependencies.values().any(|dependencies| {
-        dependencies
-            .iter()
-            .any(|path| changed_sources.contains(path.as_str()))
-    })
+        .any(|source| by_source.contains_key(source.as_str()))
 }
 
 #[cfg(all(feature = "native-compile", test))]
@@ -5282,25 +5304,72 @@ fn native_impacted_contract_indices_from_source_index(
     removed_files: &[String],
     dependency_index_complete: bool,
 ) -> Option<Vec<usize>> {
-    let mut impacted = BTreeSet::new();
-    let mut unmatched_source_found = false;
-    for source in changed_files.iter().chain(removed_files.iter()) {
-        let Some(indices) = by_source.get(source) else {
-            unmatched_source_found = true;
-            continue;
-        };
-        for index in indices {
-            impacted.insert(*index);
-        }
-    }
-    if unmatched_source_found && !dependency_index_complete {
+    let (impacted, unmatched_sources) = native_collect_impacted_contract_indices_from_source_index(
+        by_source,
+        changed_files,
+        removed_files,
+    );
+    if !unmatched_sources.is_empty() && !dependency_index_complete {
         tracing::debug!(
             changed_files = changed_files.len(),
             removed_files = removed_files.len(),
-            indexed_sources = by_source.len(),
+            indexed_sources = changed_files
+                .iter()
+                .chain(removed_files.iter())
+                .map(String::as_str)
+                .collect::<HashSet<_>>()
+                .len()
+                .saturating_sub(unmatched_sources.len()),
             "native impacted subset index is incomplete for changed file set; falling back to full compile"
         );
         return None;
+    }
+    Some(impacted.into_iter().collect())
+}
+
+#[cfg(feature = "native-compile")]
+fn native_impacted_contract_indices(
+    module_paths: &[String],
+    contract_source_paths: &[Option<String>],
+    changed_files: &[String],
+    removed_files: &[String],
+    contract_source_dependencies: &BTreeMap<String, BTreeSet<String>>,
+) -> Option<Vec<usize>> {
+    if changed_files.is_empty() && removed_files.is_empty() {
+        return Some(Vec::new());
+    }
+    let (by_source, dependency_index_complete) =
+        native_contract_source_index_for_module_paths(module_paths, contract_source_dependencies);
+    let (mut impacted, mut unmatched_sources) =
+        native_collect_impacted_contract_indices_from_source_index(
+            &by_source,
+            changed_files,
+            removed_files,
+        );
+    if !unmatched_sources.is_empty() && !dependency_index_complete {
+        for (index, source_path) in contract_source_paths.iter().enumerate() {
+            let Some(source_path) = source_path else {
+                continue;
+            };
+            if unmatched_sources.remove(source_path) {
+                impacted.insert(index);
+            }
+        }
+        if !unmatched_sources.is_empty() {
+            tracing::debug!(
+                changed_files = changed_files.len(),
+                removed_files = removed_files.len(),
+                indexed_sources = changed_files
+                    .iter()
+                    .chain(removed_files.iter())
+                    .map(String::as_str)
+                    .collect::<HashSet<_>>()
+                    .len()
+                    .saturating_sub(unmatched_sources.len()),
+                "native impacted subset index is incomplete for changed file set; falling back to full compile"
+            );
+            return None;
+        }
     }
     Some(impacted.into_iter().collect())
 }
@@ -7044,21 +7113,29 @@ fn with_native_compile_session<T>(
             refresh_action,
             NativeSessionRefreshAction::IncrementalChangedSet
         ) {
-            if native_changed_files_affect_tracked_contracts(
-                &changed_files,
-                &removed_files,
+            let (by_source, dependency_index_complete) = native_contract_source_index(
                 &session.contract_output_plans,
                 &session.contract_source_dependencies,
-            ) {
+            );
+            let (scoped_changed_files, scoped_removed_files) =
+                native_filter_changed_files_to_contract_source_index(
+                    &changed_files,
+                    &removed_files,
+                    &by_source,
+                    dependency_index_complete,
+                );
+            if !scoped_changed_files.is_empty() || !scoped_removed_files.is_empty() {
                 // Prefer file-keyed override updates for relevant source changes to avoid coarse
                 // full-DB invalidation on every incremental refresh.
                 match native_apply_file_keyed_session_updates(
                     &mut session.db,
                     workspace_root,
-                    &changed_files,
-                    &removed_files,
+                    &scoped_changed_files,
+                    &scoped_removed_files,
                 ) {
                     Ok(applied_override_update) => {
+                        changed_files = scoped_changed_files;
+                        removed_files = scoped_removed_files;
                         if applied_override_update {
                             tracing::debug!(
                                 changed_files = changed_files.len(),

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -5175,21 +5175,6 @@ fn native_update_compile_session_post_build_state(
     }
 }
 
-#[cfg(all(feature = "native-compile", test))]
-fn native_contract_dependency_index_complete(
-    contract_output_plans: &[NativeContractOutputPlan],
-    contract_source_dependencies: &BTreeMap<String, BTreeSet<String>>,
-) -> bool {
-    if contract_output_plans.is_empty() {
-        return false;
-    }
-    contract_output_plans.iter().all(|plan| {
-        contract_source_dependencies
-            .get(&plan.module_path)
-            .is_some_and(|dependencies| !dependencies.is_empty())
-    })
-}
-
 #[cfg(feature = "native-compile")]
 fn native_contract_source_index_for_module_paths(
     module_paths: &[String],
@@ -5253,6 +5238,20 @@ fn native_collect_impacted_contract_indices_from_source_index(
 }
 
 #[cfg(feature = "native-compile")]
+fn native_indexed_source_metric(
+    changed_files: &[String],
+    removed_files: &[String],
+    unmatched_sources: &BTreeSet<String>,
+) -> usize {
+    // Logging-only metric: duplicates across changed/removed paths are uncommon and
+    // acceptable for this coarse visibility counter.
+    changed_files
+        .len()
+        .saturating_add(removed_files.len())
+        .saturating_sub(unmatched_sources.len())
+}
+
+#[cfg(feature = "native-compile")]
 fn native_filter_changed_files_to_contract_source_index(
     changed_files: &[String],
     removed_files: &[String],
@@ -5313,13 +5312,8 @@ fn native_impacted_contract_indices_from_source_index(
         tracing::debug!(
             changed_files = changed_files.len(),
             removed_files = removed_files.len(),
-            indexed_sources = changed_files
-                .iter()
-                .chain(removed_files.iter())
-                .map(String::as_str)
-                .collect::<HashSet<_>>()
-                .len()
-                .saturating_sub(unmatched_sources.len()),
+            indexed_sources =
+                native_indexed_source_metric(changed_files, removed_files, &unmatched_sources),
             "native impacted subset index is incomplete for changed file set; falling back to full compile"
         );
         return None;
@@ -5346,6 +5340,19 @@ fn native_impacted_contract_indices(
             changed_files,
             removed_files,
         );
+    if dependency_index_complete {
+        // With a complete dependency index, unmatched changed/removed paths are
+        // intentionally treated as non-impacting to tracked contracts.
+        debug_assert!(
+            unmatched_sources.iter().all(|source| {
+                !contract_source_paths
+                    .iter()
+                    .flatten()
+                    .any(|tracked_source| tracked_source == source)
+            }),
+            "dependency index marked complete but a tracked contract source is missing from the index"
+        );
+    }
     if !unmatched_sources.is_empty() && !dependency_index_complete {
         for (index, source_path) in contract_source_paths.iter().enumerate() {
             let Some(source_path) = source_path else {
@@ -5359,13 +5366,8 @@ fn native_impacted_contract_indices(
             tracing::debug!(
                 changed_files = changed_files.len(),
                 removed_files = removed_files.len(),
-                indexed_sources = changed_files
-                    .iter()
-                    .chain(removed_files.iter())
-                    .map(String::as_str)
-                    .collect::<HashSet<_>>()
-                    .len()
-                    .saturating_sub(unmatched_sources.len()),
+                indexed_sources =
+                    native_indexed_source_metric(changed_files, removed_files, &unmatched_sources),
                 "native impacted subset index is incomplete for changed file set; falling back to full compile"
             );
             return None;
@@ -7134,6 +7136,8 @@ fn with_native_compile_session<T>(
                     &scoped_removed_files,
                 ) {
                     Ok(applied_override_update) => {
+                        // Intentionally narrow the downstream snapshot scope on success:
+                        // only tracked sources that reached keyed DB updates should be seen as changed.
                         changed_files = scoped_changed_files;
                         removed_files = scoped_removed_files;
                         if applied_override_update {
@@ -7153,6 +7157,8 @@ fn with_native_compile_session<T>(
                         }
                     }
                     Err(err) => {
+                        // Keep the original (non-scoped) changed/removed sets on keyed-update
+                        // failure so downstream compilation stays conservative.
                         tracing::warn!(
                             workspace_root = %workspace_root.display(),
                             changed_files = changed_files.len(),

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -5155,6 +5155,98 @@ fn native_impacted_source_index_requires_complete_dependency_index_for_unmatched
 
 #[cfg(feature = "native-compile")]
 #[test]
+fn native_filter_changed_files_to_contract_source_index_skips_unrelated_sources_when_complete() {
+    let by_source = HashMap::from([
+        ("src/contract_a.cairo".to_string(), vec![0_usize]),
+        ("src/shared.cairo".to_string(), vec![0_usize, 1_usize]),
+        ("src/contract_b.cairo".to_string(), vec![1_usize]),
+    ]);
+    let (changed, removed) = native_filter_changed_files_to_contract_source_index(
+        &[
+            "src/contract_a.cairo".to_string(),
+            "src/unrelated_math.cairo".to_string(),
+        ],
+        &[
+            "src/unknown_removed.cairo".to_string(),
+            "src/contract_b.cairo".to_string(),
+        ],
+        &by_source,
+        true,
+    );
+    assert_eq!(
+        changed,
+        vec!["src/contract_a.cairo".to_string()],
+        "complete dependency index should scope changed-file overrides to tracked sources only"
+    );
+    assert_eq!(
+        removed,
+        vec!["src/contract_b.cairo".to_string()],
+        "complete dependency index should scope removed-file overrides to tracked sources only"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn native_filter_changed_files_to_contract_source_index_keeps_full_set_when_incomplete() {
+    let by_source = HashMap::from([("src/contract_a.cairo".to_string(), vec![0_usize])]);
+    let changed_input = vec![
+        "src/contract_a.cairo".to_string(),
+        "src/untracked.cairo".to_string(),
+    ];
+    let removed_input = vec!["src/removed_untracked.cairo".to_string()];
+    let (changed, removed) = native_filter_changed_files_to_contract_source_index(
+        &changed_input,
+        &removed_input,
+        &by_source,
+        false,
+    );
+    assert_eq!(
+        changed, changed_input,
+        "incomplete dependency indexes must keep conservative changed-file coverage"
+    );
+    assert_eq!(
+        removed, removed_input,
+        "incomplete dependency indexes must keep conservative removed-file coverage"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn native_contract_source_index_for_module_paths_tracks_per_source_indices_and_completeness() {
+    let module_paths = vec!["pkg::a".to_string(), "pkg::b".to_string()];
+    let dependencies = BTreeMap::from([(
+        "pkg::a".to_string(),
+        BTreeSet::from([
+            "src/contract_a.cairo".to_string(),
+            "src/shared.cairo".to_string(),
+        ]),
+    )]);
+    let (by_source, complete) =
+        native_contract_source_index_for_module_paths(&module_paths, &dependencies);
+    assert!(
+        !complete,
+        "missing dependency entries for any contract keep the index conservative/incomplete"
+    );
+    assert_eq!(
+        by_source
+            .get("src/contract_a.cairo")
+            .expect("source should be indexed"),
+        &vec![0_usize]
+    );
+    assert_eq!(
+        by_source
+            .get("src/shared.cairo")
+            .expect("shared source should be indexed"),
+        &vec![0_usize]
+    );
+    assert!(
+        by_source.get("src/contract_b.cairo").is_none(),
+        "contracts without dependency entries must not create synthetic source-index mappings"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
 fn native_impacted_contract_indices_uses_module_paths_without_rebuilding_source_index() {
     let module_paths = vec![
         "pkg::contract_a".to_string(),


### PR DESCRIPTION
## Summary
- scope native file-keyed incremental updates to dependency-indexed changed/removed files when index coverage is complete
- keep conservative full changed-file coverage when dependency index is incomplete
- rework impacted-contract selection to use source->contract index lookup + conservative fallback behavior
- add focused regression tests for source-index scoping and completeness behavior

## Why
This is the next ROI step from the supremacy research roadmap: reduce unnecessary invalidation churn on incremental daemon cycles and tighten impacted-unit selection from changed-file sets.

## Notes
- stacked on top of #15 (base branch: codex/native-compile-mvp)
- per request, tests were added but not executed in this pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the incremental invalidation pipeline for the native compile daemon by introducing a pre-built source-to-contract inverted index (`native_contract_source_index_for_module_paths`) that replaces the older per-invocation full scan. When the dependency index is complete, only changed/removed files that map to a tracked contract source are forwarded to the file-keyed DB update and the downstream snapshot; untracked changes are silently dropped rather than conservatively passed through. When the index is incomplete, the full changed/removed sets are preserved (existing conservative behaviour). Three regression tests are added to cover the new filter and index-building helpers.

Key concerns:

- **Critical: `debug_assert!` in `native_impacted_contract_indices` is a no-op in release builds.** If `dependency_index_complete` is erroneously `true` and a tracked contract source is absent from the index, the function silently returns a partial impacted set, causing those contracts to be skipped during incremental compilation. A release-visible fallback (warn + return `None`) is needed to make this failure mode recoverable rather than silent.
- **Tests were explicitly not executed per the PR description.** For a correctness-sensitive incremental invalidation path, unverified tests should block merge.
- **The `complete = true` branch of `native_contract_source_index_for_module_paths` (the fast-path that gates all scoping behaviour) has no dedicated test coverage** in the new additions — only the `complete = false` path is exercised.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge: a release-build silent under-invalidation risk exists, and the new regression tests have not been executed.
- The refactoring logic is architecturally sound and the conservative fallbacks are correctly wired. However, the `debug_assert!` that guards the key invariant (complete index ↔ all tracked sources indexed) is silently stripped in release builds, creating a production-invisible correctness hole. Additionally, the PR author explicitly states the new tests were not run, which is an unacceptable state for production-critical incremental compile logic. These two issues together warrant a low confidence score.
- Pay close attention to `crates/uc-cli/src/main.rs` lines 5343–5375 (`native_impacted_contract_indices` — the `debug_assert!` / release-build gap) and `crates/uc-cli/src/main_tests.rs` (unexecuted tests, missing `complete = true` coverage).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/uc-cli/src/main.rs | Core refactor: replaces the old `native_impacted_contract_indices` / `native_contract_dependency_index_complete` pair with a new three-function pipeline (build index → collect impacted → filter changed set). Logic is generally sound, but the `debug_assert!` in `native_impacted_contract_indices` silently skips its invariant check in release builds, creating a potential silent under-invalidation path if the dependency index is stale or misreported as complete. |
| crates/uc-cli/src/main_tests.rs | Three new regression tests added for `native_filter_changed_files_to_contract_source_index` and `native_contract_source_index_for_module_paths`; PR author explicitly states tests were not executed. The complete-index path of `native_contract_source_index_for_module_paths` (where all modules have deps and `complete == true` is returned) has no dedicated test coverage. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["IncrementalChangedSet refresh triggered"] --> B["native_contract_source_index\n(build by_source map + completeness flag)"]
    B --> C{"dependency_index_complete?"}
    C -- "false (incomplete)" --> D["native_filter_changed_files_to_contract_source_index\nreturns FULL changed/removed sets (conservative)"]
    C -- "true (complete)" --> E["native_filter_changed_files_to_contract_source_index\nfilters to only tracked sources"]
    D --> F{"scoped sets non-empty?"}
    E --> F
    F -- "empty" --> G["Clear changed_files + removed_files\nSkip file-keyed update\nSnapshot sees no changes"]
    F -- "non-empty" --> H["native_apply_file_keyed_session_updates\n(scoped sets)"]
    H --> I{"Ok?"}
    I -- "Ok(applied)" --> J["Narrow outer changed_files = scoped\nremoved_files = scoped\nSnapshot sees only tracked sources"]
    I -- "Err" --> K["Keep ORIGINAL (unscoped) changed/removed sets\nRebuild session state (conservative)"]
    J --> L["NativeCompileSessionSnapshot\nwith narrowed changed_files/removed_files"]
    K --> L
    G --> M["NativeCompileSessionSnapshot\nwith empty changed_files/removed_files"]
```

<sub>Last reviewed commit: 6c88556</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->