### PR TITLE
[codex] Fix real repo benchmark relative paths

### DIFF
--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -72,13 +72,28 @@ validate_timeout_secs() {
 canonical_existing_file_path() {
   local label="$1"
   local path="$2"
-  if [[ ! -e "$path" ]]; then
-    echo "$label is missing: $path" >&2
+  if [[ ! -f "$path" ]]; then
+    echo "$label is missing or not a regular file: $path" >&2
     exit 1
   fi
-  local dir
+  local dir base
   dir="$(cd "$(dirname "$path")" && pwd -P)"
-  printf '%s/%s\n' "$dir" "$(basename "$path")"
+  base="$(basename "$path")"
+  if [[ "$dir" == "/" ]]; then
+    printf '/%s\n' "$base"
+  else
+    printf '%s/%s\n' "${dir%/}" "$base"
+  fi
+}
+
+canonical_existing_dir_path() {
+  local label="$1"
+  local path="$2"
+  if [[ ! -d "$path" ]]; then
+    echo "$label is missing or not a directory: $path" >&2
+    exit 1
+  fi
+  (cd "$path" && pwd -P)
 }
 
 canonical_dir_path() {
@@ -236,6 +251,11 @@ fi
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 is required for real repo benchmarks" >&2
   exit 1
+fi
+
+if [[ -n "${UC_NATIVE_CORELIB_SRC:-}" ]]; then
+  UC_NATIVE_CORELIB_SRC="$(canonical_existing_dir_path "UC_NATIVE_CORELIB_SRC" "$UC_NATIVE_CORELIB_SRC")"
+  export UC_NATIVE_CORELIB_SRC
 fi
 
 RESULTS_DIR="$(canonical_dir_path "results directory" "$RESULTS_DIR")"

--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -69,6 +69,28 @@ validate_timeout_secs() {
   fi
 }
 
+canonical_existing_file_path() {
+  local label="$1"
+  local path="$2"
+  if [[ ! -e "$path" ]]; then
+    echo "$label is missing: $path" >&2
+    exit 1
+  fi
+  local dir
+  dir="$(cd "$(dirname "$path")" && pwd -P)"
+  printf '%s/%s\n' "$dir" "$(basename "$path")"
+}
+
+canonical_dir_path() {
+  local label="$1"
+  local path="$2"
+  if ! mkdir -p "$path"; then
+    echo "Failed to create $label: $path" >&2
+    exit 1
+  fi
+  (cd "$path" && pwd -P)
+}
+
 validate_case_tag() {
   local tag="$1"
   if [[ ! "$tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
@@ -197,6 +219,7 @@ if [[ "${#CASE_MANIFESTS[@]}" -eq 0 ]]; then
   exit 2
 fi
 
+UC_BIN="$(canonical_existing_file_path "UC binary" "$UC_BIN")"
 if [[ ! -x "$UC_BIN" ]]; then
   echo "UC binary is missing or not executable: $UC_BIN" >&2
   exit 1
@@ -215,7 +238,7 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-mkdir -p "$RESULTS_DIR"
+RESULTS_DIR="$(canonical_dir_path "results directory" "$RESULTS_DIR")"
 
 measure_command_ms() {
   local cwd="$1"

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -301,6 +301,22 @@ test_real_repo_benchmark_rejects_no_cases_with_updated_usage() {
   fi
 }
 
+test_real_repo_benchmark_rejects_directory_uc_bin() {
+  local stderr_path="$TEST_TMP_DIR/directory-uc-bin.err"
+  if "$BENCH_SCRIPT" \
+    --uc-bin "$TEST_TMP_DIR" \
+    --case /tmp/Scarb.toml supported \
+    >"$TEST_TMP_DIR/directory-uc-bin.out" 2>"$stderr_path"; then
+    echo "expected real repo benchmark script to reject directory --uc-bin" >&2
+    return 1
+  fi
+  if ! grep -q "UC binary is missing or not a regular file" "$stderr_path"; then
+    echo "expected regular-file validation for --uc-bin" >&2
+    cat "$stderr_path" >&2
+    return 1
+  fi
+}
+
 test_real_repo_benchmark_accepts_cases_file() {
   local cases_root="$TEST_TMP_DIR/cases-file-cases"
   local mock_bin_dir="$TEST_TMP_DIR/cases-file-mock-bin"
@@ -349,7 +365,8 @@ test_real_repo_benchmark_canonicalizes_relative_paths() {
   local cases_root="$work_dir/cases"
   local mock_bin_dir="$work_dir/bin"
   local results_dir="$work_dir/results"
-  mkdir -p "$mock_bin_dir" "$results_dir"
+  local corelib_dir="$work_dir/corelib/src"
+  mkdir -p "$mock_bin_dir" "$results_dir" "$corelib_dir"
   write_mock_uc_bin "$mock_bin_dir/uc"
   write_mock_scarb_bin "$mock_bin_dir/scarb"
   write_manifest_case "$cases_root" "supported"
@@ -360,6 +377,7 @@ test_real_repo_benchmark_canonicalizes_relative_paths() {
     PATH="$mock_bin_dir:$PATH" \
     MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/relative-paths-uc.args" \
     MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/relative-paths-scarb.args" \
+    UC_NATIVE_CORELIB_SRC=corelib/src \
     "$BENCH_SCRIPT" \
       --uc-bin bin/uc \
       --results-dir results \
@@ -390,6 +408,13 @@ test_real_repo_benchmark_canonicalizes_relative_paths() {
   canonical_results_dir="$(cd "$results_dir" && pwd -P)"
   if ! grep -q "report=$canonical_results_dir/real-repo-supported-uc-auto-build-report.json" "$TEST_TMP_DIR/relative-paths-uc.args"; then
     echo "expected absolute report path under the requested results directory" >&2
+    cat "$TEST_TMP_DIR/relative-paths-uc.args" >&2
+    return 1
+  fi
+  local canonical_corelib_dir
+  canonical_corelib_dir="$(cd "$corelib_dir" && pwd -P)"
+  if ! grep -q "corelib=$canonical_corelib_dir" "$TEST_TMP_DIR/relative-paths-uc.args"; then
+    echo "expected relative UC_NATIVE_CORELIB_SRC to be canonicalized before cwd changes" >&2
     cat "$TEST_TMP_DIR/relative-paths-uc.args" >&2
     return 1
   fi
@@ -427,7 +452,8 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   local mock_uc="$mock_bin_dir/uc"
   local mock_scarb="$mock_bin_dir/scarb"
   local results_dir="$TEST_TMP_DIR/results"
-  mkdir -p "$mock_bin_dir" "$results_dir"
+  local corelib_dir="$TEST_TMP_DIR/fake-corelib/src"
+  mkdir -p "$mock_bin_dir" "$results_dir" "$corelib_dir"
   write_mock_uc_bin "$mock_uc"
   write_mock_scarb_bin "$mock_scarb"
   write_manifest_case "$cases_root" "supported"
@@ -437,7 +463,7 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   local stdout_text
   stdout_text="$(
     PATH="$mock_bin_dir:$PATH" \
-    UC_NATIVE_CORELIB_SRC="/tmp/fake-corelib/src" \
+    UC_NATIVE_CORELIB_SRC="$corelib_dir" \
     MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/uc.args" \
     MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/scarb.args" \
     "$BENCH_SCRIPT" \
@@ -489,7 +515,9 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   assert_contains "$markdown_text" "| fallback-used | fallback_used | scarb_fallback |"
   assert_contains "$markdown_text" "| unsupported | native_unsupported | <none> | 2.14.0 |"
 
-  if ! grep -q "build .*supported.* disallow=1 corelib=/tmp/fake-corelib/src report=" "$TEST_TMP_DIR/uc.args"; then
+  local canonical_corelib_dir
+  canonical_corelib_dir="$(cd "$corelib_dir" && pwd -P)"
+  if ! grep -q "build .*supported.* disallow=1 corelib=$canonical_corelib_dir report=" "$TEST_TMP_DIR/uc.args"; then
     echo "expected supported case to run strict uc benchmark build" >&2
     cat "$TEST_TMP_DIR/uc.args" >&2
     return 1
@@ -745,6 +773,8 @@ run_test "real_repo_benchmark_rejects_zero_runs_from_environment" \
   test_real_repo_benchmark_rejects_zero_runs_from_environment
 run_test "real_repo_benchmark_rejects_no_cases_with_updated_usage" \
   test_real_repo_benchmark_rejects_no_cases_with_updated_usage
+run_test "real_repo_benchmark_rejects_directory_uc_bin" \
+  test_real_repo_benchmark_rejects_directory_uc_bin
 run_test "real_repo_benchmark_accepts_cases_file" \
   test_real_repo_benchmark_accepts_cases_file
 run_test "real_repo_benchmark_canonicalizes_relative_paths" \

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -344,6 +344,57 @@ test_real_repo_benchmark_accepts_cases_file() {
   fi
 }
 
+test_real_repo_benchmark_canonicalizes_relative_paths() {
+  local work_dir="$TEST_TMP_DIR/relative-paths-work"
+  local cases_root="$work_dir/cases"
+  local mock_bin_dir="$work_dir/bin"
+  local results_dir="$work_dir/results"
+  mkdir -p "$mock_bin_dir" "$results_dir"
+  write_mock_uc_bin "$mock_bin_dir/uc"
+  write_mock_scarb_bin "$mock_bin_dir/scarb"
+  write_manifest_case "$cases_root" "supported"
+
+  local stdout_text
+  stdout_text="$(
+    cd "$work_dir"
+    PATH="$mock_bin_dir:$PATH" \
+    MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/relative-paths-uc.args" \
+    MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/relative-paths-scarb.args" \
+    "$BENCH_SCRIPT" \
+      --uc-bin bin/uc \
+      --results-dir results \
+      --runs 1 \
+      --cold-runs 1 \
+      --warm-settle-seconds 0 \
+      --case cases/supported/Scarb.toml supported
+  )"
+
+  local json_path
+  json_path="$(awk -F': ' '/Benchmark JSON:/ {print $2}' <<<"$stdout_text")"
+  [[ -f "$json_path" ]] || { echo "missing json report: $json_path" >&2; return 1; }
+
+  local classification
+  classification="$(jq -r '.cases[] | select(.tag=="supported") | .support_matrix.classification' "$json_path")"
+  if [[ "$classification" != "native_supported" ]]; then
+    echo "expected relative paths to preserve native-supported classification" >&2
+    cat "$json_path" >&2
+    return 1
+  fi
+
+  if grep -q 'report=results/' "$TEST_TMP_DIR/relative-paths-uc.args"; then
+    echo "expected uc auto-build report path to be canonicalized before cwd changes" >&2
+    cat "$TEST_TMP_DIR/relative-paths-uc.args" >&2
+    return 1
+  fi
+  local canonical_results_dir
+  canonical_results_dir="$(cd "$results_dir" && pwd -P)"
+  if ! grep -q "report=$canonical_results_dir/real-repo-supported-uc-auto-build-report.json" "$TEST_TMP_DIR/relative-paths-uc.args"; then
+    echo "expected absolute report path under the requested results directory" >&2
+    cat "$TEST_TMP_DIR/relative-paths-uc.args" >&2
+    return 1
+  fi
+}
+
 test_real_repo_benchmark_rejects_malformed_cases_file_rows() {
   local cases_file="$TEST_TMP_DIR/malformed-cases-file.tsv"
   local stderr_path="$TEST_TMP_DIR/malformed-cases-file.err"
@@ -696,6 +747,8 @@ run_test "real_repo_benchmark_rejects_no_cases_with_updated_usage" \
   test_real_repo_benchmark_rejects_no_cases_with_updated_usage
 run_test "real_repo_benchmark_accepts_cases_file" \
   test_real_repo_benchmark_accepts_cases_file
+run_test "real_repo_benchmark_canonicalizes_relative_paths" \
+  test_real_repo_benchmark_canonicalizes_relative_paths
 run_test "real_repo_benchmark_rejects_malformed_cases_file_rows" \
   test_real_repo_benchmark_rejects_malformed_cases_file_rows
 run_test "real_repo_benchmark_records_support_matrix_categories" \


### PR DESCRIPTION
## Summary

- Canonicalize `--uc-bin` and `--results-dir` before the real-repo benchmark harness changes into copied repo sandboxes.
- Add a regression test that invokes the harness with relative UC/results paths and a relative manifest path, then verifies native support classification still works and report paths are absolute.

## Root Cause

The harness accepted relative paths but later executed UC builds from temporary copied repo directories. That made `--report-path benchmarks/results/...` resolve inside the sandbox instead of the requested results directory, so successful UC builds could be misclassified as `build_failed` because the build report was never collected.

## Validation

- `bash benchmarks/scripts/tests/real_repo_benchmark_test.sh`
- `make validate-bench-scripts`
- `make agent-validate`
- `make local-ci`
- Pre-push hook: `make local-ci`

## Local Benchmark Evidence

With `UC_NATIVE_TOOLCHAIN_2_14_BIN=/Users/espejelomar/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`, the fixed harness generated `/Users/espejelomar/StarkNet/uc-deployed-source-inventory-20260425/benchmarks/results/real-repo-bench-20260425-035219.json`.

5 cold / 5 warm same-window results:

| Repo | Classification | Backend | Cold p95 speedup | Warm noop p95 speedup |
|---|---|---|---:|---:|
| monero | `native_supported` | `uc_native_external_helper` | `1.507x` | `108.149x` |
| braavos_account | `native_supported` | `uc_native_external_helper` | `1.252x` | `36.505x` |

Braavos factory remains outside this claim because it requires a future Cairo 2.5 helper lane (`UC_NATIVE_TOOLCHAIN_2_5_BIN`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests that verify path validation, canonicalization, and that benchmark outputs/logs show canonical absolute paths; includes a case ensuring non-regular paths are rejected.

* **Chores**
  * Improved path validation and normalization for benchmark execution and results handling so outputs and invocations consistently use canonical filesystem paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->