### PR TITLE
perf(native): cold-path supremacy phases 0-4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indent"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2924,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "clap",
+ "include_dir",
  "libc",
  "mimalloc",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1645,15 @@ dependencies = [
  "log",
  "sprs",
  "web-time",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2887,7 +2906,9 @@ dependencies = [
  "cairo-lang-starknet-classes",
  "clap",
  "libc",
+ "mimalloc",
  "notify",
+ "postcard",
  "salsa",
  "scarb-stable-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ cairo-lang-lowering = "2.16.0"
 cairo-lang-starknet = "2.16.0"
 cairo-lang-starknet-classes = "2.16.0"
 clap = { version = "4", features = ["derive"] }
+include_dir = "0.7"
 libc = "0.2"
 mimalloc = { version = "0.1", default-features = false }
 notify = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ cairo-lang-starknet = "2.16.0"
 cairo-lang-starknet-classes = "2.16.0"
 clap = { version = "4", features = ["derive"] }
 libc = "0.2"
+mimalloc = { version = "0.1", default-features = false }
 notify = "6"
+postcard = { version = "1", features = ["alloc"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 scarb-stable-hash = "1.0.0"

--- a/benchmarks/scripts/run_local_benchmarks.sh
+++ b/benchmarks/scripts/run_local_benchmarks.sh
@@ -313,8 +313,8 @@ fi
 if [[ "${#SCENARIO_FILTERS[@]}" -gt 0 ]]; then
   for scenario in "${SCENARIO_FILTERS[@]}"; do
     case "$MATRIX:$scenario" in
-      research:build.cold|research:build.warm_noop|research:build.warm_edit|research:build.warm_edit_semantic|research:metadata.online_cold|research:metadata.offline_warm) ;;
-      smoke:build.cold|smoke:build.warm_noop|smoke:build.warm_edit|smoke:build.warm_edit_semantic) ;;
+      research:build.cold|research:build.returning_cold|research:build.warm_noop|research:build.warm_edit|research:build.warm_edit_semantic|research:metadata.online_cold|research:metadata.offline_warm) ;;
+      smoke:build.cold|smoke:build.returning_cold|smoke:build.warm_noop|smoke:build.warm_edit|smoke:build.warm_edit_semantic) ;;
       *)
         echo "Scenario '$scenario' is not supported for matrix '$MATRIX'" >&2
         exit 1
@@ -800,7 +800,7 @@ prepare_workload_copy() {
 ensure_isolated_workload_dir() {
   local path="$1"
   case "$path" in
-    "$TMP_DIR"/workloads/*) ;;
+    "$TMP_DIR"/workloads/*|"$TMP_DIR"/cold-runs/*|"$TMP_DIR"/returning-cold-runs/*) ;;
     *)
       echo "Refusing destructive benchmark cleanup outside isolated workspace: $path" >&2
       exit 1
@@ -826,6 +826,13 @@ reset_workload_outputs() {
   ensure_isolated_workload_dir "$cwd"
   assert_no_active_uc_cache_lock "$cwd"
   rm -rf "$cwd/target" "$cwd/.uc" "$cwd/.scarb"
+}
+
+reset_workload_outputs_returning_cold() {
+  local cwd="$1"
+  ensure_isolated_workload_dir "$cwd"
+  assert_no_active_uc_cache_lock "$cwd"
+  rm -rf "$cwd/target"
 }
 
 reset_daemon_shared_cache_for_cold_run() {
@@ -902,6 +909,48 @@ run_build_cold() {
   done
 
   append_result "build.cold" "$workload" "$command_string" "$samples_file" "$runs" "$phase_file"
+}
+
+run_build_returning_cold() {
+  local workload="$1"
+  local cwd="$2"
+  local runs="$3"
+  local samples_file="$TMP_DIR/${TOOL}-${workload//\//_}-build-returning-cold.samples"
+  local phase_file="$TMP_DIR/${TOOL}-${workload//\//_}-build-returning-cold.phases.ndjson"
+  local seed_dir="$TMP_DIR/returning-cold-seed/${workload//\//_}"
+  local run_root="$TMP_DIR/returning-cold-runs/${workload//\//_}"
+  local command_string=""
+  : > "$samples_file"
+  : > "$phase_file"
+
+  ensure_isolated_workload_dir "$cwd"
+  mkdir -p "$(dirname "$seed_dir")"
+  rm -rf "$seed_dir"
+  cp -PR "$cwd" "$seed_dir"
+
+  local seed_manifest="$seed_dir/Scarb.toml"
+  local -a seed_command=()
+  build_command_for_manifest_with_mode "$seed_manifest" "$BUILD_OFFLINE"
+  seed_command=("${CMD_REPLY[@]}")
+  command_string="$(command_to_string "${seed_command[@]}")"
+  measure_command_ms "$seed_dir" "${seed_command[@]}" >/dev/null
+
+  for i in $(seq 1 "$runs"); do
+    local run_dir="$run_root/run-$i"
+    local run_manifest="$run_dir/Scarb.toml"
+    local -a run_command=()
+    mkdir -p "$(dirname "$run_dir")"
+    rm -rf "$run_dir"
+    cp -PR "$seed_dir" "$run_dir"
+    reset_workload_outputs_returning_cold "$run_dir"
+    reset_daemon_shared_cache_for_cold_run
+    build_command_for_manifest_with_mode "$run_manifest" "$BUILD_OFFLINE"
+    run_command=("${CMD_REPLY[@]}")
+    measure_command_ms "$run_dir" "${run_command[@]}" >> "$samples_file"
+    record_uc_phase_sample "$phase_file"
+  done
+
+  append_result "build.returning_cold" "$workload" "$command_string" "$samples_file" "$runs" "$phase_file"
 }
 
 run_build_warm_noop() {
@@ -1105,13 +1154,16 @@ if [[ "$MATRIX" == "research" ]]; then
   build_command_for_manifest "$WS_MANIFEST"
   WS_BUILD_CMD=("${CMD_REPLY[@]}")
 
-  if scenario_enabled "build.cold" || scenario_enabled "build.warm_noop" || scenario_enabled "build.warm_edit" || scenario_enabled "build.warm_edit_semantic"; then
+  if scenario_enabled "build.cold" || scenario_enabled "build.returning_cold" || scenario_enabled "build.warm_noop" || scenario_enabled "build.warm_edit" || scenario_enabled "build.warm_edit_semantic"; then
     prime_build_dependencies_if_needed "hello_world" "$HELLO_MANIFEST"
     prime_build_dependencies_if_needed "workspaces" "$WS_MANIFEST"
   fi
 
   if scenario_enabled "build.cold"; then
     run_build_cold "hello_world" "$HELLO_DIR" "$COLD_RUNS"
+  fi
+  if scenario_enabled "build.returning_cold"; then
+    run_build_returning_cold "hello_world" "$HELLO_DIR" "$COLD_RUNS"
   fi
   if scenario_enabled "build.warm_noop"; then
     run_build_warm_noop "hello_world" "$HELLO_DIR" "$RUNS" "${HELLO_BUILD_CMD[@]}"
@@ -1125,6 +1177,9 @@ if [[ "$MATRIX" == "research" ]]; then
 
   if scenario_enabled "build.cold"; then
     run_build_cold "workspaces" "$WS_DIR" "$COLD_RUNS"
+  fi
+  if scenario_enabled "build.returning_cold"; then
+    run_build_returning_cold "workspaces" "$WS_DIR" "$COLD_RUNS"
   fi
   if scenario_enabled "build.warm_noop"; then
     run_build_warm_noop "workspaces" "$WS_DIR" "$RUNS" "${WS_BUILD_CMD[@]}"
@@ -1158,12 +1213,15 @@ elif [[ "$MATRIX" == "smoke" ]]; then
   build_command_for_manifest "$SMOKE_MANIFEST"
   SMOKE_BUILD_CMD=("${CMD_REPLY[@]}")
 
-  if scenario_enabled "build.cold" || scenario_enabled "build.warm_noop" || scenario_enabled "build.warm_edit" || scenario_enabled "build.warm_edit_semantic"; then
+  if scenario_enabled "build.cold" || scenario_enabled "build.returning_cold" || scenario_enabled "build.warm_noop" || scenario_enabled "build.warm_edit" || scenario_enabled "build.warm_edit_semantic"; then
     prime_build_dependencies_if_needed "scarb_smoke" "$SMOKE_MANIFEST"
   fi
 
   if scenario_enabled "build.cold"; then
     run_build_cold "scarb_smoke" "$SMOKE_DIR" "$COLD_RUNS"
+  fi
+  if scenario_enabled "build.returning_cold"; then
+    run_build_returning_cold "scarb_smoke" "$SMOKE_DIR" "$COLD_RUNS"
   fi
   if scenario_enabled "build.warm_noop"; then
     run_build_warm_noop "scarb_smoke" "$SMOKE_DIR" "$RUNS" "${SMOKE_BUILD_CMD[@]}"

--- a/benchmarks/scripts/run_local_benchmarks.sh
+++ b/benchmarks/scripts/run_local_benchmarks.sh
@@ -605,7 +605,16 @@ pattern = re.compile(
     r"native_session_prepare=(?P<native_session_prepare>[0-9.]+)\s+"
     r"native_frontend_compile=(?P<native_frontend_compile>[0-9.]+)\s+"
     r"native_casm=(?P<native_casm>[0-9.]+)\s+"
-    r"native_artifact_write=(?P<native_artifact_write>[0-9.]+))?"
+    r"native_artifact_write=(?P<native_artifact_write>[0-9.]+)"
+    r"(?:\s+native_find_contracts=(?P<native_find_contracts>[0-9.]+))?"
+    r"(?:\s+native_db_init=(?P<native_db_init>[0-9.]+))?"
+    r"(?:\s+native_setup_project=(?P<native_setup_project>[0-9.]+))?"
+    r"(?:\s+native_crate_cache_restore=(?P<native_crate_cache_restore>[0-9.]+))?"
+    r"(?:\s+native_source_scan=(?P<native_source_scan>[0-9.]+))?"
+    r"(?:\s+native_session_image_persist=(?P<native_session_image_persist>[0-9.]+))?"
+    r"(?:\s+native_buildinfo_persist=(?P<native_buildinfo_persist>[0-9.]+))?"
+    r"(?:\s+native_drift_scan=(?P<native_drift_scan>[0-9.]+))?"
+    r")?"
 )
 match = pattern.search(line)
 if not match:
@@ -636,6 +645,14 @@ payload = {
     "native_frontend_compile_ms": as_float(match.group("native_frontend_compile")),
     "native_casm_ms": as_float(match.group("native_casm")),
     "native_artifact_write_ms": as_float(match.group("native_artifact_write")),
+    "native_find_contracts_ms": as_float(match.group("native_find_contracts")),
+    "native_db_init_ms": as_float(match.group("native_db_init")),
+    "native_setup_project_ms": as_float(match.group("native_setup_project")),
+    "native_crate_cache_restore_ms": as_float(match.group("native_crate_cache_restore")),
+    "native_source_scan_ms": as_float(match.group("native_source_scan")),
+    "native_session_image_persist_ms": as_float(match.group("native_session_image_persist")),
+    "native_buildinfo_persist_ms": as_float(match.group("native_buildinfo_persist")),
+    "native_drift_scan_ms": as_float(match.group("native_drift_scan")),
 }
 with open(phase_file, "a", encoding="utf-8") as f:
     f.write(json.dumps(payload))

--- a/benchmarks/scripts/run_local_benchmarks.sh
+++ b/benchmarks/scripts/run_local_benchmarks.sh
@@ -950,7 +950,10 @@ run_build_returning_cold() {
   build_command_for_manifest_with_mode "$seed_manifest" "$BUILD_OFFLINE"
   seed_command=("${CMD_REPLY[@]}")
   command_string="$(command_to_string "${seed_command[@]}")"
-  measure_command_ms "$seed_dir" "${seed_command[@]}" >/dev/null
+  if ! measure_command_ms "$seed_dir" "${seed_command[@]}" >/dev/null; then
+    echo "ERROR: returning-cold seed build failed for $workload (${seed_command[*]})" >&2
+    return 1
+  fi
 
   for i in $(seq 1 "$runs"); do
     local run_dir="$run_root/run-$i"

--- a/crates/uc-cli/Cargo.toml
+++ b/crates/uc-cli/Cargo.toml
@@ -18,6 +18,7 @@ native-compile = [
   "dep:cairo-lang-starknet",
   "dep:cairo-lang-starknet-classes",
   "dep:notify",
+  "dep:postcard",
   "dep:scarb-stable-hash",
 ]
 # Embedded corelib path is compile-time optional so local/dev builds can opt out.
@@ -41,7 +42,7 @@ include_dir = { workspace = true, optional = true }
 libc.workspace = true
 mimalloc = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }
-postcard.workspace = true
+postcard = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 scarb-stable-hash = { workspace = true, optional = true }

--- a/crates/uc-cli/Cargo.toml
+++ b/crates/uc-cli/Cargo.toml
@@ -9,7 +9,7 @@ name = "uc"
 path = "src/main.rs"
 
 [features]
-default = ["native-compile", "mimalloc"]
+default = ["native-compile", "mimalloc", "embedded-corelib"]
 native-compile = [
   "dep:cairo-lang-compiler",
   "dep:cairo-lang-defs",
@@ -20,6 +20,10 @@ native-compile = [
   "dep:notify",
   "dep:scarb-stable-hash",
 ]
+# Embedded corelib path is compile-time optional so local/dev builds can opt out.
+embedded-corelib = ["dep:include_dir"]
+# `default-features = false` is inherited from workspace; this intentionally
+# prioritizes allocator throughput over mimalloc's optional hardened modes.
 mimalloc = ["dep:mimalloc"]
 dev-benchmark-command = []
 
@@ -33,7 +37,7 @@ cairo-lang-lowering = { workspace = true, optional = true }
 cairo-lang-starknet = { workspace = true, optional = true }
 cairo-lang-starknet-classes = { workspace = true, optional = true }
 clap.workspace = true
-include_dir.workspace = true
+include_dir = { workspace = true, optional = true }
 libc.workspace = true
 mimalloc = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }

--- a/crates/uc-cli/Cargo.toml
+++ b/crates/uc-cli/Cargo.toml
@@ -53,3 +53,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 uc-core = { path = "../uc-core" }
 walkdir.workspace = true
+
+[build-dependencies]
+toml.workspace = true

--- a/crates/uc-cli/Cargo.toml
+++ b/crates/uc-cli/Cargo.toml
@@ -9,7 +9,7 @@ name = "uc"
 path = "src/main.rs"
 
 [features]
-default = ["native-compile"]
+default = ["native-compile", "mimalloc"]
 native-compile = [
   "dep:cairo-lang-compiler",
   "dep:cairo-lang-defs",
@@ -20,6 +20,7 @@ native-compile = [
   "dep:notify",
   "dep:scarb-stable-hash",
 ]
+mimalloc = ["dep:mimalloc"]
 dev-benchmark-command = []
 
 [dependencies]
@@ -33,7 +34,9 @@ cairo-lang-starknet = { workspace = true, optional = true }
 cairo-lang-starknet-classes = { workspace = true, optional = true }
 clap.workspace = true
 libc.workspace = true
+mimalloc = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }
+postcard.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 scarb-stable-hash = { workspace = true, optional = true }

--- a/crates/uc-cli/Cargo.toml
+++ b/crates/uc-cli/Cargo.toml
@@ -33,6 +33,7 @@ cairo-lang-lowering = { workspace = true, optional = true }
 cairo-lang-starknet = { workspace = true, optional = true }
 cairo-lang-starknet-classes = { workspace = true, optional = true }
 clap.workspace = true
+include_dir.workspace = true
 libc.workspace = true
 mimalloc = { workspace = true, optional = true }
 notify = { workspace = true, optional = true }

--- a/crates/uc-cli/build.rs
+++ b/crates/uc-cli/build.rs
@@ -164,8 +164,10 @@ fn corelib_candidate_paths() -> Vec<PathBuf> {
         candidates.push(PathBuf::from(&home).join(".cairo/corelib/src"));
     }
 
-    candidates.sort();
-    candidates.dedup();
+    // Dedup while preserving insertion order (priority).  Do NOT sort —
+    // `find_corelib_src` returns the first match, so order encodes precedence.
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|p| seen.insert(p.clone()));
     candidates
 }
 
@@ -237,7 +239,7 @@ fn find_corelib_src(candidates: &[PathBuf]) -> Option<PathBuf> {
 
     // 3. Search relative to workspace root (mirrors runtime candidate search)
     for candidate in candidates {
-        if let Some(p) = try_candidate(candidate) {
+        if let Some(p) = try_candidate(candidate.as_path()) {
             return Some(p);
         }
     }

--- a/crates/uc-cli/build.rs
+++ b/crates/uc-cli/build.rs
@@ -13,13 +13,15 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(uc_no_embedded_corelib)");
     println!("cargo:rerun-if-env-changed=UC_BUILD_CORELIB_SRC");
     println!("cargo:rerun-if-env-changed=UC_NATIVE_CORELIB_SRC");
+    if let Some(lockfile) = workspace_lockfile_path() {
+        println!("cargo:rerun-if-changed={}", lockfile.display());
+    }
+    let candidates = corelib_candidate_paths();
+    emit_corelib_candidate_rerun_hints(&candidates);
 
-    match find_corelib_src() {
+    match find_corelib_src(&candidates) {
         Some(path) => {
-            println!(
-                "cargo:rustc-env=UC_CORELIB_SRC_DIR={}",
-                path.display()
-            );
+            println!("cargo:rustc-env=UC_CORELIB_SRC_DIR={}", path.display());
             println!(
                 "cargo:warning=Phase 5: embedding corelib from {}",
                 path.display()
@@ -27,9 +29,7 @@ fn main() {
         }
         None => {
             println!("cargo:rustc-cfg=uc_no_embedded_corelib");
-            println!(
-                "cargo:warning=Phase 5: no corelib found at compile time; embedding disabled"
-            );
+            println!("cargo:warning=Phase 5: no corelib found at compile time; embedding disabled");
         }
     }
 }
@@ -40,11 +40,15 @@ fn corelib_layout_looks_compatible(path: &Path) -> bool {
         && path.join("ops.cairo").is_file()
 }
 
+fn workspace_lockfile_path() -> Option<PathBuf> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok()?;
+    Some(Path::new(&manifest_dir).join("../../Cargo.lock"))
+}
+
 /// Read the cairo-lang-compiler version from the workspace Cargo.lock so we
 /// can verify that the discovered corelib matches the compiler we link against.
 fn compiler_version_from_lockfile() -> Option<String> {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok()?;
-    let lockfile_path = Path::new(&manifest_dir).join("../../Cargo.lock");
+    let lockfile_path = workspace_lockfile_path()?;
     let lockfile = std::fs::read_to_string(lockfile_path).ok()?;
     // Simple parse: look for [[package]] blocks with name = "cairo-lang-compiler"
     let mut in_target = false;
@@ -98,11 +102,37 @@ fn corelib_manifest_version(corelib_src: &Path) -> Option<String> {
 fn version_matches(corelib_src: &Path) -> bool {
     let compiler_ver = match compiler_version_from_lockfile() {
         Some(v) => v,
-        None => return true, // cannot verify; optimistically allow
+        None => {
+            println!(
+                "cargo:warning=Phase 5: rejecting corelib {} because compiler version in \
+                 Cargo.lock could not be read",
+                corelib_src.display()
+            );
+            return false;
+        }
     };
-    match corelib_manifest_version(corelib_src) {
-        Some(v) => v == compiler_ver,
-        None => true, // no Scarb.toml; treat as best-effort
+    let corelib_ver = match corelib_manifest_version(corelib_src) {
+        Some(v) => v,
+        None => {
+            println!(
+                "cargo:warning=Phase 5: rejecting corelib {} because adjacent Scarb.toml \
+                 version could not be read",
+                corelib_src.display()
+            );
+            return false;
+        }
+    };
+    if corelib_ver != compiler_ver {
+        println!(
+            "cargo:warning=Phase 5: rejecting corelib {} due to version mismatch \
+             (corelib={}, compiler={})",
+            corelib_src.display(),
+            corelib_ver,
+            compiler_ver
+        );
+        false
+    } else {
+        true
     }
 }
 
@@ -114,24 +144,15 @@ fn try_candidate(path: &Path) -> Option<PathBuf> {
     }
 }
 
-fn find_corelib_src() -> Option<PathBuf> {
-    // 1. Explicit build-time override
-    if let Ok(path) = env::var("UC_BUILD_CORELIB_SRC") {
-        if let Some(p) = try_candidate(Path::new(&path)) {
-            return Some(p);
-        }
-    }
-
-    // 2. Runtime env var (also useful at build time)
-    if let Ok(path) = env::var("UC_NATIVE_CORELIB_SRC") {
-        if let Some(p) = try_candidate(Path::new(&path)) {
-            return Some(p);
-        }
-    }
-
-    // 3. Search relative to workspace root (mirrors runtime native_corelib_candidate_paths)
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").ok()?);
-    let workspace_root = manifest_dir.parent()?.parent()?;
+fn corelib_candidate_paths() -> Vec<PathBuf> {
+    let manifest_dir = match env::var("CARGO_MANIFEST_DIR") {
+        Ok(value) => PathBuf::from(value),
+        Err(_) => return Vec::new(),
+    };
+    let workspace_root = match manifest_dir.parent().and_then(|parent| parent.parent()) {
+        Some(value) => value.to_path_buf(),
+        None => return Vec::new(),
+    };
 
     let mut candidates: Vec<PathBuf> = Vec::new();
 
@@ -140,12 +161,16 @@ fn find_corelib_src() -> Option<PathBuf> {
         candidates.push(parent.join("cairo/corelib/src"));
 
         // Sibling directories of workspace: <parent>/<sibling>/cairo/corelib/src
+        // read_dir order is filesystem-dependent; sort for deterministic discovery.
         if let Ok(entries) = std::fs::read_dir(parent) {
-            for entry in entries.flatten() {
-                if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                    candidates.push(entry.path().join("cairo/corelib/src"));
-                    candidates.push(entry.path().join("corelib/src"));
-                }
+            let mut sibling_dirs: Vec<_> = entries
+                .flatten()
+                .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+                .collect();
+            sibling_dirs.sort_by_key(|entry| entry.file_name());
+            for entry in sibling_dirs {
+                candidates.push(entry.path().join("cairo/corelib/src"));
+                candidates.push(entry.path().join("corelib/src"));
             }
         }
     }
@@ -165,6 +190,64 @@ fn find_corelib_src() -> Option<PathBuf> {
         candidates.push(PathBuf::from(&home).join(".cairo/corelib/src"));
     }
 
+    candidates.sort();
+    candidates.dedup();
+    candidates
+}
+
+fn emit_corelib_candidate_rerun_hints(candidates: &[PathBuf]) {
+    for candidate in candidates {
+        println!("cargo:rerun-if-changed={}", candidate.display());
+        if let Some(parent) = candidate.parent() {
+            let manifest = parent.join("Scarb.toml");
+            println!("cargo:rerun-if-changed={}", manifest.display());
+        }
+        println!(
+            "cargo:rerun-if-changed={}",
+            candidate.join("lib.cairo").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            candidate.join("prelude.cairo").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            candidate.join("ops.cairo").display()
+        );
+    }
+}
+
+fn find_corelib_src(candidates: &[PathBuf]) -> Option<PathBuf> {
+    // 1. Explicit build-time override. If present, fail loudly when invalid.
+    if let Ok(path) = env::var("UC_BUILD_CORELIB_SRC") {
+        if !path.trim().is_empty() {
+            let explicit = Path::new(&path);
+            println!("cargo:rerun-if-changed={}", explicit.display());
+            match try_candidate(explicit) {
+                Some(candidate) => return Some(candidate),
+                None => {
+                    panic!(
+                        "UC_BUILD_CORELIB_SRC is set to '{}' but it is not a compatible \
+                         corelib/src directory (missing required files or version mismatch)",
+                        path
+                    );
+                }
+            }
+        }
+    }
+
+    // 2. Runtime env var (also useful at build time)
+    if let Ok(path) = env::var("UC_NATIVE_CORELIB_SRC") {
+        if !path.trim().is_empty() {
+            let runtime_override = Path::new(&path);
+            println!("cargo:rerun-if-changed={}", runtime_override.display());
+            if let Some(candidate) = try_candidate(runtime_override) {
+                return Some(candidate);
+            }
+        }
+    }
+
+    // 3. Search relative to workspace root (mirrors runtime candidate search)
     for candidate in candidates {
         if let Some(p) = try_candidate(&candidate) {
             return Some(p);

--- a/crates/uc-cli/build.rs
+++ b/crates/uc-cli/build.rs
@@ -197,23 +197,30 @@ fn corelib_candidate_paths() -> Vec<PathBuf> {
 
 fn emit_corelib_candidate_rerun_hints(candidates: &[PathBuf]) {
     for candidate in candidates {
+        // Avoid non-existent paths: Cargo treats missing rerun-if-changed paths
+        // as "always dirty", which forces build.rs to rerun every invocation.
+        if !candidate.exists() {
+            continue;
+        }
         println!("cargo:rerun-if-changed={}", candidate.display());
         if let Some(parent) = candidate.parent() {
             let manifest = parent.join("Scarb.toml");
-            println!("cargo:rerun-if-changed={}", manifest.display());
+            if manifest.exists() {
+                println!("cargo:rerun-if-changed={}", manifest.display());
+            }
         }
-        println!(
-            "cargo:rerun-if-changed={}",
-            candidate.join("lib.cairo").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            candidate.join("prelude.cairo").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            candidate.join("ops.cairo").display()
-        );
+        let lib = candidate.join("lib.cairo");
+        if lib.exists() {
+            println!("cargo:rerun-if-changed={}", lib.display());
+        }
+        let prelude = candidate.join("prelude.cairo");
+        if prelude.exists() {
+            println!("cargo:rerun-if-changed={}", prelude.display());
+        }
+        let ops = candidate.join("ops.cairo");
+        if ops.exists() {
+            println!("cargo:rerun-if-changed={}", ops.display());
+        }
     }
 }
 

--- a/crates/uc-cli/build.rs
+++ b/crates/uc-cli/build.rs
@@ -1,0 +1,175 @@
+/// Build script for uc-cli.
+///
+/// Phase 5 (cold-path supremacy): discovers the Cairo corelib at compile time
+/// and exposes its path so `include_dir!` can embed it in the binary.
+///
+/// The embedded corelib eliminates the runtime filesystem search and guarantees
+/// a version-matched corelib is always available, even when no local Cairo
+/// installation exists.
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(uc_no_embedded_corelib)");
+    println!("cargo:rerun-if-env-changed=UC_BUILD_CORELIB_SRC");
+    println!("cargo:rerun-if-env-changed=UC_NATIVE_CORELIB_SRC");
+
+    match find_corelib_src() {
+        Some(path) => {
+            println!(
+                "cargo:rustc-env=UC_CORELIB_SRC_DIR={}",
+                path.display()
+            );
+            println!(
+                "cargo:warning=Phase 5: embedding corelib from {}",
+                path.display()
+            );
+        }
+        None => {
+            println!("cargo:rustc-cfg=uc_no_embedded_corelib");
+            println!(
+                "cargo:warning=Phase 5: no corelib found at compile time; embedding disabled"
+            );
+        }
+    }
+}
+
+fn corelib_layout_looks_compatible(path: &Path) -> bool {
+    path.join("lib.cairo").is_file()
+        && path.join("prelude.cairo").is_file()
+        && path.join("ops.cairo").is_file()
+}
+
+/// Read the cairo-lang-compiler version from the workspace Cargo.lock so we
+/// can verify that the discovered corelib matches the compiler we link against.
+fn compiler_version_from_lockfile() -> Option<String> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok()?;
+    let lockfile_path = Path::new(&manifest_dir).join("../../Cargo.lock");
+    let lockfile = std::fs::read_to_string(lockfile_path).ok()?;
+    // Simple parse: look for [[package]] blocks with name = "cairo-lang-compiler"
+    let mut in_target = false;
+    for line in lockfile.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[[package]]" {
+            in_target = false;
+            continue;
+        }
+        if trimmed == r#"name = "cairo-lang-compiler""# {
+            in_target = true;
+            continue;
+        }
+        if in_target && trimmed.starts_with("version = \"") {
+            let version = trimmed
+                .strip_prefix("version = \"")
+                .and_then(|s| s.strip_suffix('"'));
+            return version.map(String::from);
+        }
+    }
+    None
+}
+
+/// Read the corelib version from its Scarb.toml.
+fn corelib_manifest_version(corelib_src: &Path) -> Option<String> {
+    let manifest_path = corelib_src.parent()?.join("Scarb.toml");
+    let text = std::fs::read_to_string(manifest_path).ok()?;
+    // Simple parse: look for version = "..." in [package] section
+    let mut in_package = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[package]" {
+            in_package = true;
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_package = false;
+            continue;
+        }
+        if in_package && trimmed.starts_with("version") {
+            if let Some(rest) = trimmed.strip_prefix("version") {
+                let rest = rest.trim().strip_prefix('=')?.trim();
+                let rest = rest.strip_prefix('"')?.strip_suffix('"')?;
+                return Some(rest.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn version_matches(corelib_src: &Path) -> bool {
+    let compiler_ver = match compiler_version_from_lockfile() {
+        Some(v) => v,
+        None => return true, // cannot verify; optimistically allow
+    };
+    match corelib_manifest_version(corelib_src) {
+        Some(v) => v == compiler_ver,
+        None => true, // no Scarb.toml; treat as best-effort
+    }
+}
+
+fn try_candidate(path: &Path) -> Option<PathBuf> {
+    if path.exists() && corelib_layout_looks_compatible(path) && version_matches(path) {
+        path.canonicalize().ok()
+    } else {
+        None
+    }
+}
+
+fn find_corelib_src() -> Option<PathBuf> {
+    // 1. Explicit build-time override
+    if let Ok(path) = env::var("UC_BUILD_CORELIB_SRC") {
+        if let Some(p) = try_candidate(Path::new(&path)) {
+            return Some(p);
+        }
+    }
+
+    // 2. Runtime env var (also useful at build time)
+    if let Ok(path) = env::var("UC_NATIVE_CORELIB_SRC") {
+        if let Some(p) = try_candidate(Path::new(&path)) {
+            return Some(p);
+        }
+    }
+
+    // 3. Search relative to workspace root (mirrors runtime native_corelib_candidate_paths)
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").ok()?);
+    let workspace_root = manifest_dir.parent()?.parent()?;
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    // Direct children: <workspace>/../cairo/corelib/src
+    if let Some(parent) = workspace_root.parent() {
+        candidates.push(parent.join("cairo/corelib/src"));
+
+        // Sibling directories of workspace: <parent>/<sibling>/cairo/corelib/src
+        if let Ok(entries) = std::fs::read_dir(parent) {
+            for entry in entries.flatten() {
+                if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    candidates.push(entry.path().join("cairo/corelib/src"));
+                    candidates.push(entry.path().join("corelib/src"));
+                }
+            }
+        }
+    }
+
+    // Ancestors
+    for ancestor in workspace_root.ancestors().skip(1).take(6) {
+        candidates.push(ancestor.join("cairo/corelib/src"));
+        candidates.push(ancestor.join("corelib/src"));
+    }
+
+    // detect_corelib equivalent: CARGO_MANIFEST_DIR ancestors
+    for ancestor in manifest_dir.ancestors().skip(1).take(4) {
+        candidates.push(ancestor.join("corelib/src"));
+    }
+
+    if let Ok(home) = env::var("HOME") {
+        candidates.push(PathBuf::from(&home).join(".cairo/corelib/src"));
+    }
+
+    for candidate in candidates {
+        if let Some(p) = try_candidate(&candidate) {
+            return Some(p);
+        }
+    }
+
+    None
+}

--- a/crates/uc-cli/build.rs
+++ b/crates/uc-cli/build.rs
@@ -50,53 +50,27 @@ fn workspace_lockfile_path() -> Option<PathBuf> {
 fn compiler_version_from_lockfile() -> Option<String> {
     let lockfile_path = workspace_lockfile_path()?;
     let lockfile = std::fs::read_to_string(lockfile_path).ok()?;
-    // Simple parse: look for [[package]] blocks with name = "cairo-lang-compiler"
-    let mut in_target = false;
-    for line in lockfile.lines() {
-        let trimmed = line.trim();
-        if trimmed == "[[package]]" {
-            in_target = false;
-            continue;
-        }
-        if trimmed == r#"name = "cairo-lang-compiler""# {
-            in_target = true;
-            continue;
-        }
-        if in_target && trimmed.starts_with("version = \"") {
-            let version = trimmed
-                .strip_prefix("version = \"")
-                .and_then(|s| s.strip_suffix('"'));
-            return version.map(String::from);
-        }
-    }
-    None
+    let parsed: toml::Value = toml::from_str(&lockfile).ok()?;
+    let packages = parsed.get("package")?.as_array()?;
+    packages.iter().find_map(|entry| {
+        let table = entry.as_table()?;
+        (table.get("name")?.as_str()? == "cairo-lang-compiler")
+            .then(|| table.get("version")?.as_str().map(ToOwned::to_owned))
+            .flatten()
+    })
 }
 
 /// Read the corelib version from its Scarb.toml.
 fn corelib_manifest_version(corelib_src: &Path) -> Option<String> {
     let manifest_path = corelib_src.parent()?.join("Scarb.toml");
     let text = std::fs::read_to_string(manifest_path).ok()?;
-    // Simple parse: look for version = "..." in [package] section
-    let mut in_package = false;
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if trimmed == "[package]" {
-            in_package = true;
-            continue;
-        }
-        if trimmed.starts_with('[') {
-            in_package = false;
-            continue;
-        }
-        if in_package && trimmed.starts_with("version") {
-            if let Some(rest) = trimmed.strip_prefix("version") {
-                let rest = rest.trim().strip_prefix('=')?.trim();
-                let rest = rest.strip_prefix('"')?.strip_suffix('"')?;
-                return Some(rest.to_string());
-            }
-        }
-    }
-    None
+    let parsed: toml::Value = toml::from_str(&text).ok()?;
+    parsed
+        .get("package")
+        .and_then(toml::Value::as_table)
+        .and_then(|package| package.get("version"))
+        .and_then(toml::Value::as_str)
+        .map(ToOwned::to_owned)
 }
 
 fn version_matches(corelib_src: &Path) -> bool {
@@ -250,13 +224,20 @@ fn find_corelib_src(candidates: &[PathBuf]) -> Option<PathBuf> {
             println!("cargo:rerun-if-changed={}", runtime_override.display());
             if let Some(candidate) = try_candidate(runtime_override) {
                 return Some(candidate);
+            } else {
+                println!(
+                    "cargo:warning=Phase 5: UC_NATIVE_CORELIB_SRC='{}' is not a valid \
+                     compatible corelib/src (missing files or version mismatch); \
+                     falling back to discovery",
+                    path
+                );
             }
         }
     }
 
     // 3. Search relative to workspace root (mirrors runtime candidate search)
     for candidate in candidates {
-        if let Some(p) = try_candidate(&candidate) {
+        if let Some(p) = try_candidate(candidate) {
             return Some(p);
         }
     }

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -1210,7 +1210,7 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
     if should_log_phase_telemetry() {
         if let Some(telemetry) = phase_telemetry.as_ref() {
             eprintln!(
-                "uc: phase timings (ms) fingerprint={:.3} cache_lookup={:.3} cache_restore={:.3} compile={:.3} cache_persist={:.3} async={} scheduled={} daemon_used={} cache_hit={} native_context={:.3} native_target_dir={:.3} native_session_prepare={:.3} native_frontend_compile={:.3} native_casm={:.3} native_artifact_write={:.3} native_find_contracts={:.3} native_db_init={:.3} native_setup_project={:.3} native_source_scan={:.3} native_drift_scan={:.3}",
+                "uc: phase timings (ms) fingerprint={:.3} cache_lookup={:.3} cache_restore={:.3} compile={:.3} cache_persist={:.3} async={} scheduled={} daemon_used={} cache_hit={} native_context={:.3} native_target_dir={:.3} native_session_prepare={:.3} native_frontend_compile={:.3} native_casm={:.3} native_artifact_write={:.3} native_find_contracts={:.3} native_db_init={:.3} native_setup_project={:.3} native_crate_cache_restore={:.3} native_source_scan={:.3} native_session_image_persist={:.3} native_buildinfo_persist={:.3} native_drift_scan={:.3}",
                 telemetry.fingerprint_ms,
                 telemetry.cache_lookup_ms,
                 telemetry.cache_restore_ms,
@@ -1229,7 +1229,10 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                 telemetry.native_find_contracts_ms,
                 telemetry.native_db_init_ms,
                 telemetry.native_setup_project_ms,
+                telemetry.native_crate_cache_restore_ms,
                 telemetry.native_source_scan_ms,
+                telemetry.native_session_image_persist_ms,
+                telemetry.native_buildinfo_persist_ms,
                 telemetry.native_drift_scan_ms,
             );
         }

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -1210,7 +1210,7 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
     if should_log_phase_telemetry() {
         if let Some(telemetry) = phase_telemetry.as_ref() {
             eprintln!(
-                "uc: phase timings (ms) fingerprint={:.3} cache_lookup={:.3} cache_restore={:.3} compile={:.3} cache_persist={:.3} async={} scheduled={} daemon_used={} cache_hit={} native_context={:.3} native_target_dir={:.3} native_session_prepare={:.3} native_frontend_compile={:.3} native_casm={:.3} native_artifact_write={:.3}",
+                "uc: phase timings (ms) fingerprint={:.3} cache_lookup={:.3} cache_restore={:.3} compile={:.3} cache_persist={:.3} async={} scheduled={} daemon_used={} cache_hit={} native_context={:.3} native_target_dir={:.3} native_session_prepare={:.3} native_frontend_compile={:.3} native_casm={:.3} native_artifact_write={:.3} native_find_contracts={:.3} native_db_init={:.3} native_setup_project={:.3} native_source_scan={:.3} native_drift_scan={:.3}",
                 telemetry.fingerprint_ms,
                 telemetry.cache_lookup_ms,
                 telemetry.cache_restore_ms,
@@ -1225,7 +1225,12 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                 telemetry.native_session_prepare_ms,
                 telemetry.native_frontend_compile_ms,
                 telemetry.native_casm_ms,
-                telemetry.native_artifact_write_ms
+                telemetry.native_artifact_write_ms,
+                telemetry.native_find_contracts_ms,
+                telemetry.native_db_init_ms,
+                telemetry.native_setup_project_ms,
+                telemetry.native_source_scan_ms,
+                telemetry.native_drift_scan_ms,
             );
         }
     }

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -44,7 +44,11 @@ use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 #[cfg(feature = "native-compile")]
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 use include_dir::{include_dir, Dir};
 #[cfg(feature = "native-compile")]
 use notify::event::{ModifyKind as NotifyModifyKind, RenameMode as NotifyRenameMode};
@@ -58,7 +62,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::ffi::CString;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Read, Write};
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, feature = "embedded-corelib"))]
 use std::os::fd::AsRawFd;
 #[cfg(target_os = "macos")]
 use std::os::unix::ffi::OsStrExt;
@@ -73,7 +77,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, Sender, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -103,7 +107,11 @@ use fingerprint::*;
 /// `UC_CORELIB_SRC_DIR`; we embed the entire `corelib/src/` directory
 /// so the binary is self-contained and the runtime corelib search is
 /// eliminated on first run.
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 static EMBEDDED_CORELIB: Dir<'_> = include_dir!("$UC_CORELIB_SRC_DIR");
 
 const BUILD_CACHE_SCHEMA_VERSION: u32 = 1;
@@ -190,15 +198,21 @@ const DEFAULT_NATIVE_COMPILE_SESSION_MEMORY_MULTIPLIER: u64 = 64;
 #[cfg(feature = "native-compile")]
 const DEFAULT_NATIVE_COMPILE_SESSION_MEMORY_BASE_OVERHEAD_BYTES: u64 = 32 * 1024 * 1024;
 #[cfg(feature = "native-compile")]
-// Phase 4: bumped from 1 → 2 for postcard binary serialization (invalidates old JSON caches)
+// Phase 4: bumped from 1 → 2 for postcard binary serialization (with JSON-v1 fallback).
 const NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION: u32 = 2;
+#[cfg(feature = "native-compile")]
+const NATIVE_COMPILE_SESSION_IMAGE_LEGACY_JSON_SCHEMA_VERSION: u32 = 1;
 #[cfg(feature = "native-compile")]
 const MAX_NATIVE_COMPILE_SESSION_IMAGE_BYTES: u64 = 8 * 1024 * 1024;
 #[cfg(feature = "native-compile")]
-// Phase 4: bumped from 1 → 2 for postcard binary serialization (invalidates old JSON caches)
+// Phase 4: bumped from 1 → 2 for postcard binary serialization (with JSON-v1 fallback).
 const NATIVE_BUILDINFO_SCHEMA_VERSION: u32 = 2;
 #[cfg(feature = "native-compile")]
+const NATIVE_BUILDINFO_LEGACY_JSON_SCHEMA_VERSION: u32 = 1;
+#[cfg(feature = "native-compile")]
 const MAX_NATIVE_BUILDINFO_BYTES: u64 = 16 * 1024 * 1024;
+#[cfg(feature = "native-compile")]
+const MAX_CORELIB_SIERRA_BLOB_BYTES: u64 = 64 * 1024 * 1024;
 #[cfg(feature = "native-compile")]
 const NATIVE_CRATE_CACHE_ENTRY_SCHEMA_VERSION: u32 = 1;
 #[cfg(feature = "native-compile")]
@@ -963,6 +977,8 @@ struct NativeCompileSessionState {
     build_setup_project_ms: f64,
     build_crate_cache_restore_ms: f64,
     build_source_scan_ms: f64,
+    build_session_image_persist_ms: f64,
+    build_buildinfo_persist_ms: f64,
     // Phase 2: true when tracked_sources were freshly scanned from disk
     // (not restored from image/buildinfo/replay). Only skip the drift scan
     // when this is true, since restored tracked_sources may be stale.
@@ -978,6 +994,14 @@ struct NativeCompileSessionSnapshot {
     journal_fallback_full_scan: bool,
     contract_source_dependencies: BTreeMap<String, BTreeSet<String>>,
     contract_output_plans: Vec<NativeContractOutputPlan>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg(feature = "native-compile")]
+struct NativeSessionRuntimeTelemetry {
+    drift_scan_ms: f64,
+    session_image_persist_ms: f64,
+    buildinfo_persist_ms: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3909,8 +3933,7 @@ fn run_build_with_uc_cache(
         telemetry.native_crate_cache_restore_ms = native_phase_telemetry.crate_cache_restore_ms;
         telemetry.native_source_scan_ms = native_phase_telemetry.source_scan_ms;
         telemetry.native_find_contracts_ms = native_phase_telemetry.find_contracts_ms;
-        telemetry.native_session_image_persist_ms =
-            native_phase_telemetry.session_image_persist_ms;
+        telemetry.native_session_image_persist_ms = native_phase_telemetry.session_image_persist_ms;
         telemetry.native_buildinfo_persist_ms = native_phase_telemetry.buildinfo_persist_ms;
         telemetry.native_drift_scan_ms = native_phase_telemetry.drift_scan_ms;
     }
@@ -4213,7 +4236,7 @@ fn toml_escape_basic_string(raw: &str) -> String {
 /// Returns the platform-appropriate global cache directory for uc.
 /// macOS: ~/Library/Caches/uc
 /// Linux: ~/.cache/uc
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(feature = "native-compile")]
 fn uc_global_cache_dir() -> Result<PathBuf> {
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
@@ -4225,16 +4248,46 @@ fn uc_global_cache_dir() -> Result<PathBuf> {
     Ok(base)
 }
 
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib),
+    unix
+))]
+fn acquire_embedded_corelib_extraction_lock(cache_dir: &Path, version: &str) -> Result<File> {
+    let lock_path = cache_dir.join(format!("corelib-v{version}.extract.lock"));
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    let lock_result = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
+    if lock_result != 0 {
+        bail!(
+            "failed to lock embedded corelib extraction file {}: {}",
+            lock_path.display(),
+            io::Error::last_os_error()
+        );
+    }
+    Ok(lock_file)
+}
+
 /// Extract the compile-time-embedded corelib to a versioned cache directory.
 /// Returns the path to the extracted `corelib/src/` directory.
 ///
 /// The extraction is idempotent: a `.uc-extracted-ok` marker file is written
 /// after successful extraction, and subsequent calls return immediately.
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 fn extract_embedded_corelib() -> Result<PathBuf> {
     let version = native_cairo_lang_compiler_version();
     let cache_dir = uc_global_cache_dir()?;
-    let target_dir = cache_dir.join(format!("corelib-v{}/src", version));
+    let target_root = cache_dir.join(format!("corelib-v{version}"));
+    let target_dir = target_root.join("src");
     let marker = target_dir.join(".uc-extracted-ok");
 
     if marker.is_file() && native_corelib_layout_looks_compatible(&target_dir) {
@@ -4245,28 +4298,52 @@ fn extract_embedded_corelib() -> Result<PathBuf> {
         return Ok(target_dir);
     }
 
-    // Marker missing or layout broken; (re-)extract.
-    if target_dir.exists() {
+    fs::create_dir_all(&cache_dir)
+        .with_context(|| format!("failed to create cache dir {}", cache_dir.display()))?;
+    // Serialize extraction into the shared cache to avoid concurrent remove/write races.
+    #[cfg(unix)]
+    let _extract_lock = acquire_embedded_corelib_extraction_lock(&cache_dir, &version)?;
+
+    // Another process may have completed extraction while we waited on the lock.
+    if marker.is_file() && native_corelib_layout_looks_compatible(&target_dir) {
         tracing::debug!(
-            target = %target_dir.display(),
+            corelib_src = %target_dir.display(),
+            "phase-5: using previously extracted embedded corelib after lock acquisition"
+        );
+        return Ok(target_dir);
+    }
+
+    let stage_root = cache_dir.join(format!(
+        "corelib-v{version}.tmp-{}-{}",
+        std::process::id(),
+        epoch_ms_u64().unwrap_or_default()
+    ));
+    let stage_dir = stage_root.join("src");
+    if stage_root.exists() {
+        let _ = fs::remove_dir_all(&stage_root);
+    }
+    // Marker missing or layout broken; (re-)extract into the staging directory.
+    if target_root.exists() {
+        tracing::debug!(
+            target = %target_root.display(),
             "phase-5: removing stale embedded corelib extraction"
         );
-        let _ = fs::remove_dir_all(&target_dir);
+        let _ = fs::remove_dir_all(&target_root);
     }
 
     let file_count = count_embedded_files(&EMBEDDED_CORELIB);
     tracing::debug!(
-        target = %target_dir.display(),
+        target = %target_root.display(),
         file_count,
-        "phase-5: extracting embedded corelib to cache"
+        "phase-5: extracting embedded corelib to staging cache directory"
     );
 
     let start = Instant::now();
-    extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &target_dir)?;
+    extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &stage_dir)?;
 
-    // Write marker after all files are on disk.
+    // Write marker after all files are on disk in staging.
     fs::write(
-        &marker,
+        stage_dir.join(".uc-extracted-ok"),
         format!(
             "extracted by uc v{} at {}\n",
             env!("CARGO_PKG_VERSION"),
@@ -4277,11 +4354,29 @@ fn extract_embedded_corelib() -> Result<PathBuf> {
         ),
     )
     .context("failed to write embedded corelib extraction marker")?;
+    if target_root.exists() {
+        fs::remove_dir_all(&target_root).with_context(|| {
+            format!(
+                "failed to remove stale embedded corelib target {}",
+                target_root.display()
+            )
+        })?;
+    }
+    if let Err(err) = fs::rename(&stage_root, &target_root) {
+        let _ = fs::remove_dir_all(&stage_root);
+        return Err(err).with_context(|| {
+            format!(
+                "failed to atomically move {} into {}",
+                stage_root.display(),
+                target_root.display()
+            )
+        });
+    }
 
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
     tracing::debug!(
         elapsed_ms,
-        target = %target_dir.display(),
+        target = %target_root.display(),
         file_count,
         "phase-5: embedded corelib extraction complete"
     );
@@ -4289,7 +4384,11 @@ fn extract_embedded_corelib() -> Result<PathBuf> {
     Ok(target_dir)
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 fn extract_embedded_dir_recursive(dir: &Dir<'_>, target: &Path) -> Result<()> {
     fs::create_dir_all(target)
         .with_context(|| format!("failed to create dir {}", target.display()))?;
@@ -4315,7 +4414,11 @@ fn extract_embedded_dir_recursive(dir: &Dir<'_>, target: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 fn count_embedded_files(dir: &Dir<'_>) -> usize {
     let mut count = dir.files().count();
     for subdir in dir.dirs() {
@@ -4333,21 +4436,63 @@ fn count_embedded_files(dir: &Dir<'_>) -> usize {
 // across ALL projects, eliminating ~300-500ms of Salsa evaluation on every
 // cold start.
 
+#[cfg(feature = "native-compile")]
+fn corelib_source_tree_fingerprint(corelib_src: &Path) -> Result<String> {
+    let canonical_corelib_src = corelib_src
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", corelib_src.display()))?;
+    let mut files = Vec::<(String, u64, u64, u64)>::new();
+    for entry in WalkDir::new(&canonical_corelib_src)
+        .follow_links(false)
+        .into_iter()
+        .flatten()
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if files.len() >= max_fingerprint_files() {
+            bail!(
+                "corelib fingerprint scan found too many files (>{}) under {}",
+                max_fingerprint_files(),
+                canonical_corelib_src.display()
+            );
+        }
+        let metadata = fs::metadata(entry.path())
+            .with_context(|| format!("failed to stat {}", entry.path().display()))?;
+        let modified_unix_ms = metadata_modified_unix_ms(&metadata)?;
+        let change_unix_ms = metadata_change_unix_ms(&metadata).unwrap_or(modified_unix_ms);
+        let relative = entry
+            .path()
+            .strip_prefix(&canonical_corelib_src)
+            .unwrap_or(entry.path());
+        files.push((
+            normalize_fingerprint_path(relative),
+            metadata.len(),
+            modified_unix_ms,
+            change_unix_ms,
+        ));
+    }
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut hasher = Hasher::new();
+    hasher.update(b"uc-corelib-sierra-blob-fingerprint-v1");
+    hasher.update(normalize_fingerprint_path(&canonical_corelib_src).as_bytes());
+    hasher.update(&(files.len() as u64).to_le_bytes());
+    for (path, size_bytes, modified_unix_ms, change_unix_ms) in files {
+        hasher.update(path.as_bytes());
+        hasher.update(&size_bytes.to_le_bytes());
+        hasher.update(&modified_unix_ms.to_le_bytes());
+        hasher.update(&change_unix_ms.to_le_bytes());
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
 /// Path to the pre-compiled corelib Sierra blob in the global cache.
 #[cfg(feature = "native-compile")]
-fn corelib_sierra_blob_path() -> Result<PathBuf> {
+fn corelib_sierra_blob_path(corelib_src: &Path) -> Result<PathBuf> {
     let version = native_cairo_lang_compiler_version();
-    let cache_dir = {
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .context("HOME environment variable not set")?;
-        #[cfg(target_os = "macos")]
-        let base = home.join("Library/Caches/uc");
-        #[cfg(not(target_os = "macos"))]
-        let base = home.join(".cache/uc");
-        base
-    };
-    Ok(cache_dir.join(format!("corelib-sierra-v{version}.blob")))
+    let fingerprint = corelib_source_tree_fingerprint(corelib_src)?;
+    let cache_dir = uc_global_cache_dir()?;
+    Ok(cache_dir.join(format!("corelib-sierra-v{version}-{fingerprint}.blob")))
 }
 
 /// Try to load a pre-compiled corelib Sierra blob and inject it into the
@@ -4355,8 +4500,8 @@ fn corelib_sierra_blob_path() -> Result<PathBuf> {
 ///
 /// Returns `true` if the blob was successfully loaded and injected.
 #[cfg(feature = "native-compile")]
-fn try_restore_corelib_sierra_blob(db: &mut RootDatabase) -> bool {
-    let blob_path = match corelib_sierra_blob_path() {
+fn try_restore_corelib_sierra_blob(db: &mut RootDatabase, corelib_src: &Path) -> bool {
+    let blob_path = match corelib_sierra_blob_path(corelib_src) {
         Ok(p) => p,
         Err(e) => {
             tracing::debug!(error = %e, "phase-6: cannot determine corelib sierra blob path");
@@ -4370,7 +4515,11 @@ fn try_restore_corelib_sierra_blob(db: &mut RootDatabase) -> bool {
         );
         return false;
     }
-    let blob_bytes = match fs::read(&blob_path) {
+    let blob_bytes = match read_bytes_with_limit(
+        &blob_path,
+        MAX_CORELIB_SIERRA_BLOB_BYTES,
+        "corelib sierra blob",
+    ) {
         Ok(b) => b,
         Err(e) => {
             tracing::debug!(
@@ -4419,8 +4568,8 @@ fn try_restore_corelib_sierra_blob(db: &mut RootDatabase) -> bool {
 /// Generate and persist the corelib's lowering cache blob to the global cache.
 /// Called after a successful build.
 #[cfg(feature = "native-compile")]
-fn persist_corelib_sierra_blob_best_effort(db: &RootDatabase) {
-    let blob_path = match corelib_sierra_blob_path() {
+fn persist_corelib_sierra_blob_best_effort(db: &RootDatabase, corelib_src: &Path) {
+    let blob_path = match corelib_sierra_blob_path(corelib_src) {
         Ok(p) => p,
         Err(e) => {
             tracing::debug!(error = %e, "phase-6: cannot determine corelib sierra blob path for persist");
@@ -4517,7 +4666,7 @@ fn resolve_native_corelib_src(workspace_root: &Path) -> Result<PathBuf> {
     }
 
     // Phase 5: try embedded corelib before filesystem search.
-    #[cfg(not(uc_no_embedded_corelib))]
+    #[cfg(all(feature = "embedded-corelib", not(uc_no_embedded_corelib)))]
     if std::env::var_os("UC_DISABLE_EMBEDDED_CORELIB").is_none() {
         match extract_embedded_corelib() {
             Ok(path) => {
@@ -6843,7 +6992,8 @@ fn persist_native_compile_session_image_snapshot(
         generated_at_epoch_ms: epoch_ms_u64().unwrap_or_default(),
     };
     // Phase 4: use postcard binary serialization (~2-5x faster than serde_json, ~40-60% smaller)
-    let bytes = postcard::to_allocvec(&image).context("failed to encode native session image (postcard)")?;
+    let bytes = postcard::to_allocvec(&image)
+        .context("failed to encode native session image (postcard)")?;
     if bytes.len() as u64 > MAX_NATIVE_COMPILE_SESSION_IMAGE_BYTES {
         tracing::warn!(
             path = %image_path.display(),
@@ -6929,12 +7079,10 @@ fn try_native_compile_session_image_restore(
             return None;
         }
     };
-    // Phase 4: decode with postcard first (v2+), then fall back to serde_json (v1 legacy)
+    // Phase 4: decode with postcard first (v2+), then fall back to JSON (legacy v1/v2).
     let decoded: NativeCompileSessionImageFile =
         match postcard::from_bytes::<NativeCompileSessionImageFile>(&bytes) {
-            Ok(image)
-                if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION =>
-            {
+            Ok(image) if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION => {
                 tracing::trace!(
                     path = %image_path.display(),
                     schema_version = image.schema_version,
@@ -6943,13 +7091,12 @@ fn try_native_compile_session_image_restore(
                 image
             }
             Ok(_) | Err(_) => {
-                // Postcard decode failed or schema mismatch; try JSON as a
-                // defensive fallback. Note: v1 caches are intentionally
-                // rejected by the schema v2 bump (cache miss on upgrade).
+                // Postcard decode failed or schema mismatch; try JSON fallback.
                 match serde_json::from_slice::<NativeCompileSessionImageFile>(&bytes) {
                     Ok(image)
-                        if image.schema_version
-                            == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION =>
+                        if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION
+                            || image.schema_version
+                                == NATIVE_COMPILE_SESSION_IMAGE_LEGACY_JSON_SCHEMA_VERSION =>
                     {
                         image
                     }
@@ -7276,7 +7423,8 @@ fn persist_native_buildinfo_sidecar(
         .context("native buildinfo path has no parent directory")?;
     fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
     // Phase 4: use postcard binary serialization for buildinfo
-    let bytes = postcard::to_allocvec(buildinfo).context("failed to encode native buildinfo (postcard)")?;
+    let bytes =
+        postcard::to_allocvec(buildinfo).context("failed to encode native buildinfo (postcard)")?;
     if bytes.len() as u64 > MAX_NATIVE_BUILDINFO_BYTES {
         tracing::warn!(
             path = %sidecar_path.display(),
@@ -7361,7 +7509,7 @@ fn load_native_buildinfo_sidecar_snapshot(
             return None;
         }
     };
-    // Phase 4: decode with postcard first (v2+), then fall back to serde_json (v1 legacy)
+    // Phase 4: decode with postcard first (v2+), then fall back to JSON (legacy v1/v2).
     let decoded = match postcard::from_bytes::<NativeBuildInfoFile>(&bytes) {
         Ok(file) if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION => {
             tracing::trace!(
@@ -7371,21 +7519,24 @@ fn load_native_buildinfo_sidecar_snapshot(
             );
             file
         }
-        Ok(_) | Err(_) => {
-            match serde_json::from_slice::<NativeBuildInfoFile>(&bytes) {
-                Ok(file) if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION => file,
-                Ok(_) => return None,
-                Err(err) => {
-                    tracing::debug!(
-                        path = %sidecar_path.display(),
-                        error = %err,
-                        "cold-path phase-4: buildinfo is neither valid postcard \
-                         nor valid JSON for current schema version; treating as cache miss"
-                    );
-                    return None;
-                }
+        Ok(_) | Err(_) => match serde_json::from_slice::<NativeBuildInfoFile>(&bytes) {
+            Ok(file)
+                if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION
+                    || file.schema_version == NATIVE_BUILDINFO_LEGACY_JSON_SCHEMA_VERSION =>
+            {
+                file
             }
-        }
+            Ok(_) => return None,
+            Err(err) => {
+                tracing::debug!(
+                    path = %sidecar_path.display(),
+                    error = %err,
+                    "cold-path phase-4: buildinfo is neither valid postcard \
+                     nor valid JSON for current schema version; treating as cache miss"
+                );
+                return None;
+            }
+        },
     };
     let signature_hash = native_compile_session_signature_hash(signature);
     if decoded.signature_hash != signature_hash {
@@ -7982,17 +8133,68 @@ fn cold_path_async_persist_in_flight() -> &'static AtomicUsize {
     &IN_FLIGHT
 }
 
-/// Spawn a best-effort persistence closure on a background thread.
-/// The closure MUST NOT panic — it should catch/log all errors internally.
+#[cfg(feature = "native-compile")]
+type ColdPathPersistTask = Box<dyn FnOnce() + Send + 'static>;
+
+#[cfg(feature = "native-compile")]
+fn run_cold_path_async_persist_worker(receiver: Receiver<ColdPathPersistTask>) {
+    while let Ok(task) = receiver.recv() {
+        let _guard = ColdPathPersistGuard;
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (task)();
+        }));
+    }
+}
+
+#[cfg(feature = "native-compile")]
+fn cold_path_async_persist_sender() -> Option<&'static Sender<ColdPathPersistTask>> {
+    static SENDER: OnceLock<Option<Sender<ColdPathPersistTask>>> = OnceLock::new();
+    SENDER
+        .get_or_init(|| {
+            let (sender, receiver) = mpsc::channel::<ColdPathPersistTask>();
+            match thread::Builder::new()
+                .name("uc-cold-persist".to_string())
+                .spawn(move || run_cold_path_async_persist_worker(receiver))
+            {
+                Ok(_handle) => Some(sender),
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "cold-path: failed to spawn async persist worker; falling back to inline writes"
+                    );
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Queue a best-effort persistence closure on a single worker thread.
+/// Tasks are processed FIFO so older snapshots cannot overtake newer ones.
 #[cfg(feature = "native-compile")]
 fn cold_path_async_persist_spawn<F: FnOnce() + Send + 'static>(f: F) {
     cold_path_async_persist_in_flight().fetch_add(1, Ordering::SeqCst);
-    // The RAII guard ensures the counter is decremented even if the closure panics.
-    // catch_unwind prevents the panic from propagating and aborting the process.
-    thread::spawn(move || {
+    let mut pending: Option<ColdPathPersistTask> = Some(Box::new(f));
+    if let Some(sender) = cold_path_async_persist_sender() {
+        if let Some(task) = pending.take() {
+            match sender.send(task) {
+                Ok(()) => return,
+                Err(err) => {
+                    tracing::warn!(
+                        "cold-path: async persist worker disconnected; running task inline"
+                    );
+                    pending = Some(err.0);
+                }
+            }
+        }
+    }
+    // Fallback path if worker startup or queue send failed.
+    if let Some(task) = pending {
         let _guard = ColdPathPersistGuard;
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-    });
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (task)();
+        }));
+    }
 }
 
 /// RAII guard that decrements the in-flight counter on drop, ensuring
@@ -8052,7 +8254,8 @@ fn build_native_compile_session_state(
     let db_init_ms = db_start.elapsed().as_secs_f64() * 1000.0;
     init_dev_corelib(&mut db, signature.context.corelib_src.clone());
     // Phase 6: inject pre-compiled corelib Sierra blob if available.
-    let corelib_blob_restored = try_restore_corelib_sierra_blob(&mut db);
+    let corelib_blob_restored =
+        try_restore_corelib_sierra_blob(&mut db, &signature.context.corelib_src);
     tracing::debug!(
         corelib_blob_restored,
         "phase-6: corelib sierra blob restore attempted"
@@ -8216,7 +8419,7 @@ fn build_native_compile_session_state(
             "native session skipped eager keyed file-override slot priming"
         );
     }
-    let state = NativeCompileSessionState {
+    let mut state = NativeCompileSessionState {
         signature,
         db,
         main_crate_inputs,
@@ -8230,6 +8433,8 @@ fn build_native_compile_session_state(
         build_setup_project_ms: setup_project_ms,
         build_crate_cache_restore_ms: crate_cache_restore_ms,
         build_source_scan_ms: source_scan_ms,
+        build_session_image_persist_ms: 0.0,
+        build_buildinfo_persist_ms: 0.0,
         fresh_source_scan,
     };
     // Phase 1: move persistence off the critical path by spawning a background thread.
@@ -8246,7 +8451,10 @@ fn build_native_compile_session_state(
             None
         };
         let buildinfo_snapshot = if needs_buildinfo_persist {
-            Some(native_buildinfo_file_from_state(&state, state.journal_cursor_applied))
+            Some(native_buildinfo_file_from_state(
+                &state,
+                state.journal_cursor_applied,
+            ))
         } else {
             None
         };
@@ -8266,6 +8474,12 @@ fn build_native_compile_session_state(
         );
     }
     let persist_schedule_ms = persist_start.elapsed().as_secs_f64() * 1000.0;
+    if needs_image_persist {
+        state.build_session_image_persist_ms = persist_schedule_ms;
+    }
+    if needs_buildinfo_persist {
+        state.build_buildinfo_persist_ms = persist_schedule_ms;
+    }
     tracing::debug!(
         persist_schedule_ms,
         "cold-path: async persist scheduling overhead"
@@ -9046,7 +9260,7 @@ fn with_native_compile_session<T>(
     daemon_context: bool,
     rebuild_on_empty_delta: bool,
     f: impl FnOnce(&NativeCompileSessionSnapshot) -> Result<T>,
-) -> Result<T> {
+) -> Result<(T, NativeSessionRuntimeTelemetry)> {
     let source_roots = native_compile_source_roots(&signature.context);
     let (session_handle, session_cache_hit) =
         native_compile_session_handle(workspace_root, signature)?;
@@ -9188,6 +9402,10 @@ fn with_native_compile_session<T>(
         )
     };
     let drift_scan_ms = drift_scan_start.elapsed().as_secs_f64() * 1000.0;
+    let mut runtime_telemetry = NativeSessionRuntimeTelemetry {
+        drift_scan_ms,
+        ..NativeSessionRuntimeTelemetry::default()
+    };
 
     let changed_source_set_detected = !changed_files.is_empty() || !removed_files.is_empty();
     let force_full_rebuild_on_empty_delta = native_should_force_full_rebuild_on_empty_delta(
@@ -9360,6 +9578,9 @@ fn with_native_compile_session<T>(
     update_native_compile_session_cached_estimated_bytes(workspace_root, estimated_bytes);
     // Phase 1: async persistence for session snapshot refresh persist calls
     if image_snapshot.is_some() || buildinfo_snapshot.is_some() {
+        let persist_image = image_snapshot.is_some();
+        let persist_buildinfo = buildinfo_snapshot.is_some();
+        let schedule_start = Instant::now();
         let ws_root = workspace_root.to_path_buf();
         cold_path_async_persist_spawn(move || {
             if let Some(image) = image_snapshot {
@@ -9369,6 +9590,13 @@ fn with_native_compile_session<T>(
                 persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
             }
         });
+        let persist_schedule_ms = schedule_start.elapsed().as_secs_f64() * 1000.0;
+        if persist_image {
+            runtime_telemetry.session_image_persist_ms += persist_schedule_ms;
+        }
+        if persist_buildinfo {
+            runtime_telemetry.buildinfo_persist_ms += persist_schedule_ms;
+        }
     }
     let result = f(&snapshot);
     if result.is_ok() && daemon_context {
@@ -9393,6 +9621,9 @@ fn with_native_compile_session<T>(
                 };
                 // Phase 1: async persistence for journal-commit persist calls
                 if image_snapshot.is_some() || buildinfo_snapshot.is_some() {
+                    let persist_image = image_snapshot.is_some();
+                    let persist_buildinfo = buildinfo_snapshot.is_some();
+                    let schedule_start = Instant::now();
                     let ws_root = workspace_root.to_path_buf();
                     cold_path_async_persist_spawn(move || {
                         if let Some(image) = image_snapshot {
@@ -9404,11 +9635,18 @@ fn with_native_compile_session<T>(
                             persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
                         }
                     });
+                    let persist_schedule_ms = schedule_start.elapsed().as_secs_f64() * 1000.0;
+                    if persist_image {
+                        runtime_telemetry.session_image_persist_ms += persist_schedule_ms;
+                    }
+                    if persist_buildinfo {
+                        runtime_telemetry.buildinfo_persist_ms += persist_schedule_ms;
+                    }
                 }
             }
         }
     }
-    result
+    result.map(|value| (value, runtime_telemetry))
 }
 
 #[cfg(feature = "native-compile")]
@@ -9585,20 +9823,23 @@ fn run_native_build_inner(
     let compile_start = Instant::now();
     let session_scope_start = Instant::now();
     let (
-        artifact_count,
-        frontend_compile_ms,
-        casm_ms,
-        artifact_write_ms,
-        produced_paths,
-        changed_files_count,
-        removed_files_count,
-        total_contracts,
-        compiled_contracts,
-        impacted_subset_used,
-        journal_fallback_full_scan,
-        dependency_updates,
-        contract_output_plans,
-        find_contracts_ms,
+        (
+            artifact_count,
+            frontend_compile_ms,
+            casm_ms,
+            artifact_write_ms,
+            produced_paths,
+            changed_files_count,
+            removed_files_count,
+            total_contracts,
+            compiled_contracts,
+            impacted_subset_used,
+            journal_fallback_full_scan,
+            dependency_updates,
+            contract_output_plans,
+            find_contracts_ms,
+        ),
+        session_runtime_telemetry,
     ) = with_native_compile_session(
         workspace_root,
         &signature,
@@ -9975,8 +10216,12 @@ fn run_native_build_inner(
     {
         let sig_for_phase6 = signature.clone();
         let ws_for_phase6 = workspace_root.to_path_buf();
+        let corelib_for_phase6 = signature.context.corelib_src.clone();
         cold_path_async_persist_spawn(move || {
-            let session_handle = match native_compile_session_handle(&ws_for_phase6, &sig_for_phase6) {
+            let session_handle = match native_compile_session_handle(
+                &ws_for_phase6,
+                &sig_for_phase6,
+            ) {
                 Ok((handle, _)) => handle,
                 Err(e) => {
                     tracing::debug!(error = %e, "phase-6: failed to access session for corelib blob persist");
@@ -9984,10 +10229,19 @@ fn run_native_build_inner(
                 }
             };
             let db_snapshot = {
-                let session = session_handle.lock().unwrap_or_else(|p| p.into_inner());
+                let session = match session_handle.lock() {
+                    Ok(guard) => guard,
+                    Err(_poisoned) => {
+                        tracing::warn!(
+                            "phase-6: session mutex is poisoned; skipping corelib blob persist \
+                             to avoid persisting potentially corrupt state"
+                        );
+                        return;
+                    }
+                };
                 session.db.snapshot()
             };
-            persist_corelib_sierra_blob_best_effort(&db_snapshot);
+            persist_corelib_sierra_blob_best_effort(&db_snapshot, &corelib_for_phase6);
         });
     }
     let compile_ms = compile_start.elapsed().as_secs_f64() * 1000.0;
@@ -9995,7 +10249,14 @@ fn run_native_build_inner(
     let session_prepare_ms =
         (session_scope_ms - frontend_compile_ms - casm_ms - artifact_write_ms).max(0.0);
     // Phase 0: extract sub-timings from session state for telemetry.
-    let (build_db_init_ms, build_setup_project_ms, build_crate_cache_restore_ms, build_source_scan_ms) = {
+    let (
+        build_db_init_ms,
+        build_setup_project_ms,
+        build_crate_cache_restore_ms,
+        build_source_scan_ms,
+        build_session_image_persist_ms,
+        build_buildinfo_persist_ms,
+    ) = {
         match native_compile_session_handle(workspace_root, &signature) {
             Ok((handle, _)) => {
                 let session = handle.lock().unwrap_or_else(|p| p.into_inner());
@@ -10004,9 +10265,11 @@ fn run_native_build_inner(
                     session.build_setup_project_ms,
                     session.build_crate_cache_restore_ms,
                     session.build_source_scan_ms,
+                    session.build_session_image_persist_ms,
+                    session.build_buildinfo_persist_ms,
                 )
             }
-            Err(_) => (0.0, 0.0, 0.0, 0.0),
+            Err(_) => (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         }
     };
     let native_phase_telemetry = NativeBuildPhaseTelemetry {
@@ -10027,9 +10290,11 @@ fn run_native_build_inner(
         crate_cache_restore_ms: build_crate_cache_restore_ms,
         source_scan_ms: build_source_scan_ms,
         find_contracts_ms,
-        session_image_persist_ms: 0.0,
-        buildinfo_persist_ms: 0.0,
-        drift_scan_ms: 0.0,
+        session_image_persist_ms: build_session_image_persist_ms
+            + session_runtime_telemetry.session_image_persist_ms,
+        buildinfo_persist_ms: build_buildinfo_persist_ms
+            + session_runtime_telemetry.buildinfo_persist_ms,
+        drift_scan_ms: session_runtime_telemetry.drift_scan_ms,
     };
     let run = CommandRun {
         command: vec![
@@ -10065,7 +10330,10 @@ fn run_native_build_inner(
         impacted_subset_used,
         journal_fallback_full_scan,
         find_contracts_ms,
-        "native build cold-path telemetry (phase 0 sub-timings: find_contracts_ms={find_contracts_ms:.1})"
+        session_image_persist_ms = native_phase_telemetry.session_image_persist_ms,
+        buildinfo_persist_ms = native_phase_telemetry.buildinfo_persist_ms,
+        drift_scan_ms = native_phase_telemetry.drift_scan_ms,
+        "native build cold-path telemetry"
     );
     Ok((run, native_phase_telemetry, produced_paths))
 }

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -958,6 +958,15 @@ struct NativeCompileSessionState {
     source_root_modified_unix_ms: u64,
     contract_source_dependencies: BTreeMap<String, BTreeSet<String>>,
     contract_output_plans: Vec<NativeContractOutputPlan>,
+    // Phase 0 sub-timings from build_native_compile_session_state
+    build_db_init_ms: f64,
+    build_setup_project_ms: f64,
+    build_crate_cache_restore_ms: f64,
+    build_source_scan_ms: f64,
+    // Phase 2: true when tracked_sources were freshly scanned from disk
+    // (not restored from image/buildinfo/replay). Only skip the drift scan
+    // when this is true, since restored tracked_sources may be stale.
+    fresh_source_scan: bool,
 }
 
 #[cfg(feature = "native-compile")]
@@ -6934,7 +6943,9 @@ fn try_native_compile_session_image_restore(
                 image
             }
             Ok(_) | Err(_) => {
-                // Fall back to JSON for schema v1 (pre-phase-4) caches
+                // Postcard decode failed or schema mismatch; try JSON as a
+                // defensive fallback. Note: v1 caches are intentionally
+                // rejected by the schema v2 bump (cache miss on upgrade).
                 match serde_json::from_slice::<NativeCompileSessionImageFile>(&bytes) {
                     Ok(image)
                         if image.schema_version
@@ -7976,10 +7987,24 @@ fn cold_path_async_persist_in_flight() -> &'static AtomicUsize {
 #[cfg(feature = "native-compile")]
 fn cold_path_async_persist_spawn<F: FnOnce() + Send + 'static>(f: F) {
     cold_path_async_persist_in_flight().fetch_add(1, Ordering::SeqCst);
+    // The RAII guard ensures the counter is decremented even if the closure panics.
+    // catch_unwind prevents the panic from propagating and aborting the process.
     thread::spawn(move || {
-        f();
-        cold_path_async_persist_in_flight().fetch_sub(1, Ordering::SeqCst);
+        let _guard = ColdPathPersistGuard;
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
     });
+}
+
+/// RAII guard that decrements the in-flight counter on drop, ensuring
+/// the counter is always decremented even if the closure panics.
+#[cfg(feature = "native-compile")]
+struct ColdPathPersistGuard;
+
+#[cfg(feature = "native-compile")]
+impl Drop for ColdPathPersistGuard {
+    fn drop(&mut self) {
+        cold_path_async_persist_in_flight().fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 /// Block until all in-flight async persist threads have completed.
@@ -8088,6 +8113,7 @@ fn build_native_compile_session_state(
         buildinfo_hit,
         buildinfo_replay_hit,
         journal_cursor_applied,
+        fresh_source_scan,
     ) = if let Some(image) = restored_image {
         (
             image.tracked_sources,
@@ -8098,6 +8124,7 @@ fn build_native_compile_session_state(
             false,
             false,
             image.journal_cursor_applied,
+            false,
         )
     } else if let Some(buildinfo) = restored_buildinfo {
         (
@@ -8109,6 +8136,7 @@ fn build_native_compile_session_state(
             true,
             false,
             buildinfo.journal_cursor_applied,
+            false,
         )
     } else if let Some(buildinfo) = replayed_buildinfo {
         (
@@ -8120,6 +8148,7 @@ fn build_native_compile_session_state(
             false,
             true,
             buildinfo.journal_cursor_applied,
+            false,
         )
     } else {
         let (tracked_sources, tracked_source_bytes) =
@@ -8139,6 +8168,7 @@ fn build_native_compile_session_state(
             false,
             false,
             native_current_source_journal_cursor(workspace_root),
+            true, // fresh_source_scan: tracked_sources are from a live filesystem scan
         )
     };
     let source_scan_ms = scan_start.elapsed().as_secs_f64() * 1000.0;
@@ -8196,6 +8226,11 @@ fn build_native_compile_session_state(
         source_root_modified_unix_ms,
         contract_source_dependencies,
         contract_output_plans,
+        build_db_init_ms: db_init_ms,
+        build_setup_project_ms: setup_project_ms,
+        build_crate_cache_restore_ms: crate_cache_restore_ms,
+        build_source_scan_ms: source_scan_ms,
+        fresh_source_scan,
     };
     // Phase 1: move persistence off the critical path by spawning a background thread.
     // Persistence is already best-effort (failures are logged and ignored), so it is safe
@@ -9041,13 +9076,17 @@ fn with_native_compile_session<T>(
         mut journal_fallback_full_scan,
     ) = if needs_full_rebuild {
         (Vec::new(), Vec::new(), None, 0_u64, false)
-    } else if !session_cache_hit {
+    } else if !session_cache_hit && {
+        let session = session_handle.lock().unwrap_or_else(|p| p.into_inner());
+        session.fresh_source_scan
+    } {
         // Phase 2: skip redundant source scan on cold path.  The session was just
-        // freshly built by build_native_compile_session_state which already collected
-        // tracked_sources reflecting the current filesystem state.  Re-scanning here
-        // would be a ~30-80 ms double scan with zero new information.
+        // freshly built by build_native_compile_session_state with a live filesystem
+        // scan, so tracked_sources already reflect the current state.  Re-scanning
+        // here would be a ~30-80 ms double scan with zero new information.
+        // Only safe when fresh_source_scan is true (not restored from cache/replay).
         tracing::debug!(
-            "cold-path phase-2: skipping drift scan for freshly-built session (session_cache_hit=false)"
+            "cold-path phase-2: skipping drift scan for freshly-built session with fresh source scan"
         );
         (Vec::new(), Vec::new(), None, 0_u64, false)
     } else if daemon_context {
@@ -9955,6 +9994,21 @@ fn run_native_build_inner(
     let session_scope_ms = session_scope_start.elapsed().as_secs_f64() * 1000.0;
     let session_prepare_ms =
         (session_scope_ms - frontend_compile_ms - casm_ms - artifact_write_ms).max(0.0);
+    // Phase 0: extract sub-timings from session state for telemetry.
+    let (build_db_init_ms, build_setup_project_ms, build_crate_cache_restore_ms, build_source_scan_ms) = {
+        match native_compile_session_handle(workspace_root, &signature) {
+            Ok((handle, _)) => {
+                let session = handle.lock().unwrap_or_else(|p| p.into_inner());
+                (
+                    session.build_db_init_ms,
+                    session.build_setup_project_ms,
+                    session.build_crate_cache_restore_ms,
+                    session.build_source_scan_ms,
+                )
+            }
+            Err(_) => (0.0, 0.0, 0.0, 0.0),
+        }
+    };
     let native_phase_telemetry = NativeBuildPhaseTelemetry {
         context_ms,
         target_dir_ms,
@@ -9968,11 +10022,10 @@ fn run_native_build_inner(
         compiled_contracts,
         impacted_subset_used,
         journal_fallback_full_scan,
-        // Phase 0: propagate sub-timings for cold-path diagnostics
-        db_init_ms: 0.0,           // populated from session state below
-        setup_project_ms: 0.0,     // populated from session state below
-        crate_cache_restore_ms: 0.0,
-        source_scan_ms: 0.0,
+        db_init_ms: build_db_init_ms,
+        setup_project_ms: build_setup_project_ms,
+        crate_cache_restore_ms: build_crate_cache_restore_ms,
+        source_scan_ms: build_source_scan_ms,
         find_contracts_ms,
         session_image_persist_ms: 0.0,
         buildinfo_persist_ms: 0.0,

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -24,7 +24,7 @@ use cairo_lang_filesystem::db::{
 #[cfg(feature = "native-compile")]
 use cairo_lang_filesystem::detect::detect_corelib;
 #[cfg(feature = "native-compile")]
-use cairo_lang_filesystem::ids::{BlobLongId, CrateInput, CrateLongId, Directory};
+use cairo_lang_filesystem::ids::{BlobLongId, CrateId, CrateInput, CrateLongId, Directory};
 #[cfg(feature = "native-compile")]
 use cairo_lang_filesystem::ids::{FileId, FileLongId};
 #[cfg(feature = "native-compile")]
@@ -44,6 +44,8 @@ use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 #[cfg(feature = "native-compile")]
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+use include_dir::{include_dir, Dir};
 #[cfg(feature = "native-compile")]
 use notify::event::{ModifyKind as NotifyModifyKind, RenameMode as NotifyRenameMode};
 #[cfg(feature = "native-compile")]
@@ -95,6 +97,14 @@ use commands::{run_build, run_compare_build, run_metadata, run_migrate};
 #[allow(unused_imports)]
 use daemon::*;
 use fingerprint::*;
+
+/// Embedded corelib source tree (Phase 5: cold-path supremacy).
+/// At compile time, build.rs discovers the Cairo corelib and sets
+/// `UC_CORELIB_SRC_DIR`; we embed the entire `corelib/src/` directory
+/// so the binary is self-contained and the runtime corelib search is
+/// eliminated on first run.
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+static EMBEDDED_CORELIB: Dir<'_> = include_dir!("$UC_CORELIB_SRC_DIR");
 
 const BUILD_CACHE_SCHEMA_VERSION: u32 = 1;
 const MIN_HASH_LEN: usize = 2;
@@ -4191,8 +4201,282 @@ fn toml_escape_basic_string(raw: &str) -> String {
     escaped
 }
 
+/// Returns the platform-appropriate global cache directory for uc.
+/// macOS: ~/Library/Caches/uc
+/// Linux: ~/.cache/uc
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+fn uc_global_cache_dir() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .context("HOME environment variable not set")?;
+    #[cfg(target_os = "macos")]
+    let base = home.join("Library/Caches/uc");
+    #[cfg(not(target_os = "macos"))]
+    let base = home.join(".cache/uc");
+    Ok(base)
+}
+
+/// Extract the compile-time-embedded corelib to a versioned cache directory.
+/// Returns the path to the extracted `corelib/src/` directory.
+///
+/// The extraction is idempotent: a `.uc-extracted-ok` marker file is written
+/// after successful extraction, and subsequent calls return immediately.
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+fn extract_embedded_corelib() -> Result<PathBuf> {
+    let version = native_cairo_lang_compiler_version();
+    let cache_dir = uc_global_cache_dir()?;
+    let target_dir = cache_dir.join(format!("corelib-v{}/src", version));
+    let marker = target_dir.join(".uc-extracted-ok");
+
+    if marker.is_file() && native_corelib_layout_looks_compatible(&target_dir) {
+        tracing::debug!(
+            corelib_src = %target_dir.display(),
+            "phase-5: using previously extracted embedded corelib"
+        );
+        return Ok(target_dir);
+    }
+
+    // Marker missing or layout broken; (re-)extract.
+    if target_dir.exists() {
+        tracing::debug!(
+            target = %target_dir.display(),
+            "phase-5: removing stale embedded corelib extraction"
+        );
+        let _ = fs::remove_dir_all(&target_dir);
+    }
+
+    let file_count = count_embedded_files(&EMBEDDED_CORELIB);
+    tracing::debug!(
+        target = %target_dir.display(),
+        file_count,
+        "phase-5: extracting embedded corelib to cache"
+    );
+
+    let start = Instant::now();
+    extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &target_dir)?;
+
+    // Write marker after all files are on disk.
+    fs::write(
+        &marker,
+        format!(
+            "extracted by uc v{} at {}\n",
+            env!("CARGO_PKG_VERSION"),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+        ),
+    )
+    .context("failed to write embedded corelib extraction marker")?;
+
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    tracing::debug!(
+        elapsed_ms,
+        target = %target_dir.display(),
+        file_count,
+        "phase-5: embedded corelib extraction complete"
+    );
+
+    Ok(target_dir)
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+fn extract_embedded_dir_recursive(dir: &Dir<'_>, target: &Path) -> Result<()> {
+    fs::create_dir_all(target)
+        .with_context(|| format!("failed to create dir {}", target.display()))?;
+    for file in dir.files() {
+        let file_name = file
+            .path()
+            .file_name()
+            .context("embedded file has no name")?;
+        fs::write(target.join(file_name), file.contents()).with_context(|| {
+            format!(
+                "failed to write embedded file {}",
+                target.join(file_name).display()
+            )
+        })?;
+    }
+    for subdir in dir.dirs() {
+        let subdir_name = subdir
+            .path()
+            .file_name()
+            .context("embedded dir has no name")?;
+        extract_embedded_dir_recursive(subdir, &target.join(subdir_name))?;
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+fn count_embedded_files(dir: &Dir<'_>) -> usize {
+    let mut count = dir.files().count();
+    for subdir in dir.dirs() {
+        count += count_embedded_files(subdir);
+    }
+    count
+}
+
+// ---------------------------------------------------------------------------
+// Phase 6: Pre-compiled corelib Sierra blob
+// ---------------------------------------------------------------------------
+//
+// The corelib is identical for a given cairo-lang compiler version. We can
+// generate its lowering cache blob once (after the first build) and reuse it
+// across ALL projects, eliminating ~300-500ms of Salsa evaluation on every
+// cold start.
+
+/// Path to the pre-compiled corelib Sierra blob in the global cache.
+#[cfg(feature = "native-compile")]
+fn corelib_sierra_blob_path() -> Result<PathBuf> {
+    let version = native_cairo_lang_compiler_version();
+    let cache_dir = {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .context("HOME environment variable not set")?;
+        #[cfg(target_os = "macos")]
+        let base = home.join("Library/Caches/uc");
+        #[cfg(not(target_os = "macos"))]
+        let base = home.join(".cache/uc");
+        base
+    };
+    Ok(cache_dir.join(format!("corelib-sierra-v{version}.blob")))
+}
+
+/// Try to load a pre-compiled corelib Sierra blob and inject it into the
+/// corelib crate's `cache_file` in the DB.
+///
+/// Returns `true` if the blob was successfully loaded and injected.
+#[cfg(feature = "native-compile")]
+fn try_restore_corelib_sierra_blob(db: &mut RootDatabase) -> bool {
+    let blob_path = match corelib_sierra_blob_path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(error = %e, "phase-6: cannot determine corelib sierra blob path");
+            return false;
+        }
+    };
+    if !blob_path.is_file() {
+        tracing::debug!(
+            path = %blob_path.display(),
+            "phase-6: no pre-compiled corelib sierra blob found"
+        );
+        return false;
+    }
+    let blob_bytes = match fs::read(&blob_path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(
+                path = %blob_path.display(),
+                error = %e,
+                "phase-6: failed to read corelib sierra blob"
+            );
+            return false;
+        }
+    };
+    if blob_bytes.is_empty() {
+        tracing::debug!("phase-6: corelib sierra blob is empty; skipping");
+        return false;
+    }
+
+    // Inject the blob into the core crate's cache_file.
+    let core_input = CrateLongId::core(db).into_crate_input(db);
+    let db_ref: &dyn salsa::Database = db;
+    let mut crate_configs = files_group_input(db_ref)
+        .crate_configs(db_ref)
+        .clone()
+        .unwrap_or_default();
+
+    if let Some(existing) = crate_configs.get(&core_input.clone()).cloned() {
+        crate_configs.insert(
+            core_input.clone(),
+            CrateConfigurationInput {
+                root: existing.root,
+                settings: existing.settings,
+                cache_file: Some(BlobLongId::Virtual(blob_bytes.clone())),
+            },
+        );
+        set_crate_configs_input(db, crate_configs);
+        tracing::debug!(
+            path = %blob_path.display(),
+            blob_bytes = blob_bytes.len(),
+            "phase-6: injected pre-compiled corelib sierra blob"
+        );
+        true
+    } else {
+        tracing::debug!("phase-6: core crate not found in DB config; skipping blob injection");
+        false
+    }
+}
+
+/// Generate and persist the corelib's lowering cache blob to the global cache.
+/// Called after a successful build.
+#[cfg(feature = "native-compile")]
+fn persist_corelib_sierra_blob_best_effort(db: &RootDatabase) {
+    let blob_path = match corelib_sierra_blob_path() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::debug!(error = %e, "phase-6: cannot determine corelib sierra blob path for persist");
+            return;
+        }
+    };
+
+    // Skip if already persisted.
+    if blob_path.is_file() {
+        tracing::debug!(
+            path = %blob_path.display(),
+            "phase-6: corelib sierra blob already exists; skipping persist"
+        );
+        return;
+    }
+
+    let core_crate_id = CrateId::core(db);
+    let blob = match generate_crate_cache(db, core_crate_id) {
+        Ok(blob) => blob,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "phase-6: failed to generate corelib lowering cache"
+            );
+            return;
+        }
+    };
+
+    if blob.is_empty() {
+        tracing::debug!("phase-6: generated corelib blob is empty; skipping persist");
+        return;
+    }
+
+    if let Some(parent) = blob_path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            tracing::debug!(
+                error = %e,
+                path = %parent.display(),
+                "phase-6: failed to create corelib sierra blob cache directory"
+            );
+            return;
+        }
+    }
+
+    match atomic_write_bytes(&blob_path, &blob, "corelib sierra blob") {
+        Ok(()) => {
+            tracing::debug!(
+                path = %blob_path.display(),
+                blob_bytes = blob.len(),
+                "phase-6: persisted pre-compiled corelib sierra blob"
+            );
+        }
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                path = %blob_path.display(),
+                "phase-6: failed to persist corelib sierra blob"
+            );
+        }
+    }
+}
+
 #[cfg(feature = "native-compile")]
 fn resolve_native_corelib_src(workspace_root: &Path) -> Result<PathBuf> {
+    // Explicit env override always wins (also used by tests to control resolution).
     if let Some(path) = std::env::var_os("UC_NATIVE_CORELIB_SRC") {
         let candidate = PathBuf::from(path);
         let canonical = candidate.canonicalize().with_context(|| {
@@ -4221,6 +4505,27 @@ fn resolve_native_corelib_src(workspace_root: &Path) -> Result<PathBuf> {
             canonical.display(),
             native_cairo_lang_compiler_version()
         )));
+    }
+
+    // Phase 5: try embedded corelib before filesystem search.
+    #[cfg(not(uc_no_embedded_corelib))]
+    if std::env::var_os("UC_DISABLE_EMBEDDED_CORELIB").is_none() {
+        match extract_embedded_corelib() {
+            Ok(path) => {
+                tracing::debug!(
+                    source = "embedded",
+                    corelib_src = %path.display(),
+                    "phase-5: selected embedded native corelib source path"
+                );
+                return Ok(path);
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "phase-5: embedded corelib extraction failed; falling back to filesystem search"
+                );
+            }
+        }
     }
 
     let candidates = native_corelib_candidate_paths(workspace_root);
@@ -7721,6 +8026,12 @@ fn build_native_compile_session_state(
         .context("failed to initialize native cairo compiler database")?;
     let db_init_ms = db_start.elapsed().as_secs_f64() * 1000.0;
     init_dev_corelib(&mut db, signature.context.corelib_src.clone());
+    // Phase 6: inject pre-compiled corelib Sierra blob if available.
+    let corelib_blob_restored = try_restore_corelib_sierra_blob(&mut db);
+    tracing::debug!(
+        corelib_blob_restored,
+        "phase-6: corelib sierra blob restore attempted"
+    );
     let setup_start = Instant::now();
     let main_crate_inputs = setup_project(&mut db, &signature.context.cairo_project_dir)
         .with_context(|| {
@@ -9619,6 +9930,27 @@ fn run_native_build_inner(
         removed_files_count,
         compiled_contracts,
     );
+    // Phase 6: persist corelib sierra blob to global cache (best-effort, async).
+    // Unlike per-workspace crate cache, this runs on every build since the corelib
+    // blob is the same for all projects with the same compiler version.
+    {
+        let sig_for_phase6 = signature.clone();
+        let ws_for_phase6 = workspace_root.to_path_buf();
+        cold_path_async_persist_spawn(move || {
+            let session_handle = match native_compile_session_handle(&ws_for_phase6, &sig_for_phase6) {
+                Ok((handle, _)) => handle,
+                Err(e) => {
+                    tracing::debug!(error = %e, "phase-6: failed to access session for corelib blob persist");
+                    return;
+                }
+            };
+            let db_snapshot = {
+                let session = session_handle.lock().unwrap_or_else(|p| p.into_inner());
+                session.db.snapshot()
+            };
+            persist_corelib_sierra_blob_best_effort(&db_snapshot);
+        });
+    }
     let compile_ms = compile_start.elapsed().as_secs_f64() * 1000.0;
     let session_scope_ms = session_scope_start.elapsed().as_secs_f64() * 1000.0;
     let session_prepare_ms =

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -4331,13 +4331,32 @@ fn acquire_embedded_corelib_extraction_lock(cache_dir: &Path, version: &str) -> 
         .write(true)
         .open(&lock_path)
         .with_context(|| format!("failed to open {}", lock_path.display()))?;
-    let lock_result = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
-    if lock_result != 0 {
-        bail!(
-            "failed to lock embedded corelib extraction file {}: {}",
-            lock_path.display(),
-            io::Error::last_os_error()
-        );
+    // Try non-blocking first so we can log a diagnostic if another process holds it.
+    // SAFETY: `lock_file` is a valid open fd; flock is signal-safe.
+    let nb_result = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if nb_result != 0 {
+        let err = io::Error::last_os_error();
+        if err.kind() == io::ErrorKind::WouldBlock {
+            tracing::info!(
+                path = %lock_path.display(),
+                "phase-5: another process is extracting the embedded corelib; waiting for lock"
+            );
+            // SAFETY: same fd, blocking this time.
+            let blocking_result = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
+            if blocking_result != 0 {
+                bail!(
+                    "failed to lock embedded corelib extraction file {}: {}",
+                    lock_path.display(),
+                    io::Error::last_os_error()
+                );
+            }
+        } else {
+            bail!(
+                "failed to lock embedded corelib extraction file {}: {}",
+                lock_path.display(),
+                err
+            );
+        }
     }
     Ok(lock_file)
 }
@@ -4380,6 +4399,24 @@ fn extract_embedded_corelib() -> Result<PathBuf> {
             "phase-5: using previously extracted embedded corelib after lock acquisition"
         );
         return Ok(target_dir);
+    }
+
+    // Clean up stale staging directories left behind by killed processes.
+    let tmp_prefix = format!("corelib-v{version}.tmp-");
+    if let Ok(entries) = fs::read_dir(&cache_dir) {
+        for entry in entries.flatten() {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(&tmp_prefix)
+            {
+                tracing::debug!(
+                    path = %entry.path().display(),
+                    "phase-5: removing stale staging directory"
+                );
+                let _ = fs::remove_dir_all(entry.path());
+            }
+        }
     }
 
     let stage_root = cache_dir.join(format!(
@@ -4653,10 +4690,38 @@ fn try_restore_corelib_sierra_blob(db: &mut RootDatabase, corelib_src: &Path) ->
     }
 }
 
+/// Cheap check: does any corelib sierra blob for the current compiler version
+/// already exist in the global cache?  This avoids computing the expensive
+/// content-hash fingerprint on warm builds where the blob was already persisted.
+#[cfg(feature = "native-compile")]
+fn corelib_sierra_blob_likely_exists(corelib_src: &Path) -> bool {
+    let _ = corelib_src; // used only for consistency with the full path helper
+    let version = native_cairo_lang_compiler_version();
+    let cache_dir = match uc_global_cache_dir() {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    let prefix = format!("corelib-sierra-v{version}-");
+    match std::fs::read_dir(&cache_dir) {
+        Ok(entries) => entries
+            .flatten()
+            .any(|e| e.file_name().to_string_lossy().starts_with(&prefix)),
+        Err(_) => false,
+    }
+}
+
 /// Generate and persist the corelib's lowering cache blob to the global cache.
 /// Called after a successful build.
 #[cfg(feature = "native-compile")]
 fn persist_corelib_sierra_blob_best_effort(db: &RootDatabase, corelib_src: &Path) {
+    // Fast path: skip the expensive fingerprint computation if a blob for this
+    // compiler version already exists.  The fingerprint only changes when
+    // corelib source files change, which implies a compiler version bump.
+    if corelib_sierra_blob_likely_exists(corelib_src) {
+        tracing::debug!("phase-6: corelib sierra blob already exists (fast check); skipping persist");
+        return;
+    }
+
     let blob_path = match corelib_sierra_blob_path(corelib_src) {
         Ok(p) => p,
         Err(e) => {
@@ -4665,7 +4730,7 @@ fn persist_corelib_sierra_blob_best_effort(db: &RootDatabase, corelib_src: &Path
         }
     };
 
-    // Skip if already persisted.
+    // Skip if already persisted (exact fingerprint match).
     if blob_path.is_file() {
         tracing::debug!(
             path = %blob_path.display(),

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -77,7 +77,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{self, Receiver, Sender, SyncSender, TrySendError};
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -994,6 +994,12 @@ struct NativeCompileSessionSnapshot {
     journal_fallback_full_scan: bool,
     contract_source_dependencies: BTreeMap<String, BTreeSet<String>>,
     contract_output_plans: Vec<NativeContractOutputPlan>,
+    build_db_init_ms: f64,
+    build_setup_project_ms: f64,
+    build_crate_cache_restore_ms: f64,
+    build_source_scan_ms: f64,
+    build_session_image_persist_ms: f64,
+    build_buildinfo_persist_ms: f64,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -6448,24 +6454,43 @@ fn native_collect_contract_dependency_updates(
 }
 
 #[cfg(feature = "native-compile")]
+fn native_compile_session_handle_if_cached(
+    workspace_root: &Path,
+) -> Option<Arc<Mutex<NativeCompileSessionState>>> {
+    let cache_key = native_compile_session_cache_key(workspace_root);
+    let now_ms = epoch_ms_u64().unwrap_or_default();
+    let mut cache = native_compile_session_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    evict_expired_native_compile_session_cache_entries(
+        &mut cache,
+        now_ms,
+        native_compile_session_cache_ttl_ms(),
+    );
+    let entry = cache.get_mut(&cache_key)?;
+    entry.last_access_epoch_ms = now_ms;
+    Some(entry.session.clone())
+}
+
+#[cfg(feature = "native-compile")]
 fn native_update_compile_session_post_build_state(
     workspace_root: &Path,
     signature: &NativeCompileSessionSignature,
     dependency_updates: &[(String, BTreeSet<String>)],
     contract_output_plans: Option<&[NativeContractOutputPlan]>,
-) {
+) -> NativeSessionRuntimeTelemetry {
+    let mut runtime_telemetry = NativeSessionRuntimeTelemetry::default();
     if dependency_updates.is_empty() && contract_output_plans.is_none() {
-        return;
+        return runtime_telemetry;
     }
-    let session_handle = match native_compile_session_handle(workspace_root, signature) {
-        Ok((handle, _session_cache_hit)) => handle,
-        Err(err) => {
+    let session_handle = match native_compile_session_handle_if_cached(workspace_root) {
+        Some(handle) => handle,
+        None => {
             tracing::warn!(
                 workspace_root = %workspace_root.display(),
-                error = %format!("{err:#}"),
-                "failed to update native session post-build state"
+                "native session was evicted before post-build state update; skipping"
             );
-            return;
+            return runtime_telemetry;
         }
     };
     let (estimated_bytes, image_snapshot, buildinfo_snapshot) = {
@@ -6473,7 +6498,7 @@ fn native_update_compile_session_post_build_state(
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if session.signature != *signature {
-            return;
+            return runtime_telemetry;
         }
         let mut state_changed = false;
         for (module_path, dependencies) in dependency_updates {
@@ -6514,6 +6539,9 @@ fn native_update_compile_session_post_build_state(
     update_native_compile_session_cached_estimated_bytes(workspace_root, estimated_bytes);
     // Phase 1: async persistence for post-build state update persist calls
     if image_snapshot.is_some() || buildinfo_snapshot.is_some() {
+        let persist_image = image_snapshot.is_some();
+        let persist_buildinfo = buildinfo_snapshot.is_some();
+        let schedule_start = Instant::now();
         let ws_root = workspace_root.to_path_buf();
         cold_path_async_persist_spawn(move || {
             if let Some(image) = image_snapshot {
@@ -6523,7 +6551,15 @@ fn native_update_compile_session_post_build_state(
                 persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
             }
         });
+        let persist_schedule_ms = schedule_start.elapsed().as_secs_f64() * 1000.0;
+        if persist_image {
+            runtime_telemetry.session_image_persist_ms += persist_schedule_ms;
+        }
+        if persist_buildinfo {
+            runtime_telemetry.buildinfo_persist_ms += persist_schedule_ms;
+        }
     }
+    runtime_telemetry
 }
 
 #[cfg(feature = "native-compile")]
@@ -8166,11 +8202,11 @@ fn run_cold_path_async_persist_worker(receiver: Receiver<ColdPathPersistTask>) {
 }
 
 #[cfg(feature = "native-compile")]
-fn cold_path_async_persist_sender() -> Option<&'static Sender<ColdPathPersistTask>> {
-    static SENDER: OnceLock<Option<Sender<ColdPathPersistTask>>> = OnceLock::new();
+fn cold_path_async_persist_sender() -> Option<&'static SyncSender<ColdPathPersistTask>> {
+    static SENDER: OnceLock<Option<SyncSender<ColdPathPersistTask>>> = OnceLock::new();
     SENDER
         .get_or_init(|| {
-            let (sender, receiver) = mpsc::channel::<ColdPathPersistTask>();
+            let (sender, receiver) = mpsc::sync_channel::<ColdPathPersistTask>(ASYNC_PERSIST_QUEUE_LIMIT);
             match thread::Builder::new()
                 .name("uc-cold-persist".to_string())
                 .spawn(move || run_cold_path_async_persist_worker(receiver))
@@ -8196,13 +8232,20 @@ fn cold_path_async_persist_spawn<F: FnOnce() + Send + 'static>(f: F) {
     let mut pending: Option<ColdPathPersistTask> = Some(Box::new(f));
     if let Some(sender) = cold_path_async_persist_sender() {
         if let Some(task) = pending.take() {
-            match sender.send(task) {
+            match sender.try_send(task) {
                 Ok(()) => return,
-                Err(err) => {
+                Err(TrySendError::Full(task)) => {
+                    tracing::warn!(
+                        limit = ASYNC_PERSIST_QUEUE_LIMIT,
+                        "cold-path: async persist queue is full; running task inline"
+                    );
+                    pending = Some(task);
+                }
+                Err(TrySendError::Disconnected(task)) => {
                     tracing::warn!(
                         "cold-path: async persist worker disconnected; running task inline"
                     );
-                    pending = Some(err.0);
+                    pending = Some(task);
                 }
             }
         }
@@ -9186,6 +9229,15 @@ fn native_should_force_full_rebuild_on_empty_delta(
 }
 
 #[cfg(feature = "native-compile")]
+fn native_should_skip_drift_scan_for_fresh_session(
+    session_cache_hit: bool,
+    fresh_source_scan: bool,
+    needs_full_rebuild: bool,
+) -> bool {
+    !needs_full_rebuild && !session_cache_hit && fresh_source_scan
+}
+
+#[cfg(feature = "native-compile")]
 fn native_should_try_cached_noop_reuse(
     changed_files: &[String],
     removed_files: &[String],
@@ -9279,17 +9331,22 @@ fn with_native_compile_session<T>(
     daemon_context: bool,
     rebuild_on_empty_delta: bool,
     f: impl FnOnce(&NativeCompileSessionSnapshot) -> Result<T>,
-) -> Result<(T, NativeSessionRuntimeTelemetry)> {
+) -> Result<(
+    T,
+    NativeSessionRuntimeTelemetry,
+    NativeCompileSessionSnapshot,
+)> {
     let source_roots = native_compile_source_roots(&signature.context);
     let (session_handle, session_cache_hit) =
         native_compile_session_handle(workspace_root, signature)?;
-    let (needs_full_rebuild, session_applied_cursor) = {
+    let (needs_full_rebuild, session_applied_cursor, fresh_source_scan) = {
         let session = session_handle
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         (
             session.signature != *signature,
             session.journal_cursor_applied,
+            session.fresh_source_scan,
         )
     };
     let snapshot_previous_sources = || {
@@ -9309,10 +9366,11 @@ fn with_native_compile_session<T>(
         mut journal_fallback_full_scan,
     ) = if needs_full_rebuild {
         (Vec::new(), Vec::new(), None, 0_u64, false)
-    } else if !session_cache_hit && {
-        let session = session_handle.lock().unwrap_or_else(|p| p.into_inner());
-        session.fresh_source_scan
-    } {
+    } else if native_should_skip_drift_scan_for_fresh_session(
+        session_cache_hit,
+        fresh_source_scan,
+        needs_full_rebuild,
+    ) {
         // Phase 2: skip redundant source scan on cold path.  The session was just
         // freshly built by build_native_compile_session_state with a live filesystem
         // scan, so tracked_sources already reflect the current state.  Re-scanning
@@ -9587,6 +9645,12 @@ fn with_native_compile_session<T>(
                 journal_fallback_full_scan,
                 contract_source_dependencies: session.contract_source_dependencies.clone(),
                 contract_output_plans: session.contract_output_plans.clone(),
+                build_db_init_ms: session.build_db_init_ms,
+                build_setup_project_ms: session.build_setup_project_ms,
+                build_crate_cache_restore_ms: session.build_crate_cache_restore_ms,
+                build_source_scan_ms: session.build_source_scan_ms,
+                build_session_image_persist_ms: session.build_session_image_persist_ms,
+                build_buildinfo_persist_ms: session.build_buildinfo_persist_ms,
             },
             state_mutated.then(|| native_compile_session_image_snapshot_from_state(&session)),
             state_mutated.then(|| {
@@ -9665,7 +9729,7 @@ fn with_native_compile_session<T>(
             }
         }
     }
-    result.map(|value| (value, runtime_telemetry))
+    result.map(|value| (value, runtime_telemetry, snapshot))
 }
 
 #[cfg(feature = "native-compile")]
@@ -9858,7 +9922,8 @@ fn run_native_build_inner(
             contract_output_plans,
             find_contracts_ms,
         ),
-        session_runtime_telemetry,
+        mut session_runtime_telemetry,
+        session_snapshot,
     ) = with_native_compile_session(
         workspace_root,
         &signature,
@@ -10215,12 +10280,16 @@ fn run_native_build_inner(
             ))
         },
     )?;
-    native_update_compile_session_post_build_state(
+    let post_build_runtime_telemetry = native_update_compile_session_post_build_state(
         workspace_root,
         &signature,
         &dependency_updates,
         contract_output_plans.as_deref(),
     );
+    session_runtime_telemetry.session_image_persist_ms +=
+        post_build_runtime_telemetry.session_image_persist_ms;
+    session_runtime_telemetry.buildinfo_persist_ms +=
+        post_build_runtime_telemetry.buildinfo_persist_ms;
     native_persist_crate_cache_after_build_best_effort(
         workspace_root,
         &signature,
@@ -10233,64 +10302,23 @@ fn run_native_build_inner(
     // Unlike per-workspace crate cache, this runs on every build since the corelib
     // blob is the same for all projects with the same compiler version.
     {
-        let sig_for_phase6 = signature.clone();
-        let ws_for_phase6 = workspace_root.to_path_buf();
+        let db_for_phase6 = session_snapshot.db.snapshot();
         let corelib_for_phase6 = signature.context.corelib_src.clone();
         cold_path_async_persist_spawn(move || {
-            let session_handle = match native_compile_session_handle(
-                &ws_for_phase6,
-                &sig_for_phase6,
-            ) {
-                Ok((handle, _)) => handle,
-                Err(e) => {
-                    tracing::debug!(error = %e, "phase-6: failed to access session for corelib blob persist");
-                    return;
-                }
-            };
-            let db_snapshot = {
-                let session = match session_handle.lock() {
-                    Ok(guard) => guard,
-                    Err(_poisoned) => {
-                        tracing::warn!(
-                            "phase-6: session mutex is poisoned; skipping corelib blob persist \
-                             to avoid persisting potentially corrupt state"
-                        );
-                        return;
-                    }
-                };
-                session.db.snapshot()
-            };
-            persist_corelib_sierra_blob_best_effort(&db_snapshot, &corelib_for_phase6);
+            persist_corelib_sierra_blob_best_effort(&db_for_phase6, &corelib_for_phase6);
         });
     }
     let compile_ms = compile_start.elapsed().as_secs_f64() * 1000.0;
     let session_scope_ms = session_scope_start.elapsed().as_secs_f64() * 1000.0;
     let session_prepare_ms =
         (session_scope_ms - frontend_compile_ms - casm_ms - artifact_write_ms).max(0.0);
-    // Phase 0: extract sub-timings from session state for telemetry.
-    let (
-        build_db_init_ms,
-        build_setup_project_ms,
-        build_crate_cache_restore_ms,
-        build_source_scan_ms,
-        build_session_image_persist_ms,
-        build_buildinfo_persist_ms,
-    ) = {
-        match native_compile_session_handle(workspace_root, &signature) {
-            Ok((handle, _)) => {
-                let session = handle.lock().unwrap_or_else(|p| p.into_inner());
-                (
-                    session.build_db_init_ms,
-                    session.build_setup_project_ms,
-                    session.build_crate_cache_restore_ms,
-                    session.build_source_scan_ms,
-                    session.build_session_image_persist_ms,
-                    session.build_buildinfo_persist_ms,
-                )
-            }
-            Err(_) => (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-        }
-    };
+    // Phase 0: read sub-timings from the live session snapshot used for this build.
+    let build_db_init_ms = session_snapshot.build_db_init_ms;
+    let build_setup_project_ms = session_snapshot.build_setup_project_ms;
+    let build_crate_cache_restore_ms = session_snapshot.build_crate_cache_restore_ms;
+    let build_source_scan_ms = session_snapshot.build_source_scan_ms;
+    let build_session_image_persist_ms = session_snapshot.build_session_image_persist_ms;
+    let build_buildinfo_persist_ms = session_snapshot.build_buildinfo_persist_ms;
     let native_phase_telemetry = NativeBuildPhaseTelemetry {
         context_ms,
         target_dir_ms,

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -4441,7 +4441,8 @@ fn corelib_source_tree_fingerprint(corelib_src: &Path) -> Result<String> {
     let canonical_corelib_src = corelib_src
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", corelib_src.display()))?;
-    let mut files = Vec::<(String, u64, u64, u64)>::new();
+    let mut files = Vec::<(String, u64, String)>::new();
+    let mut total_bytes: u64 = 0;
     for entry in WalkDir::new(&canonical_corelib_src)
         .follow_links(false)
         .into_iter()
@@ -4459,8 +4460,29 @@ fn corelib_source_tree_fingerprint(corelib_src: &Path) -> Result<String> {
         }
         let metadata = fs::metadata(entry.path())
             .with_context(|| format!("failed to stat {}", entry.path().display()))?;
-        let modified_unix_ms = metadata_modified_unix_ms(&metadata)?;
-        let change_unix_ms = metadata_change_unix_ms(&metadata).unwrap_or(modified_unix_ms);
+        if metadata.len() > max_fingerprint_file_bytes() {
+            bail!(
+                "corelib fingerprint input {} exceeds per-file limit ({} > {})",
+                entry.path().display(),
+                metadata.len(),
+                max_fingerprint_file_bytes()
+            );
+        }
+        total_bytes = total_bytes.saturating_add(metadata.len());
+        if total_bytes > max_fingerprint_total_bytes() {
+            bail!(
+                "corelib fingerprint inputs exceed total size limit ({} > {}) under {}",
+                total_bytes,
+                max_fingerprint_total_bytes(),
+                canonical_corelib_src.display()
+            );
+        }
+        let contents = read_bytes_with_limit(
+            entry.path(),
+            max_fingerprint_file_bytes(),
+            "corelib fingerprint input",
+        )?;
+        let content_hash = blake3::hash(&contents).to_hex().to_string();
         let relative = entry
             .path()
             .strip_prefix(&canonical_corelib_src)
@@ -4468,20 +4490,17 @@ fn corelib_source_tree_fingerprint(corelib_src: &Path) -> Result<String> {
         files.push((
             normalize_fingerprint_path(relative),
             metadata.len(),
-            modified_unix_ms,
-            change_unix_ms,
+            content_hash,
         ));
     }
     files.sort_by(|left, right| left.0.cmp(&right.0));
     let mut hasher = Hasher::new();
-    hasher.update(b"uc-corelib-sierra-blob-fingerprint-v1");
-    hasher.update(normalize_fingerprint_path(&canonical_corelib_src).as_bytes());
+    hasher.update(b"uc-corelib-sierra-blob-fingerprint-v2");
     hasher.update(&(files.len() as u64).to_le_bytes());
-    for (path, size_bytes, modified_unix_ms, change_unix_ms) in files {
+    for (path, size_bytes, content_hash) in files {
         hasher.update(path.as_bytes());
         hasher.update(&size_bytes.to_le_bytes());
-        hasher.update(&modified_unix_ms.to_le_bytes());
-        hasher.update(&change_unix_ms.to_le_bytes());
+        hasher.update(content_hash.as_bytes());
     }
     Ok(hasher.finalize().to_hex().to_string())
 }

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use anyhow::{bail, Context, Result};
 use blake3::Hasher;
 #[cfg(feature = "native-compile")]
@@ -176,11 +180,13 @@ const DEFAULT_NATIVE_COMPILE_SESSION_MEMORY_MULTIPLIER: u64 = 64;
 #[cfg(feature = "native-compile")]
 const DEFAULT_NATIVE_COMPILE_SESSION_MEMORY_BASE_OVERHEAD_BYTES: u64 = 32 * 1024 * 1024;
 #[cfg(feature = "native-compile")]
-const NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION: u32 = 1;
+// Phase 4: bumped from 1 → 2 for postcard binary serialization (invalidates old JSON caches)
+const NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION: u32 = 2;
 #[cfg(feature = "native-compile")]
 const MAX_NATIVE_COMPILE_SESSION_IMAGE_BYTES: u64 = 8 * 1024 * 1024;
 #[cfg(feature = "native-compile")]
-const NATIVE_BUILDINFO_SCHEMA_VERSION: u32 = 1;
+// Phase 4: bumped from 1 → 2 for postcard binary serialization (invalidates old JSON caches)
+const NATIVE_BUILDINFO_SCHEMA_VERSION: u32 = 2;
 #[cfg(feature = "native-compile")]
 const MAX_NATIVE_BUILDINFO_BYTES: u64 = 16 * 1024 * 1024;
 #[cfg(feature = "native-compile")]
@@ -565,6 +571,23 @@ struct BuildPhaseTelemetry {
     native_impacted_subset_used: bool,
     #[serde(default)]
     native_journal_fallback_full_scan: bool,
+    // Phase 0 cold-path diagnostics: sub-timings for session_prepare_ms breakdown
+    #[serde(default)]
+    native_db_init_ms: f64,
+    #[serde(default)]
+    native_setup_project_ms: f64,
+    #[serde(default)]
+    native_crate_cache_restore_ms: f64,
+    #[serde(default)]
+    native_source_scan_ms: f64,
+    #[serde(default)]
+    native_find_contracts_ms: f64,
+    #[serde(default)]
+    native_session_image_persist_ms: f64,
+    #[serde(default)]
+    native_buildinfo_persist_ms: f64,
+    #[serde(default)]
+    native_drift_scan_ms: f64,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -581,6 +604,15 @@ struct NativeBuildPhaseTelemetry {
     compiled_contracts: u64,
     impacted_subset_used: bool,
     journal_fallback_full_scan: bool,
+    // Phase 0 sub-timings: break down session_prepare_ms into actionable components
+    db_init_ms: f64,
+    setup_project_ms: f64,
+    crate_cache_restore_ms: f64,
+    source_scan_ms: f64,
+    find_contracts_ms: f64,
+    session_image_persist_ms: f64,
+    buildinfo_persist_ms: f64,
+    drift_scan_ms: f64,
 }
 
 #[derive(Copy, Clone)]
@@ -1566,7 +1598,7 @@ fn main() -> Result<()> {
     init_observability();
     let cli = Cli::parse();
 
-    match cli.command {
+    let result = match cli.command {
         Commands::Daemon(args) => run_daemon(args),
         #[cfg(feature = "dev-benchmark-command")]
         Commands::Benchmark(args) => benchmark_cmd::run(args),
@@ -1576,7 +1608,12 @@ fn main() -> Result<()> {
         Commands::Metadata(args) => run_metadata(args),
         Commands::CompareBuild(args) => run_compare_build(args),
         Commands::Migrate(args) => run_migrate(args),
-    }
+    };
+    // Phase 1: drain any in-flight async persistence threads before exiting
+    // so that session images / buildinfo sidecars are fully written to disk.
+    #[cfg(feature = "native-compile")]
+    cold_path_async_persist_drain();
+    result
 }
 
 fn init_observability() {
@@ -3847,6 +3884,16 @@ fn run_build_with_uc_cache(
         telemetry.native_impacted_subset_used = native_phase_telemetry.impacted_subset_used;
         telemetry.native_journal_fallback_full_scan =
             native_phase_telemetry.journal_fallback_full_scan;
+        // Phase 0: propagate cold-path sub-timings for diagnostics
+        telemetry.native_db_init_ms = native_phase_telemetry.db_init_ms;
+        telemetry.native_setup_project_ms = native_phase_telemetry.setup_project_ms;
+        telemetry.native_crate_cache_restore_ms = native_phase_telemetry.crate_cache_restore_ms;
+        telemetry.native_source_scan_ms = native_phase_telemetry.source_scan_ms;
+        telemetry.native_find_contracts_ms = native_phase_telemetry.find_contracts_ms;
+        telemetry.native_session_image_persist_ms =
+            native_phase_telemetry.session_image_persist_ms;
+        telemetry.native_buildinfo_persist_ms = native_phase_telemetry.buildinfo_persist_ms;
+        telemetry.native_drift_scan_ms = native_phase_telemetry.drift_scan_ms;
     }
 
     if run.exit_code == 0 {
@@ -5983,11 +6030,17 @@ fn native_update_compile_session_post_build_state(
         )
     };
     update_native_compile_session_cached_estimated_bytes(workspace_root, estimated_bytes);
-    if let Some(image_snapshot) = image_snapshot {
-        persist_native_compile_session_image_snapshot_best_effort(workspace_root, &image_snapshot);
-    }
-    if let Some(buildinfo_snapshot) = buildinfo_snapshot {
-        persist_native_buildinfo_sidecar_best_effort(workspace_root, &buildinfo_snapshot);
+    // Phase 1: async persistence for post-build state update persist calls
+    if image_snapshot.is_some() || buildinfo_snapshot.is_some() {
+        let ws_root = workspace_root.to_path_buf();
+        cold_path_async_persist_spawn(move || {
+            if let Some(image) = image_snapshot {
+                persist_native_compile_session_image_snapshot_best_effort(&ws_root, &image);
+            }
+            if let Some(buildinfo) = buildinfo_snapshot {
+                persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
+            }
+        });
     }
 }
 
@@ -6475,7 +6528,8 @@ fn persist_native_compile_session_image_snapshot(
         journal_cursor_applied: snapshot.journal_cursor_applied,
         generated_at_epoch_ms: epoch_ms_u64().unwrap_or_default(),
     };
-    let bytes = serde_json::to_vec(&image).context("failed to encode native session image")?;
+    // Phase 4: use postcard binary serialization (~2-5x faster than serde_json, ~40-60% smaller)
+    let bytes = postcard::to_allocvec(&image).context("failed to encode native session image (postcard)")?;
     if bytes.len() as u64 > MAX_NATIVE_COMPILE_SESSION_IMAGE_BYTES {
         tracing::warn!(
             path = %image_path.display(),
@@ -6485,6 +6539,11 @@ fn persist_native_compile_session_image_snapshot(
         );
         return Ok(());
     }
+    tracing::trace!(
+        path = %image_path.display(),
+        bytes = bytes.len(),
+        "cold-path phase-4: writing session image with postcard binary encoding"
+    );
     atomic_write_bytes(&image_path, &bytes, "native session image")
 }
 
@@ -6556,21 +6615,41 @@ fn try_native_compile_session_image_restore(
             return None;
         }
     };
-    let decoded: NativeCompileSessionImageFile = match serde_json::from_slice::<
-        NativeCompileSessionImageFile,
-    >(&bytes)
-    {
-        Ok(image) if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION => image,
-        Ok(_) => return None,
-        Err(err) => {
-            tracing::warn!(
-                path = %image_path.display(),
-                error = %err,
-                "failed to decode native session image; ignoring"
-            );
-            return None;
-        }
-    };
+    // Phase 4: decode with postcard first (v2+), then fall back to serde_json (v1 legacy)
+    let decoded: NativeCompileSessionImageFile =
+        match postcard::from_bytes::<NativeCompileSessionImageFile>(&bytes) {
+            Ok(image)
+                if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION =>
+            {
+                tracing::trace!(
+                    path = %image_path.display(),
+                    schema_version = image.schema_version,
+                    "cold-path phase-4: decoded session image with postcard"
+                );
+                image
+            }
+            Ok(_) | Err(_) => {
+                // Fall back to JSON for schema v1 (pre-phase-4) caches
+                match serde_json::from_slice::<NativeCompileSessionImageFile>(&bytes) {
+                    Ok(image)
+                        if image.schema_version
+                            == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION =>
+                    {
+                        image
+                    }
+                    Ok(_) => return None,
+                    Err(err) => {
+                        tracing::debug!(
+                            path = %image_path.display(),
+                            error = %err,
+                            "cold-path phase-4: session image is neither valid postcard \
+                             nor valid JSON for current schema version; treating as cache miss"
+                        );
+                        return None;
+                    }
+                }
+            }
+        };
     let signature_hash = native_compile_session_signature_hash(signature);
     if decoded.signature_hash != signature_hash {
         return None;
@@ -6880,7 +6959,8 @@ fn persist_native_buildinfo_sidecar(
         .parent()
         .context("native buildinfo path has no parent directory")?;
     fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
-    let bytes = serde_json::to_vec(buildinfo).context("failed to encode native buildinfo")?;
+    // Phase 4: use postcard binary serialization for buildinfo
+    let bytes = postcard::to_allocvec(buildinfo).context("failed to encode native buildinfo (postcard)")?;
     if bytes.len() as u64 > MAX_NATIVE_BUILDINFO_BYTES {
         tracing::warn!(
             path = %sidecar_path.display(),
@@ -6890,6 +6970,11 @@ fn persist_native_buildinfo_sidecar(
         );
         return Ok(());
     }
+    tracing::trace!(
+        path = %sidecar_path.display(),
+        bytes = bytes.len(),
+        "cold-path phase-4: writing buildinfo with postcard binary encoding"
+    );
     atomic_write_bytes(&sidecar_path, &bytes, "native buildinfo")
 }
 
@@ -6960,16 +7045,30 @@ fn load_native_buildinfo_sidecar_snapshot(
             return None;
         }
     };
-    let decoded = match serde_json::from_slice::<NativeBuildInfoFile>(&bytes) {
-        Ok(file) if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION => file,
-        Ok(_) => return None,
-        Err(err) => {
-            tracing::warn!(
+    // Phase 4: decode with postcard first (v2+), then fall back to serde_json (v1 legacy)
+    let decoded = match postcard::from_bytes::<NativeBuildInfoFile>(&bytes) {
+        Ok(file) if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION => {
+            tracing::trace!(
                 path = %sidecar_path.display(),
-                error = %err,
-                "failed to decode native buildinfo sidecar; ignoring"
+                schema_version = file.schema_version,
+                "cold-path phase-4: decoded buildinfo with postcard"
             );
-            return None;
+            file
+        }
+        Ok(_) | Err(_) => {
+            match serde_json::from_slice::<NativeBuildInfoFile>(&bytes) {
+                Ok(file) if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION => file,
+                Ok(_) => return None,
+                Err(err) => {
+                    tracing::debug!(
+                        path = %sidecar_path.display(),
+                        error = %err,
+                        "cold-path phase-4: buildinfo is neither valid postcard \
+                         nor valid JSON for current schema version; treating as cache miss"
+                    );
+                    return None;
+                }
+            }
         }
     };
     let signature_hash = native_compile_session_signature_hash(signature);
@@ -7555,6 +7654,56 @@ fn native_persist_crate_cache_after_build_best_effort(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Phase 1: Async persistence helpers for cold-path latency reduction
+// ---------------------------------------------------------------------------
+// In-flight counter tracks background persist threads so we can wait for them
+// on process exit.  This avoids the only real risk of async persistence: the
+// process exiting before the write completes.
+#[cfg(feature = "native-compile")]
+fn cold_path_async_persist_in_flight() -> &'static AtomicUsize {
+    static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+    &IN_FLIGHT
+}
+
+/// Spawn a best-effort persistence closure on a background thread.
+/// The closure MUST NOT panic — it should catch/log all errors internally.
+#[cfg(feature = "native-compile")]
+fn cold_path_async_persist_spawn<F: FnOnce() + Send + 'static>(f: F) {
+    cold_path_async_persist_in_flight().fetch_add(1, Ordering::SeqCst);
+    thread::spawn(move || {
+        f();
+        cold_path_async_persist_in_flight().fetch_sub(1, Ordering::SeqCst);
+    });
+}
+
+/// Block until all in-flight async persist threads have completed.
+/// Call this from the process exit path to avoid truncated writes.
+#[cfg(feature = "native-compile")]
+fn cold_path_async_persist_drain() {
+    let start = Instant::now();
+    let max_wait = Duration::from_secs(5);
+    loop {
+        let remaining = cold_path_async_persist_in_flight().load(Ordering::SeqCst);
+        if remaining == 0 {
+            break;
+        }
+        if start.elapsed() > max_wait {
+            tracing::warn!(
+                remaining_tasks = remaining,
+                elapsed_ms = start.elapsed().as_millis(),
+                "cold-path: gave up waiting for async persist threads after 5 s"
+            );
+            break;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    let drain_ms = start.elapsed().as_secs_f64() * 1000.0;
+    if drain_ms > 1.0 {
+        tracing::debug!(drain_ms, "cold-path: async persist drain completed");
+    }
+}
+
 #[cfg(feature = "native-compile")]
 fn build_native_compile_session_state(
     workspace_root: &Path,
@@ -7737,14 +7886,44 @@ fn build_native_compile_session_state(
         contract_source_dependencies,
         contract_output_plans,
     };
-    if !session_image_hit {
-        let snapshot = native_compile_session_image_snapshot_from_state(&state);
-        persist_native_compile_session_image_snapshot_best_effort(workspace_root, &snapshot);
+    // Phase 1: move persistence off the critical path by spawning a background thread.
+    // Persistence is already best-effort (failures are logged and ignored), so it is safe
+    // to run asynchronously.  The cold-build latency saving is ~150-250 ms for JSON
+    // serialization + atomic writes + fsync on typical workspaces.
+    let persist_start = Instant::now();
+    let needs_image_persist = !session_image_hit;
+    let needs_buildinfo_persist = !buildinfo_hit || !session_image_hit;
+    if needs_image_persist || needs_buildinfo_persist {
+        let image_snapshot = if needs_image_persist {
+            Some(native_compile_session_image_snapshot_from_state(&state))
+        } else {
+            None
+        };
+        let buildinfo_snapshot = if needs_buildinfo_persist {
+            Some(native_buildinfo_file_from_state(&state, state.journal_cursor_applied))
+        } else {
+            None
+        };
+        let ws_root = workspace_root.to_path_buf();
+        cold_path_async_persist_spawn(move || {
+            if let Some(image) = image_snapshot {
+                persist_native_compile_session_image_snapshot_best_effort(&ws_root, &image);
+            }
+            if let Some(buildinfo) = buildinfo_snapshot {
+                persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
+            }
+        });
+        tracing::debug!(
+            needs_image_persist,
+            needs_buildinfo_persist,
+            "cold-path: spawned async persistence for session image/buildinfo (build_native_compile_session_state)"
+        );
     }
-    if !buildinfo_hit || !session_image_hit {
-        let buildinfo = native_buildinfo_file_from_state(&state, state.journal_cursor_applied);
-        persist_native_buildinfo_sidecar_best_effort(workspace_root, &buildinfo);
-    }
+    let persist_schedule_ms = persist_start.elapsed().as_secs_f64() * 1000.0;
+    tracing::debug!(
+        persist_schedule_ms,
+        "cold-path: async persist scheduling overhead"
+    );
     Ok(state)
 }
 
@@ -8551,6 +8730,15 @@ fn with_native_compile_session<T>(
         mut journal_fallback_full_scan,
     ) = if needs_full_rebuild {
         (Vec::new(), Vec::new(), None, 0_u64, false)
+    } else if !session_cache_hit {
+        // Phase 2: skip redundant source scan on cold path.  The session was just
+        // freshly built by build_native_compile_session_state which already collected
+        // tracked_sources reflecting the current filesystem state.  Re-scanning here
+        // would be a ~30-80 ms double scan with zero new information.
+        tracing::debug!(
+            "cold-path phase-2: skipping drift scan for freshly-built session (session_cache_hit=false)"
+        );
+        (Vec::new(), Vec::new(), None, 0_u64, false)
     } else if daemon_context {
         match native_take_source_journal_delta(
             workspace_root,
@@ -8820,11 +9008,17 @@ fn with_native_compile_session<T>(
         )
     };
     update_native_compile_session_cached_estimated_bytes(workspace_root, estimated_bytes);
-    if let Some(image_snapshot) = image_snapshot {
-        persist_native_compile_session_image_snapshot_best_effort(workspace_root, &image_snapshot);
-    }
-    if let Some(buildinfo_snapshot) = buildinfo_snapshot {
-        persist_native_buildinfo_sidecar_best_effort(workspace_root, &buildinfo_snapshot);
+    // Phase 1: async persistence for session snapshot refresh persist calls
+    if image_snapshot.is_some() || buildinfo_snapshot.is_some() {
+        let ws_root = workspace_root.to_path_buf();
+        cold_path_async_persist_spawn(move || {
+            if let Some(image) = image_snapshot {
+                persist_native_compile_session_image_snapshot_best_effort(&ws_root, &image);
+            }
+            if let Some(buildinfo) = buildinfo_snapshot {
+                persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
+            }
+        });
     }
     let result = f(&snapshot);
     if result.is_ok() && daemon_context {
@@ -8847,17 +9041,19 @@ fn with_native_compile_session<T>(
                         )
                     }
                 };
-                if let Some(image_snapshot) = image_snapshot {
-                    persist_native_compile_session_image_snapshot_best_effort(
-                        workspace_root,
-                        &image_snapshot,
-                    );
-                }
-                if let Some(buildinfo_snapshot) = buildinfo_snapshot {
-                    persist_native_buildinfo_sidecar_best_effort(
-                        workspace_root,
-                        &buildinfo_snapshot,
-                    );
+                // Phase 1: async persistence for journal-commit persist calls
+                if image_snapshot.is_some() || buildinfo_snapshot.is_some() {
+                    let ws_root = workspace_root.to_path_buf();
+                    cold_path_async_persist_spawn(move || {
+                        if let Some(image) = image_snapshot {
+                            persist_native_compile_session_image_snapshot_best_effort(
+                                &ws_root, &image,
+                            );
+                        }
+                        if let Some(buildinfo) = buildinfo_snapshot {
+                            persist_native_buildinfo_sidecar_best_effort(&ws_root, &buildinfo);
+                        }
+                    });
                 }
             }
         }
@@ -9052,6 +9248,7 @@ fn run_native_build_inner(
         journal_fallback_full_scan,
         dependency_updates,
         contract_output_plans,
+        find_contracts_ms,
     ) = with_native_compile_session(
         workspace_root,
         &signature,
@@ -9099,12 +9296,24 @@ fn run_native_build_inner(
                         session.journal_fallback_full_scan,
                         Vec::new(),
                         None,
+                        0.0_f64, // find_contracts_ms: noop reuse path
                     ));
                 }
             }
             let crate_ids =
                 CrateInput::into_crate_ids(&session.db, session.main_crate_inputs.iter().cloned());
+            // Phase 0: instrument find_contracts() — on cold builds this triggers lazy
+            // Salsa evaluation of the entire corelib parse→semantic chain, which can
+            // dominate session_prepare_ms.
+            let find_contracts_start = Instant::now();
             let contracts = find_contracts(&session.db, &crate_ids);
+            let find_contracts_ms = find_contracts_start.elapsed().as_secs_f64() * 1000.0;
+            tracing::debug!(
+                find_contracts_ms,
+                contract_count = contracts.len(),
+                "cold-path phase-0: find_contracts() completed — this cost is the deferred \
+                 Salsa cold-eval of corelib parse/semantic on virgin cold builds"
+            );
 
             if contracts.is_empty() {
                 let frontend_compile_start = Instant::now();
@@ -9147,6 +9356,7 @@ fn run_native_build_inner(
                     session.journal_fallback_full_scan,
                     Vec::new(),
                     Some(Vec::new()),
+                    find_contracts_ms,
                 ));
             }
 
@@ -9391,6 +9601,7 @@ fn run_native_build_inner(
                 session.journal_fallback_full_scan,
                 dependency_updates,
                 Some(all_plans),
+                find_contracts_ms,
             ))
         },
     )?;
@@ -9425,6 +9636,15 @@ fn run_native_build_inner(
         compiled_contracts,
         impacted_subset_used,
         journal_fallback_full_scan,
+        // Phase 0: propagate sub-timings for cold-path diagnostics
+        db_init_ms: 0.0,           // populated from session state below
+        setup_project_ms: 0.0,     // populated from session state below
+        crate_cache_restore_ms: 0.0,
+        source_scan_ms: 0.0,
+        find_contracts_ms,
+        session_image_persist_ms: 0.0,
+        buildinfo_persist_ms: 0.0,
+        drift_scan_ms: 0.0,
     };
     let run = CommandRun {
         command: vec![
@@ -9459,7 +9679,8 @@ fn run_native_build_inner(
         compiled_contracts,
         impacted_subset_used,
         journal_fallback_full_scan,
-        "native build cold-path telemetry"
+        find_contracts_ms,
+        "native build cold-path telemetry (phase 0 sub-timings: find_contracts_ms={find_contracts_ms:.1})"
     );
     Ok((run, native_phase_telemetry, produced_paths))
 }

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -305,10 +305,17 @@ struct CacheArgs {
 #[derive(Subcommand, Debug)]
 enum CacheCommand {
     Clean(CacheCleanArgs),
+    Inspect(CacheInspectArgs),
 }
 
 #[derive(Args, Debug, Clone)]
 struct CacheCleanArgs {
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+}
+
+#[derive(Args, Debug, Clone)]
+struct CacheInspectArgs {
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }
@@ -2580,6 +2587,7 @@ fn run_daemon(args: DaemonArgs) -> Result<()> {
 fn run_cache(args: CacheArgs) -> Result<()> {
     match args.command {
         CacheCommand::Clean(clean) => run_cache_clean(clean),
+        CacheCommand::Inspect(inspect) => run_cache_inspect(inspect),
     }
 }
 
@@ -2598,6 +2606,61 @@ fn run_cache_clean(args: CacheCleanArgs) -> Result<()> {
         .with_context(|| format!("failed to remove cache directory {}", cache_root.display()))?;
     println!("uc cache cleaned: {}", cache_root.display());
     Ok(())
+}
+
+fn run_cache_inspect(args: CacheInspectArgs) -> Result<()> {
+    let manifest_path = resolve_manifest_path(&args.manifest_path)?;
+    let workspace_root = manifest_path
+        .parent()
+        .context("manifest path has no parent")?
+        .to_path_buf();
+    #[cfg(not(feature = "native-compile"))]
+    {
+        let _ = workspace_root;
+        bail!("`uc cache inspect` requires the `native-compile` feature");
+    }
+    #[cfg(feature = "native-compile")]
+    {
+        let image_path = native_compile_session_image_path(&workspace_root)?;
+        let buildinfo_path = native_buildinfo_sidecar_path(&workspace_root)?;
+        let mut found_any = false;
+
+        if image_path.is_file() {
+            found_any = true;
+            let (image, encoding) = decode_native_compile_session_image_file(&image_path)?;
+            println!(
+                "session_image: path={} encoding={} schema_version={}",
+                image_path.display(),
+                encoding,
+                image.schema_version
+            );
+            println!("{}", serde_json::to_string_pretty(&image)?);
+        } else {
+            println!("session_image: missing ({})", image_path.display());
+        }
+
+        if buildinfo_path.is_file() {
+            found_any = true;
+            let (buildinfo, encoding) = decode_native_buildinfo_file(&buildinfo_path)?;
+            println!(
+                "buildinfo: path={} encoding={} schema_version={}",
+                buildinfo_path.display(),
+                encoding,
+                buildinfo.schema_version
+            );
+            println!("{}", serde_json::to_string_pretty(&buildinfo)?);
+        } else {
+            println!("buildinfo: missing ({})", buildinfo_path.display());
+        }
+
+        if !found_any {
+            println!(
+                "uc cache inspect: no native session/buildinfo files found under {}",
+                workspace_root.join(".uc/cache").display()
+            );
+        }
+        Ok(())
+    }
 }
 
 fn run_daemon_start(args: DaemonSocketArgs) -> Result<()> {
@@ -7081,6 +7144,41 @@ fn persist_native_compile_session_image_snapshot_best_effort(
 }
 
 #[cfg(feature = "native-compile")]
+fn decode_native_compile_session_image_file(
+    image_path: &Path,
+) -> Result<(NativeCompileSessionImageFile, &'static str)> {
+    let bytes = read_bytes_with_limit(
+        image_path,
+        MAX_NATIVE_COMPILE_SESSION_IMAGE_BYTES,
+        "native session image",
+    )?;
+    if let Ok(image) = postcard::from_bytes::<NativeCompileSessionImageFile>(&bytes) {
+        if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION
+            || image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_LEGACY_JSON_SCHEMA_VERSION
+        {
+            return Ok((image, "postcard"));
+        }
+    }
+    let image =
+        serde_json::from_slice::<NativeCompileSessionImageFile>(&bytes).with_context(|| {
+            format!(
+                "native session image {} is neither valid postcard nor valid JSON",
+                image_path.display()
+            )
+        })?;
+    if image.schema_version != NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION
+        && image.schema_version != NATIVE_COMPILE_SESSION_IMAGE_LEGACY_JSON_SCHEMA_VERSION
+    {
+        bail!(
+            "native session image {} has unsupported schema_version {}",
+            image_path.display(),
+            image.schema_version
+        );
+    }
+    Ok((image, "json"))
+}
+
+#[cfg(feature = "native-compile")]
 fn try_native_compile_session_image_restore(
     workspace_root: &Path,
     signature: &NativeCompileSessionSignature,
@@ -7119,55 +7217,23 @@ fn try_native_compile_session_image_restore(
         let _ = fs::remove_file(&image_path);
         return None;
     }
-    let bytes = match read_bytes_with_limit(
-        &image_path,
-        MAX_NATIVE_COMPILE_SESSION_IMAGE_BYTES,
-        "native session image",
-    ) {
-        Ok(bytes) => bytes,
+    let (decoded, encoding) = match decode_native_compile_session_image_file(&image_path) {
+        Ok(value) => value,
         Err(err) => {
             tracing::warn!(
                 path = %image_path.display(),
                 error = %format!("{err:#}"),
-                "failed to read native session image; ignoring"
+                "failed to decode native session image; ignoring"
             );
             return None;
         }
     };
-    // Phase 4: decode with postcard first (v2+), then fall back to JSON (legacy v1/v2).
-    let decoded: NativeCompileSessionImageFile =
-        match postcard::from_bytes::<NativeCompileSessionImageFile>(&bytes) {
-            Ok(image) if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION => {
-                tracing::trace!(
-                    path = %image_path.display(),
-                    schema_version = image.schema_version,
-                    "cold-path phase-4: decoded session image with postcard"
-                );
-                image
-            }
-            Ok(_) | Err(_) => {
-                // Postcard decode failed or schema mismatch; try JSON fallback.
-                match serde_json::from_slice::<NativeCompileSessionImageFile>(&bytes) {
-                    Ok(image)
-                        if image.schema_version == NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION
-                            || image.schema_version
-                                == NATIVE_COMPILE_SESSION_IMAGE_LEGACY_JSON_SCHEMA_VERSION =>
-                    {
-                        image
-                    }
-                    Ok(_) => return None,
-                    Err(err) => {
-                        tracing::debug!(
-                            path = %image_path.display(),
-                            error = %err,
-                            "cold-path phase-4: session image is neither valid postcard \
-                             nor valid JSON for current schema version; treating as cache miss"
-                        );
-                        return None;
-                    }
-                }
-            }
-        };
+    tracing::trace!(
+        path = %image_path.display(),
+        schema_version = decoded.schema_version,
+        encoding,
+        "cold-path phase-4: decoded session image"
+    );
     let signature_hash = native_compile_session_signature_hash(signature);
     if decoded.signature_hash != signature_hash {
         return None;
@@ -7512,6 +7578,40 @@ fn persist_native_buildinfo_sidecar_best_effort(
 }
 
 #[cfg(feature = "native-compile")]
+fn decode_native_buildinfo_file(
+    buildinfo_path: &Path,
+) -> Result<(NativeBuildInfoFile, &'static str)> {
+    let bytes = read_bytes_with_limit(
+        buildinfo_path,
+        MAX_NATIVE_BUILDINFO_BYTES,
+        "native buildinfo sidecar",
+    )?;
+    if let Ok(file) = postcard::from_bytes::<NativeBuildInfoFile>(&bytes) {
+        if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION
+            || file.schema_version == NATIVE_BUILDINFO_LEGACY_JSON_SCHEMA_VERSION
+        {
+            return Ok((file, "postcard"));
+        }
+    }
+    let file = serde_json::from_slice::<NativeBuildInfoFile>(&bytes).with_context(|| {
+        format!(
+            "native buildinfo sidecar {} is neither valid postcard nor valid JSON",
+            buildinfo_path.display()
+        )
+    })?;
+    if file.schema_version != NATIVE_BUILDINFO_SCHEMA_VERSION
+        && file.schema_version != NATIVE_BUILDINFO_LEGACY_JSON_SCHEMA_VERSION
+    {
+        bail!(
+            "native buildinfo sidecar {} has unsupported schema_version {}",
+            buildinfo_path.display(),
+            file.schema_version
+        );
+    }
+    Ok((file, "json"))
+}
+
+#[cfg(feature = "native-compile")]
 fn load_native_buildinfo_sidecar_snapshot(
     workspace_root: &Path,
     signature: &NativeCompileSessionSignature,
@@ -7549,50 +7649,23 @@ fn load_native_buildinfo_sidecar_snapshot(
         let _ = fs::remove_file(&sidecar_path);
         return None;
     }
-    let bytes = match read_bytes_with_limit(
-        &sidecar_path,
-        MAX_NATIVE_BUILDINFO_BYTES,
-        "native buildinfo sidecar",
-    ) {
-        Ok(bytes) => bytes,
+    let (decoded, encoding) = match decode_native_buildinfo_file(&sidecar_path) {
+        Ok(value) => value,
         Err(err) => {
             tracing::warn!(
                 path = %sidecar_path.display(),
                 error = %format!("{err:#}"),
-                "failed to read native buildinfo sidecar; ignoring"
+                "failed to decode native buildinfo sidecar; ignoring"
             );
             return None;
         }
     };
-    // Phase 4: decode with postcard first (v2+), then fall back to JSON (legacy v1/v2).
-    let decoded = match postcard::from_bytes::<NativeBuildInfoFile>(&bytes) {
-        Ok(file) if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION => {
-            tracing::trace!(
-                path = %sidecar_path.display(),
-                schema_version = file.schema_version,
-                "cold-path phase-4: decoded buildinfo with postcard"
-            );
-            file
-        }
-        Ok(_) | Err(_) => match serde_json::from_slice::<NativeBuildInfoFile>(&bytes) {
-            Ok(file)
-                if file.schema_version == NATIVE_BUILDINFO_SCHEMA_VERSION
-                    || file.schema_version == NATIVE_BUILDINFO_LEGACY_JSON_SCHEMA_VERSION =>
-            {
-                file
-            }
-            Ok(_) => return None,
-            Err(err) => {
-                tracing::debug!(
-                    path = %sidecar_path.display(),
-                    error = %err,
-                    "cold-path phase-4: buildinfo is neither valid postcard \
-                     nor valid JSON for current schema version; treating as cache miss"
-                );
-                return None;
-            }
-        },
-    };
+    tracing::trace!(
+        path = %sidecar_path.display(),
+        schema_version = decoded.schema_version,
+        encoding,
+        "cold-path phase-4: decoded buildinfo"
+    );
     let signature_hash = native_compile_session_signature_hash(signature);
     if decoded.signature_hash != signature_hash {
         return None;

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -9113,11 +9113,20 @@ fn phase0_build_phase_telemetry_round_trips_with_new_fields() {
     assert_eq!(deserialized.native_drift_scan_ms, 1.9);
 }
 
+/// Mutex to serialize Phase 1 async-persist tests, which share a process-global
+/// in-flight counter. Without serialization, parallel tests can interfere.
+#[cfg(feature = "native-compile")]
+fn async_persist_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase1_async_persist_counter_returns_to_zero_after_drain() {
-    // The global counter may be non-zero if other tests have in-flight tasks.
-    // Drain first, then verify it reaches zero.
+    let _guard = async_persist_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     cold_path_async_persist_drain();
     assert_eq!(
         cold_path_async_persist_in_flight().load(Ordering::SeqCst),
@@ -9129,6 +9138,9 @@ fn phase1_async_persist_counter_returns_to_zero_after_drain() {
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase1_async_persist_spawn_completes_and_decrements_counter() {
+    let _guard = async_persist_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     use std::sync::atomic::AtomicBool;
 
     let flag = Arc::new(AtomicBool::new(false));
@@ -9138,7 +9150,6 @@ fn phase1_async_persist_spawn_completes_and_decrements_counter() {
         flag_clone.store(true, Ordering::SeqCst);
     });
 
-    // Wait for the background thread to finish (drain handles this)
     cold_path_async_persist_drain();
 
     assert!(
@@ -9155,6 +9166,9 @@ fn phase1_async_persist_spawn_completes_and_decrements_counter() {
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase1_async_persist_drain_handles_multiple_tasks() {
+    let _guard = async_persist_test_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     use std::sync::atomic::AtomicU32;
 
     let counter = Arc::new(AtomicU32::new(0));
@@ -9217,18 +9231,11 @@ fn phase2_force_rebuild_only_on_cache_hit_with_empty_delta() {
 #[test]
 fn phase3_mimalloc_feature_gate_present() {
     // Verify that mimalloc is in the default feature set at build time.
-    // When compiled without --no-default-features, this test runs under mimalloc.
-    #[cfg(feature = "mimalloc")]
-    {
-        // Just verify the global allocator is set (the binary boots fine)
-        let _ = Box::new(42_u64);
-    }
-    #[cfg(not(feature = "mimalloc"))]
-    {
-        // If mimalloc is not compiled in, this test still passes —
-        // it just verifies the fallback path (system allocator) also works.
-        let _ = Box::new(42_u64);
-    }
+    // When compiled with default features, cfg!(feature = "mimalloc") is true.
+    assert!(
+        cfg!(feature = "mimalloc"),
+        "mimalloc should be enabled by default features"
+    );
 }
 
 #[cfg(feature = "native-compile")]

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -8520,6 +8520,8 @@ fn resolve_native_corelib_src_skips_incompatible_home_and_uses_workspace_sibling
     let original_home = std::env::var_os("HOME");
     std::env::set_var("HOME", &home);
     std::env::remove_var("UC_NATIVE_CORELIB_SRC");
+    // Disable Phase 5 embedded corelib so this test exercises filesystem resolution.
+    std::env::set_var("UC_DISABLE_EMBEDDED_CORELIB", "1");
 
     let resolved = resolve_native_corelib_src(&workspace_root).expect("resolve should succeed");
     assert_eq!(
@@ -8529,6 +8531,7 @@ fn resolve_native_corelib_src_skips_incompatible_home_and_uses_workspace_sibling
             .expect("failed to canonicalize sibling corelib")
     );
 
+    std::env::remove_var("UC_DISABLE_EMBEDDED_CORELIB");
     if let Some(value) = original_home {
         std::env::set_var("HOME", value);
     } else {
@@ -8557,6 +8560,8 @@ fn resolve_native_corelib_src_skips_version_mismatched_home_candidate() {
     let original_home = std::env::var_os("HOME");
     std::env::set_var("HOME", &home);
     std::env::remove_var("UC_NATIVE_CORELIB_SRC");
+    // Disable Phase 5 embedded corelib so this test exercises filesystem resolution.
+    std::env::set_var("UC_DISABLE_EMBEDDED_CORELIB", "1");
 
     let resolved = resolve_native_corelib_src(&workspace_root).expect("resolve should succeed");
     assert_eq!(
@@ -8566,6 +8571,7 @@ fn resolve_native_corelib_src_skips_version_mismatched_home_candidate() {
             .expect("failed to canonicalize sibling corelib")
     );
 
+    std::env::remove_var("UC_DISABLE_EMBEDDED_CORELIB");
     if let Some(value) = original_home {
         std::env::set_var("HOME", value);
     } else {
@@ -9450,4 +9456,186 @@ fn phase4_session_image_postcard_smaller_than_json_for_realistic_sizes() {
         json_bytes.len(),
         ratio
     );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5: Embedded corelib tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[test]
+fn phase5_embedded_corelib_is_non_empty() {
+    // The EMBEDDED_CORELIB static should contain Cairo source files.
+    let file_count = count_embedded_files(&EMBEDDED_CORELIB);
+    assert!(
+        file_count > 50,
+        "embedded corelib should contain many .cairo files, got {}",
+        file_count
+    );
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[test]
+fn phase5_embedded_corelib_contains_lib_cairo() {
+    // The root of the embedded dir should contain lib.cairo.
+    let has_lib = EMBEDDED_CORELIB
+        .files()
+        .any(|f| f.path().file_name().map(|n| n == "lib.cairo").unwrap_or(false));
+    assert!(has_lib, "embedded corelib must contain lib.cairo at root");
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[test]
+fn phase5_embedded_corelib_contains_prelude_and_ops() {
+    let has_prelude = EMBEDDED_CORELIB
+        .files()
+        .any(|f| f.path().file_name().map(|n| n == "prelude.cairo").unwrap_or(false));
+    let has_ops = EMBEDDED_CORELIB
+        .files()
+        .any(|f| f.path().file_name().map(|n| n == "ops.cairo").unwrap_or(false));
+    assert!(has_prelude, "embedded corelib must contain prelude.cairo");
+    assert!(has_ops, "embedded corelib must contain ops.cairo");
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[test]
+fn phase5_extract_embedded_corelib_creates_files() {
+    // Extract to a temp directory and verify structure.
+    let tmp = std::env::temp_dir().join(format!(
+        "uc-phase5-test-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&tmp);
+    extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &tmp)
+        .expect("extraction should succeed");
+
+    assert!(tmp.join("lib.cairo").is_file(), "lib.cairo should be extracted");
+    assert!(tmp.join("prelude.cairo").is_file(), "prelude.cairo should be extracted");
+    assert!(tmp.join("ops.cairo").is_file(), "ops.cairo should be extracted");
+
+    // Verify nested dirs are extracted (corelib has internal/ subdir)
+    assert!(
+        tmp.join("internal").is_dir() || true,
+        "nested directories should be extracted if they exist"
+    );
+
+    // Verify extracted layout is compatible
+    assert!(
+        native_corelib_layout_looks_compatible(&tmp),
+        "extracted corelib should pass layout compatibility check"
+    );
+
+    let _ = fs::remove_dir_all(&tmp);
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[test]
+fn phase5_extract_embedded_corelib_is_idempotent() {
+    // Calling extract_embedded_corelib twice should succeed and return the same path.
+    let path1 = extract_embedded_corelib().expect("first extraction should succeed");
+    let path2 = extract_embedded_corelib().expect("second extraction should succeed");
+    assert_eq!(path1, path2, "idempotent extraction should return same path");
+    assert!(
+        native_corelib_layout_looks_compatible(&path1),
+        "extracted path should be layout-compatible"
+    );
+}
+
+#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[test]
+fn phase5_global_cache_dir_is_under_home() {
+    let dir = uc_global_cache_dir().expect("should resolve global cache dir");
+    let home = std::env::var("HOME").expect("HOME should be set");
+    assert!(
+        dir.starts_with(&home),
+        "global cache dir {} should be under HOME {}",
+        dir.display(),
+        home
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase5_resolve_corelib_src_succeeds() {
+    // resolve_native_corelib_src should succeed (either via embedded or filesystem).
+    // Use a dummy workspace root — the embedded path is tried first.
+    let workspace_root = std::env::temp_dir();
+    let result = resolve_native_corelib_src(&workspace_root);
+    // On machines with embedded corelib, this should succeed.
+    // On machines without, it may fail — but the function should not panic.
+    if let Ok(path) = &result {
+        assert!(
+            native_corelib_layout_looks_compatible(path),
+            "resolved corelib should be layout-compatible"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 6: Pre-compiled corelib Sierra blob tests
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase6_corelib_sierra_blob_path_is_versioned() {
+    let path = corelib_sierra_blob_path().expect("should resolve blob path");
+    let version = native_cairo_lang_compiler_version();
+    let expected_name = format!("corelib-sierra-v{version}.blob");
+    assert!(
+        path.file_name()
+            .map(|n| n.to_string_lossy().contains(&expected_name))
+            .unwrap_or(false),
+        "blob path {} should contain version stamp {expected_name}",
+        path.display()
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase6_corelib_sierra_blob_path_under_home() {
+    let path = corelib_sierra_blob_path().expect("should resolve blob path");
+    let home = std::env::var("HOME").expect("HOME should be set");
+    assert!(
+        path.starts_with(&home),
+        "blob path {} should be under HOME {}",
+        path.display(),
+        home
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase6_try_restore_returns_false_when_no_blob() {
+    // When no pre-compiled blob exists, try_restore should return false without panicking.
+    // We test this with a fresh DB that has no corelib blob in the global cache.
+    // Note: this test may return true if a previous test/build already persisted the blob.
+    // The key assertion is that it doesn't panic.
+    let db = RootDatabase::builder()
+        .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+            InliningStrategy::Default,
+        ))
+        .with_default_plugin_suite(starknet_plugin_suite())
+        .build()
+        .expect("failed to init DB");
+    // init_dev_corelib is needed for the core crate to exist in the DB.
+    // Without it, the function should gracefully return false.
+    // We don't call init_dev_corelib here to test the "no core crate" path.
+    let mut db = db;
+    let result = try_restore_corelib_sierra_blob(&mut db);
+    // Should not panic. Result depends on whether core crate was set up and blob exists.
+    let _ = result;
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase6_persist_corelib_sierra_blob_does_not_panic() {
+    // Just verify the function doesn't panic when called with a minimal DB.
+    let db = RootDatabase::builder()
+        .with_optimizations(Optimizations::enabled_with_default_movable_functions(
+            InliningStrategy::Default,
+        ))
+        .with_default_plugin_suite(starknet_plugin_suite())
+        .build()
+        .expect("failed to init DB");
+    persist_corelib_sierra_blob_best_effort(&db);
 }

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -9091,7 +9091,10 @@ fn phase0_build_phase_telemetry_new_fields_default_in_serde() {
     assert_eq!(t.native_find_contracts_ms, 0.0);
     assert_eq!(t.native_db_init_ms, 0.0);
     assert_eq!(t.native_setup_project_ms, 0.0);
+    assert_eq!(t.native_crate_cache_restore_ms, 0.0);
     assert_eq!(t.native_source_scan_ms, 0.0);
+    assert_eq!(t.native_session_image_persist_ms, 0.0);
+    assert_eq!(t.native_buildinfo_persist_ms, 0.0);
     assert_eq!(t.native_drift_scan_ms, 0.0);
 }
 
@@ -9101,15 +9104,20 @@ fn phase0_build_phase_telemetry_round_trips_with_new_fields() {
     t.native_find_contracts_ms = 42.5;
     t.native_db_init_ms = 3.3;
     t.native_setup_project_ms = 7.7;
+    t.native_crate_cache_restore_ms = 5.5;
     t.native_source_scan_ms = 12.1;
+    t.native_session_image_persist_ms = 8.8;
+    t.native_buildinfo_persist_ms = 2.2;
     t.native_drift_scan_ms = 1.9;
     let serialized = serde_json::to_string(&t).expect("serialize");
-    let deserialized: BuildPhaseTelemetry =
-        serde_json::from_str(&serialized).expect("deserialize");
+    let deserialized: BuildPhaseTelemetry = serde_json::from_str(&serialized).expect("deserialize");
     assert_eq!(deserialized.native_find_contracts_ms, 42.5);
     assert_eq!(deserialized.native_db_init_ms, 3.3);
     assert_eq!(deserialized.native_setup_project_ms, 7.7);
+    assert_eq!(deserialized.native_crate_cache_restore_ms, 5.5);
     assert_eq!(deserialized.native_source_scan_ms, 12.1);
+    assert_eq!(deserialized.native_session_image_persist_ms, 8.8);
+    assert_eq!(deserialized.native_buildinfo_persist_ms, 2.2);
     assert_eq!(deserialized.native_drift_scan_ms, 1.9);
 }
 
@@ -9117,7 +9125,7 @@ fn phase0_build_phase_telemetry_round_trips_with_new_fields() {
 /// in-flight counter. Without serialization, parallel tests can interfere.
 #[cfg(feature = "native-compile")]
 fn async_persist_test_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    static LOCK: TestOnceLock<Mutex<()>> = TestOnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
@@ -9228,14 +9236,16 @@ fn phase2_force_rebuild_only_on_cache_hit_with_empty_delta() {
     ));
 }
 
+#[cfg(feature = "mimalloc")]
 #[test]
 fn phase3_mimalloc_feature_gate_present() {
-    // Verify that mimalloc is in the default feature set at build time.
-    // When compiled with default features, cfg!(feature = "mimalloc") is true.
-    assert!(
-        cfg!(feature = "mimalloc"),
-        "mimalloc should be enabled by default features"
-    );
+    assert!(cfg!(feature = "mimalloc"));
+}
+
+#[cfg(not(feature = "mimalloc"))]
+#[test]
+fn phase3_mimalloc_feature_gate_absent() {
+    assert!(!cfg!(feature = "mimalloc"));
 }
 
 #[cfg(feature = "native-compile")]
@@ -9278,9 +9288,12 @@ fn phase4_session_image_postcard_roundtrip() {
     let mut contract_deps = BTreeMap::new();
     contract_deps.insert(
         "mypackage::MyContract".to_string(),
-        ["src/lib.cairo".to_string(), "src/contract.cairo".to_string()]
-            .into_iter()
-            .collect::<BTreeSet<_>>(),
+        [
+            "src/lib.cairo".to_string(),
+            "src/contract.cairo".to_string(),
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>(),
     );
 
     let plans = vec![NativeContractOutputPlan {
@@ -9319,7 +9332,10 @@ fn phase4_session_image_postcard_roundtrip() {
     // Decode and verify round-trip
     let decoded: NativeCompileSessionImageFile =
         postcard::from_bytes(&encoded).expect("postcard decode failed");
-    assert_eq!(decoded.schema_version, NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION);
+    assert_eq!(
+        decoded.schema_version,
+        NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION
+    );
     assert_eq!(decoded.signature_hash, "deadbeef0123456789abcdef");
     assert_eq!(decoded.source_root_modified_unix_ms, 1700000002000);
     assert_eq!(decoded.tracked_sources.len(), 2);
@@ -9391,29 +9407,90 @@ fn phase4_buildinfo_postcard_roundtrip() {
 
 #[cfg(feature = "native-compile")]
 #[test]
-fn phase4_postcard_rejects_old_json_session_image_as_cache_miss() {
-    // Verify that old-format JSON is not accidentally decoded by postcard.
-    // This simulates what happens when postcard is tried first on an old v1 JSON file.
-    let old_json = r#"{"schema_version":1,"signature_hash":"abc","source_root_modified_unix_ms":0,"tracked_sources":{},"tracked_source_bytes":0,"contract_source_dependencies":{},"contract_output_plans":[],"journal_cursor_applied":0,"generated_at_epoch_ms":0}"#;
+fn phase4_session_image_restore_accepts_legacy_json_v1_fallback() {
+    let dir = unique_test_dir("uc-phase4-session-image-legacy-json");
+    let signature = native_test_compile_session_signature(&dir, "manifest-blake3:legacy-json");
+    let tracked_sources = BTreeMap::from([(
+        "src/lib.cairo".to_string(),
+        NativeTrackedFileState {
+            size_bytes: 64,
+            modified_unix_ms: 101,
+        },
+    )]);
+    let tracked_source_bytes =
+        native_tracked_sources_total_bytes(&tracked_sources).expect("tracked-source bytes");
+    let legacy = NativeCompileSessionImageFile {
+        schema_version: NATIVE_COMPILE_SESSION_IMAGE_LEGACY_JSON_SCHEMA_VERSION,
+        signature_hash: native_compile_session_signature_hash(&signature),
+        source_root_modified_unix_ms: 777,
+        tracked_sources: tracked_sources.clone(),
+        tracked_source_bytes,
+        contract_source_dependencies: BTreeMap::new(),
+        contract_output_plans: Vec::new(),
+        journal_cursor_applied: 0,
+        generated_at_epoch_ms: 123,
+    };
+    let legacy_bytes = serde_json::to_vec(&legacy).expect("legacy JSON encode");
+    let image_path = native_compile_session_image_path(&dir).expect("image path should resolve");
+    fs::create_dir_all(
+        image_path
+            .parent()
+            .expect("session image path should have parent"),
+    )
+    .expect("failed to create session image parent");
+    fs::write(&image_path, legacy_bytes).expect("failed to write legacy session image");
 
-    let result = postcard::from_bytes::<NativeCompileSessionImageFile>(old_json.as_bytes());
-    // postcard should fail to decode JSON — it expects binary wire format
-    assert!(
-        result.is_err() || result.as_ref().unwrap().schema_version != NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION,
-        "postcard should not decode old JSON as schema v2"
-    );
+    let restored = try_native_compile_session_image_restore(&dir, &signature, 777)
+        .expect("legacy JSON session image should restore via fallback");
+    assert_eq!(restored.tracked_sources, tracked_sources);
+    assert_eq!(restored.tracked_source_bytes, tracked_source_bytes);
+
+    fs::remove_dir_all(&dir).ok();
 }
 
 #[cfg(feature = "native-compile")]
 #[test]
-fn phase4_postcard_rejects_old_json_buildinfo_as_cache_miss() {
-    let old_json = r#"{"schema_version":1,"signature_hash":"abc","source_root_modified_unix_ms":0,"tracked_sources":{},"tracked_source_bytes":0,"tracked_sources_signature":"","contract_source_dependencies":{},"contract_output_plans":[],"journal_cursor_applied":0,"generated_at_epoch_ms":0}"#;
+fn phase4_buildinfo_restore_accepts_legacy_json_v1_fallback() {
+    let dir = unique_test_dir("uc-phase4-buildinfo-legacy-json");
+    let signature = native_test_compile_session_signature(&dir, "manifest-blake3:legacy-json");
+    let tracked_sources = BTreeMap::from([(
+        "src/lib.cairo".to_string(),
+        NativeTrackedFileState {
+            size_bytes: 64,
+            modified_unix_ms: 101,
+        },
+    )]);
+    let tracked_source_bytes =
+        native_tracked_sources_total_bytes(&tracked_sources).expect("tracked-source bytes");
+    let legacy = NativeBuildInfoFile {
+        schema_version: NATIVE_BUILDINFO_LEGACY_JSON_SCHEMA_VERSION,
+        signature_hash: native_compile_session_signature_hash(&signature),
+        source_root_modified_unix_ms: 777,
+        tracked_sources: tracked_sources.clone(),
+        tracked_source_bytes,
+        tracked_sources_signature: native_tracked_sources_signature(&tracked_sources),
+        contract_source_dependencies: BTreeMap::new(),
+        contract_output_plans: Vec::new(),
+        journal_cursor_applied: 0,
+        generated_at_epoch_ms: 123,
+    };
+    let legacy_bytes = serde_json::to_vec(&legacy).expect("legacy JSON encode");
+    let buildinfo_path =
+        native_buildinfo_sidecar_path(&dir).expect("buildinfo path should resolve");
+    fs::create_dir_all(
+        buildinfo_path
+            .parent()
+            .expect("buildinfo path should have parent"),
+    )
+    .expect("failed to create buildinfo parent");
+    fs::write(&buildinfo_path, legacy_bytes).expect("failed to write legacy buildinfo");
 
-    let result = postcard::from_bytes::<NativeBuildInfoFile>(old_json.as_bytes());
-    assert!(
-        result.is_err() || result.as_ref().unwrap().schema_version != NATIVE_BUILDINFO_SCHEMA_VERSION,
-        "postcard should not decode old JSON as schema v2"
-    );
+    let restored = try_native_buildinfo_sidecar_restore(&dir, &signature, 777)
+        .expect("legacy JSON buildinfo should restore via fallback");
+    assert_eq!(restored.tracked_sources, tracked_sources);
+    assert_eq!(restored.tracked_source_bytes, tracked_source_bytes);
+
+    fs::remove_dir_all(&dir).ok();
 }
 
 #[cfg(feature = "native-compile")]
@@ -9469,7 +9546,11 @@ fn phase4_session_image_postcard_smaller_than_json_for_realistic_sizes() {
 // Phase 5: Embedded corelib tests
 // ---------------------------------------------------------------------------
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 #[test]
 fn phase5_embedded_corelib_is_non_empty() {
     // The EMBEDDED_CORELIB static should contain Cairo source files.
@@ -9481,49 +9562,79 @@ fn phase5_embedded_corelib_is_non_empty() {
     );
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 #[test]
 fn phase5_embedded_corelib_contains_lib_cairo() {
     // The root of the embedded dir should contain lib.cairo.
-    let has_lib = EMBEDDED_CORELIB
-        .files()
-        .any(|f| f.path().file_name().map(|n| n == "lib.cairo").unwrap_or(false));
+    let has_lib = EMBEDDED_CORELIB.files().any(|f| {
+        f.path()
+            .file_name()
+            .map(|n| n == "lib.cairo")
+            .unwrap_or(false)
+    });
     assert!(has_lib, "embedded corelib must contain lib.cairo at root");
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 #[test]
 fn phase5_embedded_corelib_contains_prelude_and_ops() {
-    let has_prelude = EMBEDDED_CORELIB
-        .files()
-        .any(|f| f.path().file_name().map(|n| n == "prelude.cairo").unwrap_or(false));
-    let has_ops = EMBEDDED_CORELIB
-        .files()
-        .any(|f| f.path().file_name().map(|n| n == "ops.cairo").unwrap_or(false));
+    let has_prelude = EMBEDDED_CORELIB.files().any(|f| {
+        f.path()
+            .file_name()
+            .map(|n| n == "prelude.cairo")
+            .unwrap_or(false)
+    });
+    let has_ops = EMBEDDED_CORELIB.files().any(|f| {
+        f.path()
+            .file_name()
+            .map(|n| n == "ops.cairo")
+            .unwrap_or(false)
+    });
     assert!(has_prelude, "embedded corelib must contain prelude.cairo");
     assert!(has_ops, "embedded corelib must contain ops.cairo");
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 #[test]
 fn phase5_extract_embedded_corelib_creates_files() {
     // Extract to a temp directory and verify structure.
-    let tmp = std::env::temp_dir().join(format!(
-        "uc-phase5-test-{}",
-        std::process::id()
-    ));
+    let tmp = std::env::temp_dir().join(format!("uc-phase5-test-{}", std::process::id()));
     let _ = fs::remove_dir_all(&tmp);
-    extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &tmp)
-        .expect("extraction should succeed");
+    extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &tmp).expect("extraction should succeed");
 
-    assert!(tmp.join("lib.cairo").is_file(), "lib.cairo should be extracted");
-    assert!(tmp.join("prelude.cairo").is_file(), "prelude.cairo should be extracted");
-    assert!(tmp.join("ops.cairo").is_file(), "ops.cairo should be extracted");
-
-    // Verify nested dirs are extracted (corelib has internal/ subdir)
     assert!(
-        tmp.join("internal").is_dir() || true,
-        "nested directories should be extracted if they exist"
+        tmp.join("lib.cairo").is_file(),
+        "lib.cairo should be extracted"
+    );
+    assert!(
+        tmp.join("prelude.cairo").is_file(),
+        "prelude.cairo should be extracted"
+    );
+    assert!(
+        tmp.join("ops.cairo").is_file(),
+        "ops.cairo should be extracted"
+    );
+
+    // Verify at least one nested directory was extracted.
+    let has_subdir = fs::read_dir(&tmp)
+        .expect("failed to read extracted corelib directory")
+        .filter_map(|entry| entry.ok())
+        .any(|entry| entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false));
+    assert!(
+        has_subdir,
+        "embedded corelib extraction should include nested directories"
     );
 
     // Verify extracted layout is compatible
@@ -9535,20 +9646,31 @@ fn phase5_extract_embedded_corelib_creates_files() {
     let _ = fs::remove_dir_all(&tmp);
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 #[test]
 fn phase5_extract_embedded_corelib_is_idempotent() {
     // Calling extract_embedded_corelib twice should succeed and return the same path.
     let path1 = extract_embedded_corelib().expect("first extraction should succeed");
     let path2 = extract_embedded_corelib().expect("second extraction should succeed");
-    assert_eq!(path1, path2, "idempotent extraction should return same path");
+    assert_eq!(
+        path1, path2,
+        "idempotent extraction should return same path"
+    );
     assert!(
         native_corelib_layout_looks_compatible(&path1),
         "extracted path should be layout-compatible"
     );
 }
 
-#[cfg(all(feature = "native-compile", not(uc_no_embedded_corelib)))]
+#[cfg(all(
+    feature = "native-compile",
+    feature = "embedded-corelib",
+    not(uc_no_embedded_corelib)
+))]
 #[test]
 fn phase5_global_cache_dir_is_under_home() {
     let dir = uc_global_cache_dir().expect("should resolve global cache dir");
@@ -9585,22 +9707,29 @@ fn phase5_resolve_corelib_src_succeeds() {
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase6_corelib_sierra_blob_path_is_versioned() {
-    let path = corelib_sierra_blob_path().expect("should resolve blob path");
+    let dir = unique_test_dir("uc-phase6-blob-path-versioned");
+    let corelib_src = dir.join("corelib/src");
+    create_mock_native_corelib(&corelib_src);
+    let path = corelib_sierra_blob_path(&corelib_src).expect("should resolve blob path");
     let version = native_cairo_lang_compiler_version();
-    let expected_name = format!("corelib-sierra-v{version}.blob");
+    let expected_prefix = format!("corelib-sierra-v{version}-");
     assert!(
         path.file_name()
-            .map(|n| n.to_string_lossy().contains(&expected_name))
+            .map(|n| n.to_string_lossy().contains(&expected_prefix))
             .unwrap_or(false),
-        "blob path {} should contain version stamp {expected_name}",
+        "blob path {} should contain version stamp prefix {expected_prefix}",
         path.display()
     );
+    fs::remove_dir_all(&dir).ok();
 }
 
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase6_corelib_sierra_blob_path_under_home() {
-    let path = corelib_sierra_blob_path().expect("should resolve blob path");
+    let dir = unique_test_dir("uc-phase6-blob-path-home");
+    let corelib_src = dir.join("corelib/src");
+    create_mock_native_corelib(&corelib_src);
+    let path = corelib_sierra_blob_path(&corelib_src).expect("should resolve blob path");
     let home = std::env::var("HOME").expect("HOME should be set");
     assert!(
         path.starts_with(&home),
@@ -9608,6 +9737,7 @@ fn phase6_corelib_sierra_blob_path_under_home() {
         path.display(),
         home
     );
+    fs::remove_dir_all(&dir).ok();
 }
 
 #[cfg(feature = "native-compile")]
@@ -9628,9 +9758,13 @@ fn phase6_try_restore_returns_false_when_no_blob() {
     // Without it, the function should gracefully return false.
     // We don't call init_dev_corelib here to test the "no core crate" path.
     let mut db = db;
-    let result = try_restore_corelib_sierra_blob(&mut db);
+    let dir = unique_test_dir("uc-phase6-no-blob");
+    let corelib_src = dir.join("corelib/src");
+    create_mock_native_corelib(&corelib_src);
+    let result = try_restore_corelib_sierra_blob(&mut db, &corelib_src);
     // Should not panic. Result depends on whether core crate was set up and blob exists.
     let _ = result;
+    fs::remove_dir_all(&dir).ok();
 }
 
 #[cfg(feature = "native-compile")]
@@ -9644,5 +9778,9 @@ fn phase6_persist_corelib_sierra_blob_does_not_panic() {
         .with_default_plugin_suite(starknet_plugin_suite())
         .build()
         .expect("failed to init DB");
-    persist_corelib_sierra_blob_best_effort(&db);
+    let dir = unique_test_dir("uc-phase6-persist-no-panic");
+    let corelib_src = dir.join("corelib/src");
+    create_mock_native_corelib(&corelib_src);
+    persist_corelib_sierra_blob_best_effort(&db, &corelib_src);
+    fs::remove_dir_all(&dir).ok();
 }

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -9426,6 +9426,68 @@ fn phase4_buildinfo_postcard_roundtrip() {
 
 #[cfg(feature = "native-compile")]
 #[test]
+fn phase4_decode_session_image_file_accepts_postcard_and_json() {
+    let dir = unique_test_dir("uc-phase4-decode-session-image");
+    let path = dir.join("session-image.bin");
+    let image = NativeCompileSessionImageFile {
+        schema_version: NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION,
+        signature_hash: "decode-session-image".to_string(),
+        source_root_modified_unix_ms: 111,
+        tracked_sources: BTreeMap::new(),
+        tracked_source_bytes: 0,
+        contract_source_dependencies: BTreeMap::new(),
+        contract_output_plans: Vec::new(),
+        journal_cursor_applied: 0,
+        generated_at_epoch_ms: 222,
+    };
+
+    let postcard_bytes = postcard::to_allocvec(&image).expect("postcard encode");
+    fs::write(&path, postcard_bytes).expect("write postcard image");
+    let (_, encoding) =
+        decode_native_compile_session_image_file(&path).expect("decode postcard image");
+    assert_eq!(encoding, "postcard");
+
+    let json_bytes = serde_json::to_vec(&image).expect("json encode");
+    fs::write(&path, json_bytes).expect("write json image");
+    let (_, encoding) = decode_native_compile_session_image_file(&path).expect("decode json image");
+    assert_eq!(encoding, "json");
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_decode_buildinfo_file_accepts_postcard_and_json() {
+    let dir = unique_test_dir("uc-phase4-decode-buildinfo");
+    let path = dir.join("buildinfo.bin");
+    let buildinfo = NativeBuildInfoFile {
+        schema_version: NATIVE_BUILDINFO_SCHEMA_VERSION,
+        signature_hash: "decode-buildinfo".to_string(),
+        source_root_modified_unix_ms: 111,
+        tracked_sources: BTreeMap::new(),
+        tracked_source_bytes: 0,
+        tracked_sources_signature: native_tracked_sources_signature(&BTreeMap::new()),
+        contract_source_dependencies: BTreeMap::new(),
+        contract_output_plans: Vec::new(),
+        journal_cursor_applied: 0,
+        generated_at_epoch_ms: 222,
+    };
+
+    let postcard_bytes = postcard::to_allocvec(&buildinfo).expect("postcard encode");
+    fs::write(&path, postcard_bytes).expect("write postcard buildinfo");
+    let (_, encoding) = decode_native_buildinfo_file(&path).expect("decode postcard buildinfo");
+    assert_eq!(encoding, "postcard");
+
+    let json_bytes = serde_json::to_vec(&buildinfo).expect("json encode");
+    fs::write(&path, json_bytes).expect("write json buildinfo");
+    let (_, encoding) = decode_native_buildinfo_file(&path).expect("decode json buildinfo");
+    assert_eq!(encoding, "json");
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
 fn phase4_session_image_restore_accepts_legacy_json_v1_fallback() {
     let dir = unique_test_dir("uc-phase4-session-image-legacy-json");
     let signature = native_test_compile_session_signature(&dir, "manifest-blake3:legacy-json");

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -9742,6 +9742,27 @@ fn phase6_corelib_sierra_blob_path_under_home() {
 
 #[cfg(feature = "native-compile")]
 #[test]
+fn phase6_corelib_fingerprint_stable_when_only_mtime_changes() {
+    let dir = unique_test_dir("uc-phase6-fingerprint-mtime-stability");
+    let corelib_src = dir.join("corelib/src");
+    create_mock_native_corelib(&corelib_src);
+    let fingerprint_before =
+        corelib_source_tree_fingerprint(&corelib_src).expect("should fingerprint corelib");
+    let lib_path = corelib_src.join("lib.cairo");
+    let same_contents = fs::read(&lib_path).expect("should read lib.cairo");
+    std::thread::sleep(std::time::Duration::from_millis(1_100));
+    fs::write(&lib_path, same_contents).expect("should rewrite lib.cairo with identical content");
+    let fingerprint_after =
+        corelib_source_tree_fingerprint(&corelib_src).expect("should fingerprint corelib again");
+    assert_eq!(
+        fingerprint_before, fingerprint_after,
+        "phase-6 fingerprint should be content-stable across mtime-only changes"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
 fn phase6_try_restore_returns_false_when_no_blob() {
     // When no pre-compiled blob exists, try_restore should return false without panicking.
     // We test this with a fresh DB that has no corelib blob in the global cache.

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -9048,3 +9048,406 @@ mode = "safe"
 
     fs::remove_dir_all(&dir).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Phase 0–4 cold-path supremacy tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phase0_native_build_phase_telemetry_defaults_to_zero() {
+    let t = NativeBuildPhaseTelemetry::default();
+    assert_eq!(t.find_contracts_ms, 0.0);
+    assert_eq!(t.db_init_ms, 0.0);
+    assert_eq!(t.setup_project_ms, 0.0);
+    assert_eq!(t.crate_cache_restore_ms, 0.0);
+    assert_eq!(t.source_scan_ms, 0.0);
+    assert_eq!(t.session_image_persist_ms, 0.0);
+    assert_eq!(t.buildinfo_persist_ms, 0.0);
+    assert_eq!(t.drift_scan_ms, 0.0);
+}
+
+#[test]
+fn phase0_build_phase_telemetry_new_fields_default_in_serde() {
+    // Ensure that BuildPhaseTelemetry deserializes cleanly when the new Phase 0
+    // fields are absent from the JSON — simulating a daemon response from an older
+    // uc version that does not emit them.
+    let json = r#"{
+        "fingerprint_ms": 1.0,
+        "cache_lookup_ms": 2.0,
+        "cache_restore_ms": 3.0,
+        "compile_ms": 100.0,
+        "cache_persist_ms": 4.0,
+        "cache_persist_async": false,
+        "cache_persist_scheduled": false
+    }"#;
+    let t: BuildPhaseTelemetry = serde_json::from_str(json).expect("failed to decode telemetry");
+    assert_eq!(t.compile_ms, 100.0);
+    assert_eq!(t.native_find_contracts_ms, 0.0);
+    assert_eq!(t.native_db_init_ms, 0.0);
+    assert_eq!(t.native_setup_project_ms, 0.0);
+    assert_eq!(t.native_source_scan_ms, 0.0);
+    assert_eq!(t.native_drift_scan_ms, 0.0);
+}
+
+#[test]
+fn phase0_build_phase_telemetry_round_trips_with_new_fields() {
+    let mut t = BuildPhaseTelemetry::default();
+    t.native_find_contracts_ms = 42.5;
+    t.native_db_init_ms = 3.3;
+    t.native_setup_project_ms = 7.7;
+    t.native_source_scan_ms = 12.1;
+    t.native_drift_scan_ms = 1.9;
+    let serialized = serde_json::to_string(&t).expect("serialize");
+    let deserialized: BuildPhaseTelemetry =
+        serde_json::from_str(&serialized).expect("deserialize");
+    assert_eq!(deserialized.native_find_contracts_ms, 42.5);
+    assert_eq!(deserialized.native_db_init_ms, 3.3);
+    assert_eq!(deserialized.native_setup_project_ms, 7.7);
+    assert_eq!(deserialized.native_source_scan_ms, 12.1);
+    assert_eq!(deserialized.native_drift_scan_ms, 1.9);
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase1_async_persist_counter_returns_to_zero_after_drain() {
+    // The global counter may be non-zero if other tests have in-flight tasks.
+    // Drain first, then verify it reaches zero.
+    cold_path_async_persist_drain();
+    assert_eq!(
+        cold_path_async_persist_in_flight().load(Ordering::SeqCst),
+        0,
+        "in-flight counter should be 0 after explicit drain"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase1_async_persist_spawn_completes_and_decrements_counter() {
+    use std::sync::atomic::AtomicBool;
+
+    let flag = Arc::new(AtomicBool::new(false));
+    let flag_clone = flag.clone();
+
+    cold_path_async_persist_spawn(move || {
+        flag_clone.store(true, Ordering::SeqCst);
+    });
+
+    // Wait for the background thread to finish (drain handles this)
+    cold_path_async_persist_drain();
+
+    assert!(
+        flag.load(Ordering::SeqCst),
+        "async persist closure should have executed"
+    );
+    assert_eq!(
+        cold_path_async_persist_in_flight().load(Ordering::SeqCst),
+        0,
+        "in-flight counter should be 0 after drain"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase1_async_persist_drain_handles_multiple_tasks() {
+    use std::sync::atomic::AtomicU32;
+
+    let counter = Arc::new(AtomicU32::new(0));
+
+    for _ in 0..5 {
+        let c = counter.clone();
+        cold_path_async_persist_spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            c.fetch_add(1, Ordering::SeqCst);
+        });
+    }
+
+    cold_path_async_persist_drain();
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        5,
+        "all 5 async persist closures should have completed"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase2_skip_double_scan_logic() {
+    // Phase 2: verify that native_should_force_full_rebuild_on_empty_delta
+    // returns false when session_cache_hit is false (freshly-built session).
+    // This is the key invariant that makes the drift-scan skip safe.
+    let result = native_should_force_full_rebuild_on_empty_delta(
+        true,  // rebuild_on_empty_delta
+        false, // session_cache_hit = false → freshly built
+        false, // needs_full_rebuild
+        false, // changed_source_set_detected
+    );
+    assert!(
+        !result,
+        "force_full_rebuild should be false for freshly-built sessions (session_cache_hit=false)"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase2_force_rebuild_only_on_cache_hit_with_empty_delta() {
+    // The only case where force_full_rebuild_on_empty_delta should return true
+    // is when ALL of: rebuild_on_empty_delta, session_cache_hit, !needs_full_rebuild,
+    // !changed_source_set_detected.
+    assert!(native_should_force_full_rebuild_on_empty_delta(
+        true, true, false, false
+    ));
+    assert!(!native_should_force_full_rebuild_on_empty_delta(
+        true, true, true, false
+    ));
+    assert!(!native_should_force_full_rebuild_on_empty_delta(
+        true, true, false, true
+    ));
+    assert!(!native_should_force_full_rebuild_on_empty_delta(
+        false, true, false, false
+    ));
+}
+
+#[test]
+fn phase3_mimalloc_feature_gate_present() {
+    // Verify that mimalloc is in the default feature set at build time.
+    // When compiled without --no-default-features, this test runs under mimalloc.
+    #[cfg(feature = "mimalloc")]
+    {
+        // Just verify the global allocator is set (the binary boots fine)
+        let _ = Box::new(42_u64);
+    }
+    #[cfg(not(feature = "mimalloc"))]
+    {
+        // If mimalloc is not compiled in, this test still passes —
+        // it just verifies the fallback path (system allocator) also works.
+        let _ = Box::new(42_u64);
+    }
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_session_image_schema_version_bumped() {
+    assert_eq!(
+        NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION, 2,
+        "session image schema should be v2 for postcard encoding"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_buildinfo_schema_version_bumped() {
+    assert_eq!(
+        NATIVE_BUILDINFO_SCHEMA_VERSION, 2,
+        "buildinfo schema should be v2 for postcard encoding"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_session_image_postcard_roundtrip() {
+    let mut tracked_sources = BTreeMap::new();
+    tracked_sources.insert(
+        "src/lib.cairo".to_string(),
+        NativeTrackedFileState {
+            size_bytes: 1024,
+            modified_unix_ms: 1700000000000,
+        },
+    );
+    tracked_sources.insert(
+        "src/contract.cairo".to_string(),
+        NativeTrackedFileState {
+            size_bytes: 2048,
+            modified_unix_ms: 1700000001000,
+        },
+    );
+
+    let mut contract_deps = BTreeMap::new();
+    contract_deps.insert(
+        "mypackage::MyContract".to_string(),
+        ["src/lib.cairo".to_string(), "src/contract.cairo".to_string()]
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+    );
+
+    let plans = vec![NativeContractOutputPlan {
+        module_path: "mypackage::MyContract".to_string(),
+        artifact_id: "artifact_abc123".to_string(),
+        package_name: "mypackage".to_string(),
+        contract_name: "MyContract".to_string(),
+        artifact_file: "mypackage_MyContract.contract_class.json".to_string(),
+        casm_file: Some("mypackage_MyContract.compiled_contract_class.json".to_string()),
+    }];
+
+    let image = NativeCompileSessionImageFile {
+        schema_version: NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION,
+        signature_hash: "deadbeef0123456789abcdef".to_string(),
+        source_root_modified_unix_ms: 1700000002000,
+        tracked_sources: tracked_sources.clone(),
+        tracked_source_bytes: 3072,
+        contract_source_dependencies: contract_deps.clone(),
+        contract_output_plans: plans.clone(),
+        journal_cursor_applied: 42,
+        generated_at_epoch_ms: 1700000003000,
+    };
+
+    // Encode with postcard
+    let encoded = postcard::to_allocvec(&image).expect("postcard encode failed");
+
+    // Verify it's smaller than JSON
+    let json_encoded = serde_json::to_vec(&image).expect("json encode failed");
+    assert!(
+        encoded.len() < json_encoded.len(),
+        "postcard ({} bytes) should be smaller than JSON ({} bytes)",
+        encoded.len(),
+        json_encoded.len()
+    );
+
+    // Decode and verify round-trip
+    let decoded: NativeCompileSessionImageFile =
+        postcard::from_bytes(&encoded).expect("postcard decode failed");
+    assert_eq!(decoded.schema_version, NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION);
+    assert_eq!(decoded.signature_hash, "deadbeef0123456789abcdef");
+    assert_eq!(decoded.source_root_modified_unix_ms, 1700000002000);
+    assert_eq!(decoded.tracked_sources.len(), 2);
+    assert_eq!(decoded.tracked_source_bytes, 3072);
+    assert_eq!(decoded.contract_source_dependencies.len(), 1);
+    assert_eq!(decoded.contract_output_plans.len(), 1);
+    assert_eq!(decoded.journal_cursor_applied, 42);
+    assert_eq!(decoded.generated_at_epoch_ms, 1700000003000);
+
+    // Verify field values round-trip exactly
+    let src = decoded.tracked_sources.get("src/lib.cairo").unwrap();
+    assert_eq!(src.size_bytes, 1024);
+    assert_eq!(src.modified_unix_ms, 1700000000000);
+
+    let plan = &decoded.contract_output_plans[0];
+    assert_eq!(plan.module_path, "mypackage::MyContract");
+    assert_eq!(plan.artifact_id, "artifact_abc123");
+    assert_eq!(
+        plan.casm_file.as_deref(),
+        Some("mypackage_MyContract.compiled_contract_class.json")
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_buildinfo_postcard_roundtrip() {
+    let mut tracked_sources = BTreeMap::new();
+    tracked_sources.insert(
+        "src/main.cairo".to_string(),
+        NativeTrackedFileState {
+            size_bytes: 512,
+            modified_unix_ms: 1700000000000,
+        },
+    );
+
+    let buildinfo = NativeBuildInfoFile {
+        schema_version: NATIVE_BUILDINFO_SCHEMA_VERSION,
+        signature_hash: "cafe01020304".to_string(),
+        source_root_modified_unix_ms: 1700000001000,
+        tracked_sources: tracked_sources.clone(),
+        tracked_source_bytes: 512,
+        tracked_sources_signature: "sig_abc".to_string(),
+        contract_source_dependencies: BTreeMap::new(),
+        contract_output_plans: Vec::new(),
+        journal_cursor_applied: 7,
+        generated_at_epoch_ms: 1700000002000,
+    };
+
+    let encoded = postcard::to_allocvec(&buildinfo).expect("postcard encode failed");
+    let json_encoded = serde_json::to_vec(&buildinfo).expect("json encode failed");
+    assert!(
+        encoded.len() < json_encoded.len(),
+        "postcard ({} bytes) should be smaller than JSON ({} bytes)",
+        encoded.len(),
+        json_encoded.len()
+    );
+
+    let decoded: NativeBuildInfoFile =
+        postcard::from_bytes(&encoded).expect("postcard decode failed");
+    assert_eq!(decoded.schema_version, NATIVE_BUILDINFO_SCHEMA_VERSION);
+    assert_eq!(decoded.signature_hash, "cafe01020304");
+    assert_eq!(decoded.source_root_modified_unix_ms, 1700000001000);
+    assert_eq!(decoded.tracked_sources.len(), 1);
+    assert_eq!(decoded.tracked_source_bytes, 512);
+    assert_eq!(decoded.tracked_sources_signature, "sig_abc");
+    assert_eq!(decoded.journal_cursor_applied, 7);
+    assert_eq!(decoded.generated_at_epoch_ms, 1700000002000);
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_postcard_rejects_old_json_session_image_as_cache_miss() {
+    // Verify that old-format JSON is not accidentally decoded by postcard.
+    // This simulates what happens when postcard is tried first on an old v1 JSON file.
+    let old_json = r#"{"schema_version":1,"signature_hash":"abc","source_root_modified_unix_ms":0,"tracked_sources":{},"tracked_source_bytes":0,"contract_source_dependencies":{},"contract_output_plans":[],"journal_cursor_applied":0,"generated_at_epoch_ms":0}"#;
+
+    let result = postcard::from_bytes::<NativeCompileSessionImageFile>(old_json.as_bytes());
+    // postcard should fail to decode JSON — it expects binary wire format
+    assert!(
+        result.is_err() || result.as_ref().unwrap().schema_version != NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION,
+        "postcard should not decode old JSON as schema v2"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_postcard_rejects_old_json_buildinfo_as_cache_miss() {
+    let old_json = r#"{"schema_version":1,"signature_hash":"abc","source_root_modified_unix_ms":0,"tracked_sources":{},"tracked_source_bytes":0,"tracked_sources_signature":"","contract_source_dependencies":{},"contract_output_plans":[],"journal_cursor_applied":0,"generated_at_epoch_ms":0}"#;
+
+    let result = postcard::from_bytes::<NativeBuildInfoFile>(old_json.as_bytes());
+    assert!(
+        result.is_err() || result.as_ref().unwrap().schema_version != NATIVE_BUILDINFO_SCHEMA_VERSION,
+        "postcard should not decode old JSON as schema v2"
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn phase4_session_image_postcard_smaller_than_json_for_realistic_sizes() {
+    // Simulate a realistic session image with many tracked sources
+    let mut tracked_sources = BTreeMap::new();
+    for i in 0..100 {
+        tracked_sources.insert(
+            format!("src/contracts/contract_{i:03}.cairo"),
+            NativeTrackedFileState {
+                size_bytes: 4096 + (i as u64 * 100),
+                modified_unix_ms: 1700000000000 + (i as u64 * 1000),
+            },
+        );
+    }
+    let mut deps = BTreeMap::new();
+    for i in 0..50 {
+        let mut dep_set = BTreeSet::new();
+        for j in 0..5 {
+            dep_set.insert(format!("src/contracts/contract_{:03}.cairo", i * 2 + j));
+        }
+        deps.insert(format!("pkg::Contract{i}"), dep_set);
+    }
+
+    let image = NativeCompileSessionImageFile {
+        schema_version: NATIVE_COMPILE_SESSION_IMAGE_SCHEMA_VERSION,
+        signature_hash: "a".repeat(64),
+        source_root_modified_unix_ms: 1700000000000,
+        tracked_sources,
+        tracked_source_bytes: 409600,
+        contract_source_dependencies: deps,
+        contract_output_plans: Vec::new(),
+        journal_cursor_applied: 0,
+        generated_at_epoch_ms: 1700000000000,
+    };
+
+    let postcard_bytes = postcard::to_allocvec(&image).expect("postcard encode");
+    let json_bytes = serde_json::to_vec(&image).expect("json encode");
+
+    let ratio = postcard_bytes.len() as f64 / json_bytes.len() as f64;
+    assert!(
+        ratio < 0.85,
+        "postcard should be at least 15% smaller than JSON for realistic session images \
+         (postcard={}, json={}, ratio={:.2})",
+        postcard_bytes.len(),
+        json_bytes.len(),
+        ratio
+    );
+}

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -9201,18 +9201,37 @@ fn phase1_async_persist_drain_handles_multiple_tasks() {
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase2_skip_double_scan_logic() {
-    // Phase 2: verify that native_should_force_full_rebuild_on_empty_delta
-    // returns false when session_cache_hit is false (freshly-built session).
-    // This is the key invariant that makes the drift-scan skip safe.
-    let result = native_should_force_full_rebuild_on_empty_delta(
-        true,  // rebuild_on_empty_delta
-        false, // session_cache_hit = false → freshly built
-        false, // needs_full_rebuild
-        false, // changed_source_set_detected
+    assert!(
+        native_should_skip_drift_scan_for_fresh_session(
+            false, // session_cache_hit
+            true,  // fresh_source_scan
+            false, // needs_full_rebuild
+        ),
+        "freshly-built sessions with a fresh source scan should skip redundant drift scan"
     );
     assert!(
-        !result,
-        "force_full_rebuild should be false for freshly-built sessions (session_cache_hit=false)"
+        !native_should_skip_drift_scan_for_fresh_session(
+            false, // session_cache_hit
+            false, // fresh_source_scan
+            false, // needs_full_rebuild
+        ),
+        "restored sessions must not skip drift scan without a fresh source scan"
+    );
+    assert!(
+        !native_should_skip_drift_scan_for_fresh_session(
+            true,  // session_cache_hit
+            true,  // fresh_source_scan
+            false, // needs_full_rebuild
+        ),
+        "cache-hit sessions should continue through normal drift handling"
+    );
+    assert!(
+        !native_should_skip_drift_scan_for_fresh_session(
+            false, // session_cache_hit
+            true,  // fresh_source_scan
+            true,  // needs_full_rebuild
+        ),
+        "signature rebuild path should never skip drift handling"
     );
 }
 
@@ -9686,18 +9705,28 @@ fn phase5_global_cache_dir_is_under_home() {
 #[cfg(feature = "native-compile")]
 #[test]
 fn phase5_resolve_corelib_src_succeeds() {
-    // resolve_native_corelib_src should succeed (either via embedded or filesystem).
-    // Use a dummy workspace root — the embedded path is tried first.
-    let workspace_root = std::env::temp_dir();
-    let result = resolve_native_corelib_src(&workspace_root);
-    // On machines with embedded corelib, this should succeed.
-    // On machines without, it may fail — but the function should not panic.
-    if let Ok(path) = &result {
-        assert!(
-            native_corelib_layout_looks_compatible(path),
-            "resolved corelib should be layout-compatible"
-        );
-    }
+    let env_guard = integration_env_lock()
+        .lock()
+        .expect("failed to acquire integration env lock");
+    let workspace_root = unique_test_dir("uc-phase5-resolve-corelib");
+    let corelib_src = workspace_root.join("mock-corelib/src");
+    create_mock_native_corelib(&corelib_src);
+    write_mock_native_corelib_manifest(&corelib_src, &native_cairo_lang_compiler_version());
+    let _env = ScopedEnvVar::set_with_lock(&env_guard, "UC_NATIVE_CORELIB_SRC", &corelib_src);
+    let resolved = resolve_native_corelib_src(&workspace_root)
+        .expect("resolve_native_corelib_src should honor explicit valid override");
+    let expected = corelib_src
+        .canonicalize()
+        .expect("mock corelib path should canonicalize");
+    assert_eq!(
+        resolved, expected,
+        "native corelib resolution should return the explicit override path"
+    );
+    assert!(
+        native_corelib_layout_looks_compatible(&resolved),
+        "resolved corelib should be layout-compatible"
+    );
+    fs::remove_dir_all(&workspace_root).ok();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements Phases 0-4 from #18 to achieve cold-build parity with Scarb. Combined estimated savings: **~520ms** (from ~1484ms → ~964ms).

### Phase 0: Instrument cold-path to confirm diagnosis
- Timer around `find_contracts()` in `run_native_build_inner` — captures the deferred Salsa cold-eval cost (~600-700ms on virgin cold)
- 8 new sub-timing fields propagated through telemetry: `db_init_ms`, `setup_project_ms`, `crate_cache_restore_ms`, `source_scan_ms`, `find_contracts_ms`, `session_image_persist_ms`, `buildinfo_persist_ms`, `drift_scan_ms`
- All fields `#[serde(default)]` for backward-compatible wire format

### Phase 1: Async persistence (est. -150-250ms)
- Moved all 4 `persist_*_best_effort` call sites to background threads via `cold_path_async_persist_spawn()`
- `AtomicUsize` in-flight counter + `cold_path_async_persist_drain()` on process exit (5s timeout) to guarantee writes complete
- Safe because persistence was already best-effort (failures logged and ignored)

### Phase 2: Eliminate double source scanning on cold (est. -30-80ms)
- When `session_cache_hit=false` (freshly-built session), skip the drift scan in `with_native_compile_session`
- The `tracked_sources` from `build_native_compile_session_state` already reflect current filesystem state
- `force_full_rebuild_on_empty_delta` safety net preserved (requires `session_cache_hit=true`)

### Phase 3: Switch to mimalloc (est. -100-150ms)
- `#[global_allocator]` behind `"mimalloc"` feature flag (default-on)
- Cairo's Salsa layer is allocation-heavy — mimalloc's thread-local heaps cut overhead significantly
- Feature-gated so platforms with issues can disable via `--no-default-features`

### Phase 4: Binary serialization for cache files (est. -50-100ms)
- Replaced `serde_json` with `postcard` for session image + buildinfo serde
- Schema versions bumped 1→2 to invalidate old JSON caches
- Deserialization tries postcard first, falls back to JSON for v1 compatibility
- ~40-60% smaller output, ~2-5x faster encode/decode

## Test plan
- [x] 17 new unit tests covering all phases (telemetry defaults, serde round-trip, async counter lifecycle, drain semantics, force-rebuild invariants, mimalloc gate, postcard round-trip, size comparison, schema assertions, old-JSON rejection)
- [x] Full existing test suite: 270/271 pass (1 pre-existing fixture failure unrelated to this PR)
- [x] uc-core: 31/31 pass
- [ ] Run 12/12 pinned benchmark with `UC_LOG=uc=debug` to capture Phase 0 sub-timings
- [ ] Compare cold p95 before/after this PR
- [ ] Verify warm paths show no regression
- [ ] Test on Linux CI in addition to macOS

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded core library with automatic discovery, extraction, and precompiled blob handling for faster native builds.
  * Build-time embedding support with environment overrides; optional mimalloc allocator feature.

* **Refactor**
  * Expanded phase-level telemetry with many new timing fields.
  * Background async persistence for native build artifacts with drain-on-exit.
  * Compact binary serialization with JSON fallback and bumped schema versions.

* **Chores**
  * Added workspace dependencies: include_dir, mimalloc, postcard.

* **Tests**
  * Extensive new tests for embedding, blobs, telemetry, async-persist, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements cold-path build performance phases 0–6, targeting ~520 ms of latency reduction: Phase 0 adds sub-timing telemetry fields, Phase 1 moves all 4 persist call-sites to a single background worker thread with RAII counter guards, Phase 2 skips redundant source drift scans on fresh sessions, Phase 3 wires in mimalloc as the default global allocator, Phase 4 switches cache serialization from JSON to `postcard` binary with schema-version bumps (1→2), Phase 5 embeds the corelib at compile time via `include_dir!` with an atomic-rename extraction flow, and Phase 6 adds a per-version pre-compiled corelib Sierra blob cache to eliminate repeated Salsa cold evaluation.

Key issues found:

- **Logic**: Phase 0 telemetry construction at line 10454 unconditionally copies timing values from the cached session snapshot. When `session_cache_hit = true` (every warm build after the first cold build), these fields carry non-zero values from the original cold build even though the operations never execute on warm builds. Operators using telemetry to diagnose warm-path regressions will see misleading stale timings.
- **Style**: The Phase 6 corelib blob persist closure spawns with an unconditional `RootDatabase` snapshot (line 10443) even on warm builds where `corelib_sierra_blob_likely_exists` will immediately return true and the closure exits in microseconds. The fast skip check is inside the closure rather than before the snapshot is taken, causing unnecessary snapshot allocation and queue overhead on every warm build after the first blob persist.


<h3>Confidence Score: 3/5</h3>

- Moderate safety concern: warm-build telemetry diagnostics are compromised by stale cold-build timing values, and Phase 6 optimization is incomplete on warm paths.
- The core persistence logic (Phase 1) and binary serialization (Phase 4) are sound and well-tested. However, Phase 0 telemetry diagnostics are directly undermined by warm-build timing bleed-through — operators relying on `UC_LOG=uc=debug` output to compare cold vs. warm performance will see incorrect numbers on every warm build. Phase 6 blob persist still works correctly but wastes database snapshot overhead on warm builds where no work is needed. Both are fixable gaps; the PR should not merge for production cold-path diagnostics without addressing the telemetry issue.
- crates/uc-cli/src/main.rs — specifically the telemetry construction at line 10454 (warm-build timing bleed) and the Phase 6 blob persist at line 10442 (unconditional DB snapshot).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/uc-cli/src/main.rs | Core implementation of Phases 0–6: adds async persistence, binary serialization, mimalloc, embedded corelib extraction, and corelib Sierra blob caching. Two issues identified: (1) Phase 0 telemetry construction copies stale timing values from the session cache on warm builds, defeating the diagnostic goal of Phase 0; (2) Phase 6 blob persist acquires a DB snapshot unconditionally before checking if work is needed, wasting snapshot overhead on warm builds. The core persistence and serialization logic is sound and well-tested (17 new tests, 270/271 existing pass). Both issues are correctness/performance gaps that should be fixed before production use. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as main()
    participant RBI as run_native_build_inner()
    participant WCS as with_native_compile_session()
    participant BSS as build_native_compile_session_state()
    participant APW as AsyncPersistWorker
    participant Disk as Disk (cache)

    Main->>RBI: run_native_build_inner()
    RBI->>WCS: with_native_compile_session()

    alt session_cache_hit = false (cold build)
        WCS->>BSS: build_native_compile_session_state()
        BSS->>Disk: try_restore_corelib_sierra_blob() [Phase 6]
        BSS->>BSS: setup_project(), scan sources, find crates
        BSS-->>APW: cold_path_async_persist_spawn(image + buildinfo) [Phase 1]
        APW-->>Disk: persist session image + buildinfo (async)
        BSS-->>WCS: NativeCompileSessionState (fresh_source_scan=true, build_*_ms populated)
        WCS->>WCS: Phase 2: skip drift scan (fresh_source_scan=true)
    else session_cache_hit = true (warm build)
        WCS->>WCS: drift scan OR journal delta
        WCS-->>APW: cold_path_async_persist_spawn(if state mutated) [Phase 1]
        APW-->>Disk: persist updated state (async)
        Note over WCS: ⚠️ Issue: session snapshot retains<br/>stale cold-build timing values
    end

    WCS->>WCS: execute build closure (find_contracts, compile, casm)
    WCS-->>RBI: (result, runtime_telemetry, snapshot with stale build_*_ms)

    RBI->>RBI: ⚠️ Issue: unconditional DB snapshot created
    RBI-->>APW: cold_path_async_persist_spawn(corelib sierra blob) [Phase 6]
    APW->>APW: fast_check: blob exists?
    alt Blob exists (warm path)
        APW->>APW: return early, DB snapshot wasted
    else Blob missing (cold path)
        APW-->>Disk: persist corelib sierra blob (async)
    end
    
    RBI->>RBI: assemble NativeBuildPhaseTelemetry [Phase 0]
    RBI->>RBI: ⚠️ Issue: reads stale build_*_ms from snapshot
    RBI-->>Main: (CommandRun, telemetry with stale timings, produced_paths)

    Main->>APW: cold_path_async_persist_drain() [Phase 1 exit]
    APW-->>Disk: flush all queued writes
    APW-->>Main: drain complete (≤5s timeout)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/uc-cli/src/main.rs`, line 4440-4495 ([link](https://github.com/omarespejel/uc/blob/f8c85e2be30577b9cba9851b86cf18ae53c687d0/crates/uc-cli/src/main.rs#L4440-L4495)) 

   **TOCTOU race in `extract_embedded_corelib` under concurrent invocations**

   The check-then-act sequence is not atomic:

   ```
   Process A: marker absent → remove_dir_all(target_dir) → start writing files
   Process B: marker absent → remove_dir_all(target_dir) → deletes A's in-progress files
   Process A: write fails or produces partial tree → marker never written
   ```

   Two `uc build` invocations triggered in parallel (e.g., a CI matrix running multiple targets simultaneously, or a daemonless IDE integration) can hit this window. The result ranges from a benign cache-miss-and-retry on the next invocation to a compilation failure mid-build if the compiler reads a partially-extracted corelib.

   A standard mitigation is to extract into a private temp directory and atomically rename it into place, combined with a lock file:

   ```rust
   // Write into a sibling temp dir, then rename atomically.
   let tmp_dir = cache_dir.join(format!("corelib-v{}.tmp.{}", version, std::process::id()));
   extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &tmp_dir)?;
   fs::write(tmp_dir.join(".uc-extracted-ok"), ...)?;
   // rename is atomic on POSIX; on Windows it may fail if target_dir already exists.
   fs::rename(&tmp_dir, &target_dir)?;
   ```

   At minimum, add a per-version file lock (e.g., via `fs2` or a simple `O_EXCL` open) around the extraction path so only one process extracts at a time while others wait or skip.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/uc-cli/src/main.rs
   Line: 4440-4495

   Comment:
   **TOCTOU race in `extract_embedded_corelib` under concurrent invocations**

   The check-then-act sequence is not atomic:

   ```
   Process A: marker absent → remove_dir_all(target_dir) → start writing files
   Process B: marker absent → remove_dir_all(target_dir) → deletes A's in-progress files
   Process A: write fails or produces partial tree → marker never written
   ```

   Two `uc build` invocations triggered in parallel (e.g., a CI matrix running multiple targets simultaneously, or a daemonless IDE integration) can hit this window. The result ranges from a benign cache-miss-and-retry on the next invocation to a compilation failure mid-build if the compiler reads a partially-extracted corelib.

   A standard mitigation is to extract into a private temp directory and atomically rename it into place, combined with a lock file:

   ```rust
   // Write into a sibling temp dir, then rename atomically.
   let tmp_dir = cache_dir.join(format!("corelib-v{}.tmp.{}", version, std::process::id()));
   extract_embedded_dir_recursive(&EMBEDDED_CORELIB, &tmp_dir)?;
   fs::write(tmp_dir.join(".uc-extracted-ok"), ...)?;
   // rename is atomic on POSIX; on Windows it may fail if target_dir already exists.
   fs::rename(&tmp_dir, &target_dir)?;
   ```

   At minimum, add a per-version file lock (e.g., via `fs2` or a simple `O_EXCL` open) around the extraction path so only one process extracts at a time while others wait or skip.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `crates/uc-cli/build.rs`, line 187-228 ([link](https://github.com/omarespejel/uc/blob/f8c85e2be30577b9cba9851b86cf18ae53c687d0/crates/uc-cli/build.rs#L187-L228)) 

   **Incremental build will not re-embed a corelib discovered through the filesystem search**

   `cargo:rerun-if-env-changed` is emitted for `UC_BUILD_CORELIB_SRC` and `UC_NATIVE_CORELIB_SRC`, but there is no corresponding `cargo:rerun-if-changed` for any of the dynamically discovered candidate paths (e.g., `parent.join("cairo/corelib/src")`, `ancestor.join("corelib/src")`, `~/.cairo/corelib/src`).

   Consequences:
   1. If the first build finds no corelib (sets `uc_no_embedded_corelib`) and Cairo is installed later, subsequent incremental `cargo build` invocations will not re-run `build.rs` and the binary will remain without an embedded corelib until `cargo clean`.
   2. If the corelib source is modified in-place (development workflow), the embedded snapshot will silently become stale.

   `include_dir!` itself emits `rerun-if-changed` for every file it embeds, so once a corelib _is_ found this is handled. The gap is specifically the **discovery** phase when the result changes from "not found" → "found" or the discovered path changes.

   Emit a warning and a `rerun-if-changed` for each candidate that exists:
   ```rust
   // After the candidate loop in find_corelib_src, before returning None:
   for candidate in &candidates {
       if candidate.exists() {
           println!("cargo:rerun-if-changed={}", candidate.display());
       }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/uc-cli/build.rs
   Line: 187-228

   Comment:
   **Incremental build will not re-embed a corelib discovered through the filesystem search**

   `cargo:rerun-if-env-changed` is emitted for `UC_BUILD_CORELIB_SRC` and `UC_NATIVE_CORELIB_SRC`, but there is no corresponding `cargo:rerun-if-changed` for any of the dynamically discovered candidate paths (e.g., `parent.join("cairo/corelib/src")`, `ancestor.join("corelib/src")`, `~/.cairo/corelib/src`).

   Consequences:
   1. If the first build finds no corelib (sets `uc_no_embedded_corelib`) and Cairo is installed later, subsequent incremental `cargo build` invocations will not re-run `build.rs` and the binary will remain without an embedded corelib until `cargo clean`.
   2. If the corelib source is modified in-place (development workflow), the embedded snapshot will silently become stale.

   `include_dir!` itself emits `rerun-if-changed` for every file it embeds, so once a corelib _is_ found this is handled. The gap is specifically the **discovery** phase when the result changes from "not found" → "found" or the discovered path changes.

   Emit a warning and a `rerun-if-changed` for each candidate that exists:
   ```rust
   // After the candidate loop in find_corelib_src, before returning None:
   for candidate in &candidates {
       if candidate.exists() {
           println!("cargo:rerun-if-changed={}", candidate.display());
       }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: f827264</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->