### PR TITLE
fix(bench): handle real repo harness lane failures

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -85,6 +85,9 @@ This local-only harness uses `uc support native --format json` to classify each
 manifest before any timed run. Native-eligible cases are benchmarked against
 Scarb on `build.cold` and `build.warm_noop`; native-ineligible cases are listed
 separately with the exact unsupported reason and are excluded from speedup claims.
+If a native-eligible case fails during `scarb` or `uc` execution, the harness
+records that build failure in a separate section with exit code and log path
+instead of aborting the whole benchmark run.
 
 ## Fast Iteration Loop (Developer Lane)
 ```bash

--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -344,8 +344,7 @@ run_cold_stats() {
   done
   local stats_json
   if ! stats_json="$(stats_json_from_samples "$samples_file")"; then
-    local exit_code=$?
-    measurement_failure_json "$stage" "$exit_code" "$samples_file"
+    measurement_failure_json "$stage" "-1" "$samples_file"
     return 0
   fi
   measurement_ok_json "$stage" "$sample_count" "$stats_json"
@@ -390,8 +389,7 @@ run_warm_noop_stats() {
   done
   local stats_json
   if ! stats_json="$(stats_json_from_samples "$samples_file")"; then
-    local exit_code=$?
-    measurement_failure_json "$stage" "$exit_code" "$samples_file"
+    measurement_failure_json "$stage" "-1" "$samples_file"
     return 0
   fi
   measurement_ok_json "$stage" "$sample_count" "$stats_json"

--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -50,6 +50,15 @@ validate_positive_int() {
   fi
 }
 
+validate_non_negative_number() {
+  local flag="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^([0-9]+([.][0-9]+)?|[.][0-9]+)$ ]]; then
+    echo "$flag must be a non-negative number, got: $value" >&2
+    exit 2
+  fi
+}
+
 validate_timeout_secs() {
   local value="$1"
   if [[ ! "$value" =~ ^[0-9]+$ ]]; then
@@ -131,6 +140,10 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+validate_positive_int "RUNS" "$RUNS"
+validate_positive_int "COLD_RUNS" "$COLD_RUNS"
+validate_non_negative_number "WARM_SETTLE_SECONDS" "$WARM_SETTLE_SECONDS"
 
 if [[ "${#CASE_MANIFESTS[@]}" -eq 0 ]]; then
   echo "run_real_repo_benchmarks.sh requires at least one --case" >&2

--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -198,6 +198,10 @@ PY
 
 stats_json_from_samples() {
   local samples_file="$1"
+  if [[ ! -s "$samples_file" ]]; then
+    echo "stats_json_from_samples: no samples recorded in $samples_file" >&2
+    return 1
+  fi
   jq -s '
     sort as $s
     | def quantile($p):
@@ -219,6 +223,38 @@ stats_json_from_samples() {
       p95_ms: ($s | quantile(0.95))
     }
   ' "$samples_file"
+}
+
+measurement_ok_json() {
+  local stage="$1"
+  local sample_count="$2"
+  local stats_json="$3"
+  jq -n \
+    --arg stage "$stage" \
+    --argjson sample_count "$sample_count" \
+    --argjson stats "$stats_json" \
+    '{
+      status: "ok",
+      stage: $stage,
+      sample_count: $sample_count,
+      stats: $stats
+    }'
+}
+
+measurement_failure_json() {
+  local stage="$1"
+  local exit_code="$2"
+  local log_path="$3"
+  jq -n \
+    --arg stage "$stage" \
+    --argjson exit_code "$exit_code" \
+    --arg log_path "$log_path" \
+    '{
+      status: "failed",
+      stage: $stage,
+      exit_code: $exit_code,
+      log_path: $log_path
+    }'
 }
 
 prefetch_manifest_dependencies() {
@@ -249,8 +285,25 @@ replace_manifest_arg() {
   local manifest_path="$1"
   shift
   local -a command=("$@")
-  local manifest_index=$(( ${#command[@]} - 1 ))
-  command[$manifest_index]="$manifest_path"
+  local replaced=0
+  local idx=0
+  while [[ "$idx" -lt "${#command[@]}" ]]; do
+    if [[ "${command[$idx]}" == "--manifest-path" ]]; then
+      local value_index=$(( idx + 1 ))
+      if [[ "$value_index" -ge "${#command[@]}" ]]; then
+        echo "replace_manifest_arg: --manifest-path is missing its value" >&2
+        return 1
+      fi
+      command[$value_index]="$manifest_path"
+      replaced=1
+      break
+    fi
+    idx=$(( idx + 1 ))
+  done
+  if [[ "$replaced" -ne 1 ]]; then
+    echo "replace_manifest_arg: command is missing --manifest-path: ${command[*]}" >&2
+    return 1
+  fi
   printf '%s\0' "${command[@]}"
 }
 
@@ -264,6 +317,7 @@ run_cold_stats() {
   local baseline_dir="$TMP_DIR/${tag}-${tool}-cold-baseline"
   local run_root="$TMP_DIR/${tag}-${tool}-cold-runs"
   local samples_file="$TMP_DIR/${tag}-${tool}-build.cold.samples"
+  local stage="build.cold"
   : > "$samples_file"
   rm -rf "$baseline_dir" "$run_root"
   mkdir -p "$baseline_dir" "$run_root"
@@ -281,9 +335,20 @@ run_cold_stats() {
     while IFS= read -r -d '' item; do
       command+=("$item")
     done < <(replace_manifest_arg "$run_dir/Scarb.toml" "${command_template[@]}")
-    measure_command_ms "$run_dir" "$log_path" "${command[@]}" >> "$samples_file"
+    local exit_code=0
+    measure_command_ms "$run_dir" "$log_path" "${command[@]}" >> "$samples_file" || exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+      measurement_failure_json "$stage" "$exit_code" "$log_path"
+      return 0
+    fi
   done
-  stats_json_from_samples "$samples_file"
+  local stats_json
+  if ! stats_json="$(stats_json_from_samples "$samples_file")"; then
+    local exit_code=$?
+    measurement_failure_json "$stage" "$exit_code" "$samples_file"
+    return 0
+  fi
+  measurement_ok_json "$stage" "$sample_count" "$stats_json"
 }
 
 run_warm_noop_stats() {
@@ -295,6 +360,7 @@ run_warm_noop_stats() {
   local -a command_template=("$@")
   local warm_dir="$TMP_DIR/${tag}-${tool}-warm"
   local samples_file="$TMP_DIR/${tag}-${tool}-build.warm_noop.samples"
+  local stage="build.warm_noop"
   local -a command=()
   : > "$samples_file"
   rm -rf "$warm_dir"
@@ -305,13 +371,30 @@ run_warm_noop_stats() {
     command+=("$item")
   done < <(replace_manifest_arg "$warm_dir/Scarb.toml" "${command_template[@]}")
 
-  measure_command_ms "$warm_dir" "$RESULTS_DIR/real-repo-${tag}-${tool}-warm-prime.log" "${command[@]}" >/dev/null
+  local warm_prime_log="$RESULTS_DIR/real-repo-${tag}-${tool}-warm-prime.log"
+  local exit_code=0
+  measure_command_ms "$warm_dir" "$warm_prime_log" "${command[@]}" >/dev/null || exit_code=$?
+  if [[ "$exit_code" -ne 0 ]]; then
+    measurement_failure_json "$stage.prime" "$exit_code" "$warm_prime_log"
+    return 0
+  fi
   sleep "$WARM_SETTLE_SECONDS"
   for idx in $(seq 1 "$sample_count"); do
     local log_path="$RESULTS_DIR/real-repo-${tag}-${tool}-build.warm_noop-run-${idx}.log"
-    measure_command_ms "$warm_dir" "$log_path" "${command[@]}" >> "$samples_file"
+    local exit_code=0
+    measure_command_ms "$warm_dir" "$log_path" "${command[@]}" >> "$samples_file" || exit_code=$?
+    if [[ "$exit_code" -ne 0 ]]; then
+      measurement_failure_json "$stage" "$exit_code" "$log_path"
+      return 0
+    fi
   done
-  stats_json_from_samples "$samples_file"
+  local stats_json
+  if ! stats_json="$(stats_json_from_samples "$samples_file")"; then
+    local exit_code=$?
+    measurement_failure_json "$stage" "$exit_code" "$samples_file"
+    return 0
+  fi
+  measurement_ok_json "$stage" "$sample_count" "$stats_json"
 }
 
 benchmark_supported_case() {
@@ -323,7 +406,11 @@ benchmark_supported_case() {
   prefetch_manifest_dependencies "$manifest_path"
 
   local -a scarb_cmd=(scarb --manifest-path "$manifest_path" --offline build)
-  local -a uc_cmd=("$UC_BIN" build --engine uc --daemon-mode off --offline --manifest-path "$manifest_path")
+  local -a uc_cmd=(env "UC_NATIVE_DISALLOW_SCARB_FALLBACK=1")
+  if [[ -n "${UC_NATIVE_CORELIB_SRC:-}" ]]; then
+    uc_cmd+=("UC_NATIVE_CORELIB_SRC=$UC_NATIVE_CORELIB_SRC")
+  fi
+  uc_cmd+=("$UC_BIN" build --engine uc --daemon-mode off --offline --manifest-path "$manifest_path")
 
   local scarb_cold_json
   local scarb_warm_json
@@ -331,8 +418,8 @@ benchmark_supported_case() {
   local uc_warm_json
   scarb_cold_json="$(run_cold_stats "$source_dir" "$tag" "scarb" "$COLD_RUNS" "${scarb_cmd[@]}")"
   scarb_warm_json="$(run_warm_noop_stats "$source_dir" "$tag" "scarb" "$RUNS" "${scarb_cmd[@]}")"
-  UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 uc_cold_json="$(run_cold_stats "$source_dir" "$tag" "uc" "$COLD_RUNS" "${uc_cmd[@]}")"
-  UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 uc_warm_json="$(run_warm_noop_stats "$source_dir" "$tag" "uc" "$RUNS" "${uc_cmd[@]}")"
+  uc_cold_json="$(run_cold_stats "$source_dir" "$tag" "uc" "$COLD_RUNS" "${uc_cmd[@]}")"
+  uc_warm_json="$(run_warm_noop_stats "$source_dir" "$tag" "uc" "$RUNS" "${uc_cmd[@]}")"
 
   jq -n \
     --arg tag "$tag" \
@@ -346,6 +433,14 @@ benchmark_supported_case() {
       tag: $tag,
       manifest_path: $manifest_path,
       native_support: $native_support,
+      benchmark_status: (
+        if [
+          $scarb_cold.status,
+          $scarb_warm.status,
+          $uc_cold.status,
+          $uc_warm.status
+        ] | all(. == "ok") then "ok" else "failed" end
+      ),
       benchmarks: {
         scarb: {
           build: {
@@ -424,13 +519,30 @@ jq -s \
   jq -r '
     def r3: ((. * 1000 | round) / 1000);
     .cases[]
-    | select(.native_support.supported == true)
+    | select(.native_support.supported == true and .benchmark_status == "ok")
     | . as $case
-    | ($case.benchmarks.scarb.build.cold.p95_ms) as $scarb_cold
-    | ($case.benchmarks.uc.build.cold.p95_ms) as $uc_cold
-    | ($case.benchmarks.scarb.build.warm_noop.p95_ms) as $scarb_warm
-    | ($case.benchmarks.uc.build.warm_noop.p95_ms) as $uc_warm
+    | ($case.benchmarks.scarb.build.cold.stats.p95_ms) as $scarb_cold
+    | ($case.benchmarks.uc.build.cold.stats.p95_ms) as $uc_cold
+    | ($case.benchmarks.scarb.build.warm_noop.stats.p95_ms) as $scarb_warm
+    | ($case.benchmarks.uc.build.warm_noop.stats.p95_ms) as $uc_warm
     | "| \($case.tag) | \($scarb_cold | r3) | \($uc_cold | r3) | \((if $uc_cold == 0 then null else $scarb_cold / $uc_cold end) | r3) | \($scarb_warm | r3) | \($uc_warm | r3) | \((if $uc_warm == 0 then null else $scarb_warm / $uc_warm end) | r3) |"
+  ' "$OUT_JSON"
+  echo
+  echo "## Native-Eligible Cases With Build Failures"
+  echo "| Tag | Tool | Stage | Exit Code | Log Path |"
+  echo "|---|---|---|---:|---|"
+  jq -r '
+    .cases[]
+    | select(.native_support.supported == true and .benchmark_status != "ok")
+    | . as $case
+    | [
+        {tool: "scarb", lane: $case.benchmarks.scarb.build.cold},
+        {tool: "scarb", lane: $case.benchmarks.scarb.build.warm_noop},
+        {tool: "uc", lane: $case.benchmarks.uc.build.cold},
+        {tool: "uc", lane: $case.benchmarks.uc.build.warm_noop}
+      ][]
+    | select(.lane.status != "ok")
+    | "| \($case.tag) | \(.tool) | \(.lane.stage) | \(.lane.exit_code) | \(.lane.log_path) |"
   ' "$OUT_JSON"
   echo
   echo "## Native-Ineligible Cases"

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -162,6 +162,32 @@ test_real_repo_benchmark_rejects_missing_case_values() {
   fi
 }
 
+test_real_repo_benchmark_rejects_zero_runs_from_environment() {
+  local cases_root="$TEST_TMP_DIR/env-cases"
+  local mock_bin_dir="$TEST_TMP_DIR/env-mock-bin"
+  local mock_uc="$mock_bin_dir/uc"
+  local mock_scarb="$mock_bin_dir/scarb"
+  local stderr_path="$TEST_TMP_DIR/env-zero-runs.err"
+  mkdir -p "$mock_bin_dir"
+  write_mock_uc_bin "$mock_uc"
+  write_mock_scarb_bin "$mock_scarb"
+  write_manifest_case "$cases_root" "supported"
+
+  if RUNS=0 PATH="$mock_bin_dir:$PATH" "$BENCH_SCRIPT" \
+    --uc-bin "$mock_uc" \
+    --results-dir "$TEST_TMP_DIR/env-results" \
+    --case "$cases_root/supported/Scarb.toml" supported \
+    >"$TEST_TMP_DIR/env-zero-runs.out" 2>"$stderr_path"; then
+    echo "expected real repo benchmark script to reject RUNS=0 from environment" >&2
+    return 1
+  fi
+  if ! grep -q "RUNS must be a positive integer" "$stderr_path"; then
+    echo "expected explicit RUNS validation failure" >&2
+    cat "$stderr_path" >&2
+    return 1
+  fi
+}
+
 test_real_repo_benchmark_separates_supported_and_ineligible_cases() {
   local cases_root="$TEST_TMP_DIR/cases"
   local mock_bin_dir="$TEST_TMP_DIR/mock-bin"
@@ -177,6 +203,7 @@ test_real_repo_benchmark_separates_supported_and_ineligible_cases() {
   local stdout_text
   stdout_text="$(
     PATH="$mock_bin_dir:$PATH" \
+    UC_NATIVE_CORELIB_SRC="/tmp/fake-corelib/src" \
     MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/uc.args" \
     MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/scarb.args" \
     "$BENCH_SCRIPT" \
@@ -218,7 +245,7 @@ test_real_repo_benchmark_separates_supported_and_ineligible_cases() {
   assert_contains "$markdown_text" "| supported |"
   assert_contains "$markdown_text" "| unsupported | 2.14.0 |"
 
-  if ! grep -q "build .*supported.* disallow=1" "$TEST_TMP_DIR/uc.args"; then
+  if ! grep -q "build .*supported.* disallow=1 corelib=/tmp/fake-corelib/src" "$TEST_TMP_DIR/uc.args"; then
     echo "expected supported case to run uc build" >&2
     cat "$TEST_TMP_DIR/uc.args" >&2
     return 1
@@ -285,6 +312,8 @@ test_real_repo_benchmark_records_supported_build_failures() {
 
 run_test "real_repo_benchmark_rejects_missing_case_values" \
   test_real_repo_benchmark_rejects_missing_case_values
+run_test "real_repo_benchmark_rejects_zero_runs_from_environment" \
+  test_real_repo_benchmark_rejects_zero_runs_from_environment
 run_test "real_repo_benchmark_separates_supported_and_ineligible_cases" \
   test_real_repo_benchmark_separates_supported_and_ineligible_cases
 run_test "real_repo_benchmark_records_supported_build_failures" \

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -66,10 +66,14 @@ if [[ "$1" == "build" ]]; then
         ;;
       *)
         shift
-        ;;
+      ;;
     esac
   done
-  printf 'build %s\n' "$manifest" >> "$args_log"
+  if [[ "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" != "1" ]]; then
+    echo "expected UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 for uc build" >&2
+    exit 22
+  fi
+  printf 'build %s disallow=%s corelib=%s\n' "$manifest" "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" "${UC_NATIVE_CORELIB_SRC:-}" >> "$args_log"
   exit 0
 fi
 
@@ -86,7 +90,43 @@ write_mock_scarb_bin() {
 set -euo pipefail
 
 args_log="${MOCK_SCARB_ARGS_LOG:?}"
-printf 'cwd=%s cmd=%s\n' "$PWD" "$*" >> "$args_log"
+manifest=""
+subcommand=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest-path)
+      manifest="${2-}"
+      shift 2
+      ;;
+    build|fetch)
+      subcommand="$1"
+      shift
+      ;;
+    --offline)
+      shift
+      ;;
+    *)
+      echo "unexpected scarb invocation: $*" >&2
+      exit 19
+      ;;
+  esac
+done
+if [[ -z "$subcommand" ]]; then
+  echo "missing scarb subcommand" >&2
+  exit 20
+fi
+if [[ -z "$manifest" && "$subcommand" == "fetch" ]]; then
+  manifest="$PWD/Scarb.toml"
+fi
+if [[ -z "$manifest" ]]; then
+  echo "missing scarb manifest path" >&2
+  exit 20
+fi
+printf 'cwd=%s subcommand=%s manifest=%s\n' "$PWD" "$subcommand" "$manifest" >> "$args_log"
+if [[ "$subcommand" == "build" && "$manifest" == *"fails-build"* ]]; then
+  echo "forced scarb build failure for $manifest" >&2
+  exit 17
+fi
 exit 0
 MOCK
   chmod +x "$path"
@@ -162,7 +202,9 @@ test_real_repo_benchmark_separates_supported_and_ineligible_cases() {
   supported_status="$(jq -r '.cases[] | select(.tag=="supported") | .native_support.status' "$json_path")"
   local unsupported_status
   unsupported_status="$(jq -r '.cases[] | select(.tag=="unsupported") | .native_support.status' "$json_path")"
-  if [[ "$supported_status" != "supported" || "$unsupported_status" != "unsupported" ]]; then
+  local supported_benchmark_status
+  supported_benchmark_status="$(jq -r '.cases[] | select(.tag=="supported") | .benchmark_status' "$json_path")"
+  if [[ "$supported_status" != "supported" || "$unsupported_status" != "unsupported" || "$supported_benchmark_status" != "ok" ]]; then
     echo "unexpected support classification in json report" >&2
     cat "$json_path" >&2
     return 1
@@ -171,11 +213,12 @@ test_real_repo_benchmark_separates_supported_and_ineligible_cases() {
   local markdown_text
   markdown_text="$(cat "$md_path")"
   assert_contains "$markdown_text" "## Native-Eligible Cases"
+  assert_contains "$markdown_text" "## Native-Eligible Cases With Build Failures"
   assert_contains "$markdown_text" "## Native-Ineligible Cases"
   assert_contains "$markdown_text" "| supported |"
   assert_contains "$markdown_text" "| unsupported | 2.14.0 |"
 
-  if ! grep -q "build .*supported" "$TEST_TMP_DIR/uc.args"; then
+  if ! grep -q "build .*supported.* disallow=1" "$TEST_TMP_DIR/uc.args"; then
     echo "expected supported case to run uc build" >&2
     cat "$TEST_TMP_DIR/uc.args" >&2
     return 1
@@ -185,9 +228,64 @@ test_real_repo_benchmark_separates_supported_and_ineligible_cases() {
     cat "$TEST_TMP_DIR/uc.args" >&2
     return 1
   fi
+
+  if ! grep -Eq 'subcommand=build manifest=.*/Scarb.toml' "$TEST_TMP_DIR/scarb.args"; then
+    echo "expected supported case to run scarb build with rewritten manifest path" >&2
+    cat "$TEST_TMP_DIR/scarb.args" >&2
+    return 1
+  fi
+}
+
+test_real_repo_benchmark_records_supported_build_failures() {
+  local cases_root="$TEST_TMP_DIR/failure-cases"
+  local mock_bin_dir="$TEST_TMP_DIR/failure-mock-bin"
+  local mock_uc="$mock_bin_dir/uc"
+  local mock_scarb="$mock_bin_dir/scarb"
+  local results_dir="$TEST_TMP_DIR/failure-results"
+  mkdir -p "$mock_bin_dir" "$results_dir"
+  write_mock_uc_bin "$mock_uc"
+  write_mock_scarb_bin "$mock_scarb"
+  write_manifest_case "$cases_root" "fails-build"
+
+  local stdout_text
+  stdout_text="$(
+    PATH="$mock_bin_dir:$PATH" \
+    MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/failure-uc.args" \
+    MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/failure-scarb.args" \
+    "$BENCH_SCRIPT" \
+      --uc-bin "$mock_uc" \
+      --results-dir "$results_dir" \
+      --runs 1 \
+      --cold-runs 1 \
+      --warm-settle-seconds 0 \
+      --case "$cases_root/fails-build/Scarb.toml" fails-build
+  )"
+  local json_path
+  json_path="$(awk -F': ' '/Benchmark JSON:/ {print $2}' <<<"$stdout_text")"
+  local md_path
+  md_path="$(awk -F': ' '/Benchmark Markdown:/ {print $2}' <<<"$stdout_text")"
+
+  local benchmark_status
+  benchmark_status="$(jq -r '.cases[] | select(.tag=="fails-build") | .benchmark_status' "$json_path")"
+  local cold_status
+  cold_status="$(jq -r '.cases[] | select(.tag=="fails-build") | .benchmarks.scarb.build.cold.status' "$json_path")"
+  local cold_exit_code
+  cold_exit_code="$(jq -r '.cases[] | select(.tag=="fails-build") | .benchmarks.scarb.build.cold.exit_code' "$json_path")"
+  if [[ "$benchmark_status" != "failed" || "$cold_status" != "failed" || "$cold_exit_code" != "17" ]]; then
+    echo "expected supported build failure to be recorded in json report" >&2
+    cat "$json_path" >&2
+    return 1
+  fi
+
+  local markdown_text
+  markdown_text="$(cat "$md_path")"
+  assert_contains "$markdown_text" "## Native-Eligible Cases With Build Failures"
+  assert_contains "$markdown_text" "| fails-build | scarb | build.cold | 17 |"
 }
 
 run_test "real_repo_benchmark_rejects_missing_case_values" \
   test_real_repo_benchmark_rejects_missing_case_values
 run_test "real_repo_benchmark_separates_supported_and_ineligible_cases" \
   test_real_repo_benchmark_separates_supported_and_ineligible_cases
+run_test "real_repo_benchmark_records_supported_build_failures" \
+  test_real_repo_benchmark_records_supported_build_failures

--- a/docs/BENCHMARK_PLAN.md
+++ b/docs/BENCHMARK_PLAN.md
@@ -28,6 +28,7 @@ Before changing `uc` engine behavior, rerun baseline against current Scarb and s
 Do not mix native-ineligible manifests into `uc` vs Scarb speedup claims.
 Benchmark reports must separate:
 - native-eligible workloads that were actually measured against `uc` native build
+- native-eligible workloads that failed during timed execution, with exit code and log path
 - native-ineligible workloads that were skipped, along with the exact reason
 
 ## Comparator Rule


### PR DESCRIPTION
## Summary
- fix manifest-path rewriting for real-repo benchmark commands
- record supported-case lane failures instead of aborting on empty samples
- enforce strict native no-fallback env propagation in the harness

## Validation
- ./benchmarks/scripts/tests/real_repo_benchmark_test.sh
- make agent-validate
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified benchmark reporting and README: native-eligible timed-run failures are recorded with process exit code and log path.

* **New Features**
  * Structured per-lane JSON and an overall benchmark status; report now enumerates native-eligible cases with failing lanes.

* **Bug Fixes**
  * More rigorous validation: empty samples, numeric settings, and command failures now produce explicit failure JSON instead of incomplete results.

* **Tests**
  * Expanded test coverage to assert the new failure-reporting and invocation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->