### PR TITLE
[codex] Add unsupported helper lane diagnostic

### DIFF
--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -2050,6 +2050,14 @@ fn native_toolchain_helper_lane_is_productized(major_minor: &str) -> bool {
 }
 
 #[cfg(feature = "native-compile")]
+fn manifest_exact_dependency_version(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let exact = trimmed.strip_prefix('=').map(str::trim).unwrap_or(trimmed);
+    parse_cairo_version_major_minor(exact)?;
+    Some(exact.to_string())
+}
+
+#[cfg(feature = "native-compile")]
 fn manifest_dependency_exact_version(
     manifest: &TomlValue,
     dependency_name: &str,
@@ -2059,19 +2067,14 @@ fn manifest_dependency_exact_version(
         .and_then(TomlValue::as_table)
         .and_then(|table| table.get(dependency_name))?;
     match dependency {
-        TomlValue::String(raw) => {
-            let trimmed = raw.trim();
-            parse_cairo_version_major_minor(trimmed)?;
-            Some(trimmed.to_string())
-        }
+        TomlValue::String(raw) => manifest_exact_dependency_version(raw),
         TomlValue::Table(table) => {
             let raw = table
                 .get("version")
                 .and_then(TomlValue::as_str)
                 .map(str::trim)
                 .filter(|value| !value.is_empty())?;
-            parse_cairo_version_major_minor(raw)?;
-            Some(raw.to_string())
+            manifest_exact_dependency_version(raw)
         }
         _ => None,
     }
@@ -4580,20 +4583,58 @@ fn execute_daemon_build_with_backend(
     })
 }
 
+#[cfg(feature = "native-compile")]
+fn ensure_daemon_native_toolchain_request_supported(manifest_path: &Path) -> Result<()> {
+    let (_, selection) = select_native_toolchain_from_manifest_path(manifest_path)?;
+    match selection {
+        Ok(selection) => {
+            if let Some(helper_path) = selection.helper_path {
+                let message = format!(
+                    concat!(
+                        "daemon native build requires external native toolchain helper {}; ",
+                        "daemon requests cannot safely carry helper metadata yet; ",
+                        "run with --daemon-mode off or allow scarb fallback"
+                    ),
+                    helper_path.display()
+                );
+                return Err(native_fallback_eligible_error(message));
+            }
+            Ok(())
+        }
+        Err(issue) => {
+            log_native_compile_support_issue(&issue, native_cairo_lang_compiler_version());
+            Err(native_fallback_eligible_error(issue.reason()))
+        }
+    }
+}
+
+#[cfg(not(feature = "native-compile"))]
+fn ensure_daemon_native_toolchain_request_supported(_manifest_path: &Path) -> Result<()> {
+    Err(native_fallback_eligible_error(
+        "native compile backend is disabled at build time; rebuild uc with `native-compile` feature",
+    ))
+}
+
 fn execute_daemon_build(request: DaemonBuildRequest) -> Result<DaemonBuildResponse> {
     validate_daemon_protocol_version(&request.protocol_version)
         .context("daemon build request protocol mismatch")?;
     let common = common_args_from_daemon_request(&request);
     let manifest_path = resolve_manifest_path(&common.manifest_path)?;
     let requested_backend = request.compile_backend.into_compile_backend();
-    let requested_compiler_version = compiler_version_for_backend(requested_backend)?;
-    match execute_daemon_build_with_backend(
-        &request,
-        &common,
-        &manifest_path,
-        requested_backend,
-        &requested_compiler_version,
-    ) {
+    let build_result = (|| -> Result<DaemonBuildResponse> {
+        if requested_backend == BuildCompileBackend::Native {
+            ensure_daemon_native_toolchain_request_supported(&manifest_path)?;
+        }
+        let requested_compiler_version = compiler_version_for_backend(requested_backend)?;
+        execute_daemon_build_with_backend(
+            &request,
+            &common,
+            &manifest_path,
+            requested_backend,
+            &requested_compiler_version,
+        )
+    })();
+    match build_result {
         Ok(response) => Ok(response),
         Err(native_err)
             if requested_backend == BuildCompileBackend::Native

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -257,7 +257,9 @@ const UC_AGENT_JSON_SCHEMA_VERSION: u32 = 1;
 const UC_AGENT_DIAGNOSTICS_DOC_URL: &str =
     "https://github.com/omarespejel/uc/blob/main/docs/agent/AGENT_DIAGNOSTICS.md";
 #[cfg(feature = "native-compile")]
-const WORKSPACE_CARGO_TOML: &str = include_str!("../../../Cargo.toml");
+// Keep this packaged with `uc-cli`; do not read the workspace root at compile time.
+// When adding a helper lane, update this list with the root helper-builder metadata.
+const PRODUCTIZED_NATIVE_TOOLCHAIN_HELPER_LANES: &[&str] = &["2.14"];
 
 #[derive(Parser, Debug)]
 #[command(name = "uc")]
@@ -2034,25 +2036,17 @@ fn native_toolchain_env_var_name_for_major_minor(major_minor: &str) -> String {
 
 #[cfg(feature = "native-compile")]
 fn productized_native_toolchain_helper_lanes() -> Vec<String> {
-    let Ok(manifest) = toml::from_str::<TomlValue>(WORKSPACE_CARGO_TOML) else {
-        return Vec::new();
-    };
-    let Some(table) = manifest
-        .get("workspace")
-        .and_then(|value| value.get("metadata"))
-        .and_then(|value| value.get("uc-native-toolchain-helpers"))
-        .and_then(TomlValue::as_table)
-    else {
-        return Vec::new();
-    };
-    table.keys().cloned().collect()
+    PRODUCTIZED_NATIVE_TOOLCHAIN_HELPER_LANES
+        .iter()
+        .map(|lane| (*lane).to_string())
+        .collect()
 }
 
 #[cfg(feature = "native-compile")]
 fn native_toolchain_helper_lane_is_productized(major_minor: &str) -> bool {
-    productized_native_toolchain_helper_lanes()
+    PRODUCTIZED_NATIVE_TOOLCHAIN_HELPER_LANES
         .iter()
-        .any(|lane| lane == major_minor)
+        .any(|lane| *lane == major_minor)
 }
 
 #[cfg(feature = "native-compile")]

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -256,6 +256,8 @@ const CACHEABLE_ARTIFACT_SUFFIXES: [&str; 7] = [
 const UC_AGENT_JSON_SCHEMA_VERSION: u32 = 1;
 const UC_AGENT_DIAGNOSTICS_DOC_URL: &str =
     "https://github.com/omarespejel/uc/blob/main/docs/agent/AGENT_DIAGNOSTICS.md";
+#[cfg(feature = "native-compile")]
+const WORKSPACE_CARGO_TOML: &str = include_str!("../../../Cargo.toml");
 
 #[derive(Parser, Debug)]
 #[command(name = "uc")]
@@ -2031,6 +2033,29 @@ fn native_toolchain_env_var_name_for_major_minor(major_minor: &str) -> String {
 }
 
 #[cfg(feature = "native-compile")]
+fn productized_native_toolchain_helper_lanes() -> Vec<String> {
+    let Ok(manifest) = toml::from_str::<TomlValue>(WORKSPACE_CARGO_TOML) else {
+        return Vec::new();
+    };
+    let Some(table) = manifest
+        .get("workspace")
+        .and_then(|value| value.get("metadata"))
+        .and_then(|value| value.get("uc-native-toolchain-helpers"))
+        .and_then(TomlValue::as_table)
+    else {
+        return Vec::new();
+    };
+    table.keys().cloned().collect()
+}
+
+#[cfg(feature = "native-compile")]
+fn native_toolchain_helper_lane_is_productized(major_minor: &str) -> bool {
+    productized_native_toolchain_helper_lanes()
+        .iter()
+        .any(|lane| lane == major_minor)
+}
+
+#[cfg(feature = "native-compile")]
 fn manifest_dependency_exact_version(
     manifest: &TomlValue,
     dependency_name: &str,
@@ -2243,6 +2268,11 @@ enum NativeCompileSupportIssue {
         requested: String,
         helper_env: String,
     },
+    UnsupportedToolchainHelperLane {
+        requested: String,
+        helper_env: String,
+        productized_lanes: Vec<String>,
+    },
     InvalidToolchainHelper {
         requested: String,
         helper_env: String,
@@ -2260,6 +2290,7 @@ impl NativeCompileSupportIssue {
             Self::UnparseableCompilerVersion { .. } => "UCN1003",
             Self::MissingToolchainHelper { .. } => "UCN1004",
             Self::InvalidToolchainHelper { .. } => "UCN1005",
+            Self::UnsupportedToolchainHelperLane { .. } => "UCN1006",
         }
     }
 
@@ -2273,6 +2304,7 @@ impl NativeCompileSupportIssue {
             Self::CompilerVersionMismatch { .. } => "compiler_version_mismatch",
             Self::MissingToolchainHelper { .. } => "missing_toolchain_helper",
             Self::InvalidToolchainHelper { .. } => "invalid_toolchain_helper",
+            Self::UnsupportedToolchainHelperLane { .. } => "unsupported_toolchain_helper_lane",
         }
     }
 
@@ -2293,6 +2325,9 @@ impl NativeCompileSupportIssue {
             Self::MissingToolchainHelper { .. } => {
                 "native compile preflight rejected missing external toolchain helper"
             }
+            Self::UnsupportedToolchainHelperLane { .. } => {
+                "native compile preflight rejected unproductized external toolchain helper lane"
+            }
             Self::InvalidToolchainHelper { .. } => {
                 "native compile preflight rejected invalid external toolchain helper"
             }
@@ -2309,6 +2344,9 @@ impl NativeCompileSupportIssue {
             Self::CompilerVersionMismatch { .. } => "Native toolchain mismatch",
             Self::MissingToolchainHelper { .. } => "Required native toolchain helper is missing",
             Self::InvalidToolchainHelper { .. } => "Configured native toolchain helper is invalid",
+            Self::UnsupportedToolchainHelperLane { .. } => {
+                "Native toolchain helper lane is not productized"
+            }
         }
     }
 
@@ -2321,6 +2359,7 @@ impl NativeCompileSupportIssue {
             Self::MissingToolchainHelper { .. } | Self::InvalidToolchainHelper { .. } => {
                 "toolchain_lane_unavailable"
             }
+            Self::UnsupportedToolchainHelperLane { .. } => "toolchain_lane_unsupported",
         }
     }
 
@@ -2343,6 +2382,14 @@ impl NativeCompileSupportIssue {
                 helper_env,
             } => format!(
                 "The project requires native Cairo {requested}, but `{helper_env}` is not configured."
+            ),
+            Self::UnsupportedToolchainHelperLane {
+                requested,
+                helper_env,
+                productized_lanes,
+            } => format!(
+                "The project requires native Cairo {requested}, but this uc release cannot build that helper lane automatically. `{helper_env}` is unset, and the productized helper lane(s) are: {}.",
+                format_productized_helper_lanes(productized_lanes)
             ),
             Self::InvalidToolchainHelper {
                 requested,
@@ -2379,6 +2426,14 @@ impl NativeCompileSupportIssue {
                 helper_env,
             } => format!(
                 "native compile requires a Cairo {requested} helper lane, but `{helper_env}` is unset; configure it to a uc binary built with cairo-lang {requested}"
+            ),
+            Self::UnsupportedToolchainHelperLane {
+                requested,
+                helper_env,
+                productized_lanes,
+            } => format!(
+                "native compile requires a Cairo {requested} helper lane, but this release only productizes helper building for {}; provide a reviewed `{helper_env}` helper or implement the legacy compatibility adapter before marking this workload native-supported",
+                format_productized_helper_lanes(productized_lanes)
             ),
             Self::InvalidToolchainHelper {
                 requested,
@@ -2424,6 +2479,20 @@ impl NativeCompileSupportIssue {
                     "Set `{helper_env}` to the path of a uc binary built with the required cairo-lang lane."
                 ),
             ],
+            Self::UnsupportedToolchainHelperLane {
+                helper_env,
+                productized_lanes,
+                ..
+            } => vec![
+                format!(
+                    "Do not run the helper builder for this lane; this release only productizes helper building for {}.",
+                    format_productized_helper_lanes(productized_lanes)
+                ),
+                format!(
+                    "If you already have a reviewed compatible helper, set `{helper_env}` to that executable and rerun support probing."
+                ),
+                "Otherwise keep this workload in the support matrix as native_unsupported until a dedicated legacy compatibility adapter lands.".to_string(),
+            ],
             Self::InvalidToolchainHelper { helper_env, .. } => vec![
                 "Rebuild the helper with `./scripts/build_native_toolchain_helper.sh --lane <major.minor>` if the binary is stale or missing.".to_string(),
                 format!("Point `{helper_env}` at an executable uc binary for the required Cairo lane."),
@@ -2461,6 +2530,14 @@ impl NativeCompileSupportIssue {
                     format!("{helper_env}=<helper-uc-path> uc support native --manifest-path <Scarb.toml> --format json"),
                 ]
             }
+            Self::UnsupportedToolchainHelperLane {
+                helper_env,
+                requested,
+                ..
+            } => vec![
+                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+                format!("{helper_env}=<reviewed-cairo-{requested}-helper-uc-path> uc support native --manifest-path <Scarb.toml> --format json"),
+            ],
             Self::InvalidToolchainHelper {
                 requested,
                 helper_env,
@@ -2479,6 +2556,7 @@ impl NativeCompileSupportIssue {
         match self {
             Self::MissingToolchainHelper { .. } => "build_helper_lane",
             Self::InvalidToolchainHelper { .. } => "rebuild_helper_lane",
+            Self::UnsupportedToolchainHelperLane { .. } => "manual_legacy_adapter_required",
             Self::CompilerVersionMismatch { .. } | Self::UnparseableCompilerVersion { .. } => {
                 "select_matching_toolchain_lane"
             }
@@ -2502,6 +2580,9 @@ impl NativeCompileSupportIssue {
                 compiler,
             } => (Some(requested.clone()), Some(compiler.clone())),
             Self::MissingToolchainHelper { requested, .. } => (Some(requested.clone()), None),
+            Self::UnsupportedToolchainHelperLane { requested, .. } => {
+                (Some(requested.clone()), None)
+            }
             Self::InvalidToolchainHelper {
                 requested, path, ..
             } => (Some(requested.clone()), Some(path.clone())),
@@ -2524,6 +2605,15 @@ impl NativeCompileSupportIssue {
             toolchain_expected,
             toolchain_found,
         }
+    }
+}
+
+#[cfg(feature = "native-compile")]
+fn format_productized_helper_lanes(lanes: &[String]) -> String {
+    if lanes.is_empty() {
+        "<none>".to_string()
+    } else {
+        lanes.join(", ")
     }
 }
 
@@ -2553,6 +2643,17 @@ fn native_toolchain_report_for_issue(
 ) -> NativeToolchainReport {
     match issue {
         NativeCompileSupportIssue::MissingToolchainHelper { helper_env, .. } => {
+            NativeToolchainReport {
+                edition: requirement.edition.clone(),
+                requested_version: requirement.requested_version.clone(),
+                requested_major_minor: requirement.requested_major_minor.clone(),
+                request_source: requirement.request_source.clone(),
+                source: NativeToolchainSource::ExternalHelper,
+                binary_path: std::env::var(helper_env).ok(),
+                compiler_version: Some(native_cairo_lang_compiler_version().to_string()),
+            }
+        }
+        NativeCompileSupportIssue::UnsupportedToolchainHelperLane { helper_env, .. } => {
             NativeToolchainReport {
                 edition: requirement.edition.clone(),
                 requested_version: requirement.requested_version.clone(),
@@ -2628,6 +2729,15 @@ fn select_native_toolchain_from_requirement(
                 .unwrap_or_else(|| requirement.requested_version.clone().unwrap_or_default());
             let helper_env = native_toolchain_env_var_name_for_major_minor(&requested_major_minor);
             let Some(helper_path_os) = std::env::var_os(&helper_env) else {
+                if !native_toolchain_helper_lane_is_productized(&requested_major_minor) {
+                    return Ok(Err(
+                        NativeCompileSupportIssue::UnsupportedToolchainHelperLane {
+                            requested: requested_major_minor,
+                            helper_env,
+                            productized_lanes: productized_native_toolchain_helper_lanes(),
+                        },
+                    ));
+                }
                 return Ok(Err(NativeCompileSupportIssue::MissingToolchainHelper {
                     requested: requested_major_minor,
                     helper_env,
@@ -2828,6 +2938,7 @@ fn ensure_native_toolchain_requirement_supported_with_compiler(
         | NativeCompileSupportIssue::UnparseableCompilerVersion { requested, .. }
         | NativeCompileSupportIssue::CompilerVersionMismatch { requested, .. }
         | NativeCompileSupportIssue::MissingToolchainHelper { requested, .. }
+        | NativeCompileSupportIssue::UnsupportedToolchainHelperLane { requested, .. }
         | NativeCompileSupportIssue::InvalidToolchainHelper { requested, .. } => {
             tracing::warn!(
                 compiler = %compiler,

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -2265,6 +2265,7 @@ enum NativeCompileSupportIssue {
     UnsupportedToolchainHelperLane {
         requested: String,
         helper_env: String,
+        configured_path: Option<String>,
         productized_lanes: Vec<String>,
     },
     InvalidToolchainHelper {
@@ -2380,11 +2381,18 @@ impl NativeCompileSupportIssue {
             Self::UnsupportedToolchainHelperLane {
                 requested,
                 helper_env,
+                configured_path,
                 productized_lanes,
-            } => format!(
-                "The project requires native Cairo {requested}, but this uc release cannot build that helper lane automatically. `{helper_env}` is unset, and the productized helper lane(s) are: {}.",
-                format_productized_helper_lanes(productized_lanes)
-            ),
+            } => {
+                let configured = configured_path
+                    .as_deref()
+                    .map(|path| format!("`{helper_env}` points to `{path}`, but that helper is not usable. "))
+                    .unwrap_or_else(|| format!("`{helper_env}` is unset. "));
+                format!(
+                    "The project requires native Cairo {requested}, but this uc release cannot build that helper lane automatically. {configured}The productized helper lane(s) are: {}.",
+                    format_productized_helper_lanes(productized_lanes)
+                )
+            }
             Self::InvalidToolchainHelper {
                 requested,
                 helper_env,
@@ -2424,11 +2432,18 @@ impl NativeCompileSupportIssue {
             Self::UnsupportedToolchainHelperLane {
                 requested,
                 helper_env,
+                configured_path,
                 productized_lanes,
-            } => format!(
-                "native compile requires a Cairo {requested} helper lane, but this release only productizes helper building for {}; provide a reviewed `{helper_env}` helper or implement the legacy compatibility adapter before marking this workload native-supported",
-                format_productized_helper_lanes(productized_lanes)
-            ),
+            } => {
+                let configured = configured_path
+                    .as_deref()
+                    .map(|path| format!("; configured `{helper_env}` helper `{path}` is not an executable uc binary"))
+                    .unwrap_or_default();
+                format!(
+                    "native compile requires a Cairo {requested} helper lane, but this release only productizes helper building for {}{configured}; provide a reviewed `{helper_env}` helper or implement the legacy compatibility adapter before marking this workload native-supported",
+                    format_productized_helper_lanes(productized_lanes)
+                )
+            }
             Self::InvalidToolchainHelper {
                 requested,
                 helper_env,
@@ -2574,9 +2589,11 @@ impl NativeCompileSupportIssue {
                 compiler,
             } => (Some(requested.clone()), Some(compiler.clone())),
             Self::MissingToolchainHelper { requested, .. } => (Some(requested.clone()), None),
-            Self::UnsupportedToolchainHelperLane { requested, .. } => {
-                (Some(requested.clone()), None)
-            }
+            Self::UnsupportedToolchainHelperLane {
+                requested,
+                configured_path,
+                ..
+            } => (Some(requested.clone()), configured_path.clone()),
             Self::InvalidToolchainHelper {
                 requested, path, ..
             } => (Some(requested.clone()), Some(path.clone())),
@@ -2736,6 +2753,7 @@ fn select_native_toolchain_from_requirement_with_compiler(
                         NativeCompileSupportIssue::UnsupportedToolchainHelperLane {
                             requested: requested_major_minor,
                             helper_env,
+                            configured_path: None,
                             productized_lanes: productized_native_toolchain_helper_lanes(),
                         },
                     ));
@@ -2747,6 +2765,16 @@ fn select_native_toolchain_from_requirement_with_compiler(
             };
             let helper_path = PathBuf::from(helper_path_os);
             if !native_toolchain_helper_path_is_usable(&helper_path) {
+                if !native_toolchain_helper_lane_is_productized(&requested_major_minor) {
+                    return Ok(Err(
+                        NativeCompileSupportIssue::UnsupportedToolchainHelperLane {
+                            requested: requested_major_minor,
+                            helper_env,
+                            configured_path: Some(helper_path.display().to_string()),
+                            productized_lanes: productized_native_toolchain_helper_lanes(),
+                        },
+                    ));
+                }
                 return Ok(Err(NativeCompileSupportIssue::InvalidToolchainHelper {
                     requested: requested_major_minor,
                     helper_env,

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -2050,11 +2050,48 @@ fn native_toolchain_helper_lane_is_productized(major_minor: &str) -> bool {
 }
 
 #[cfg(feature = "native-compile")]
+fn is_exact_cairo_version(raw: &str) -> bool {
+    let mut parts = raw.split('.');
+    let Some(major) = parts.next() else {
+        return false;
+    };
+    let Some(minor) = parts.next() else {
+        return false;
+    };
+    let patch = parts.next();
+    if parts.next().is_some() {
+        return false;
+    }
+    let is_numeric_part = |part: &str| part.parse::<u64>().is_ok();
+    is_numeric_part(major) && is_numeric_part(minor) && patch.is_none_or(is_numeric_part)
+}
+
+#[cfg(feature = "native-compile")]
 fn manifest_exact_dependency_version(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     let exact = trimmed.strip_prefix('=').map(str::trim).unwrap_or(trimmed);
-    parse_cairo_version_major_minor(exact)?;
+    if !is_exact_cairo_version(exact) {
+        return None;
+    }
     Some(exact.to_string())
+}
+
+#[cfg(feature = "native-compile")]
+fn manifest_dependency_version_raw(manifest: &TomlValue, dependency_name: &str) -> Option<String> {
+    let dependency = manifest
+        .get("dependencies")
+        .and_then(TomlValue::as_table)
+        .and_then(|table| table.get(dependency_name))?;
+    match dependency {
+        TomlValue::String(raw) => Some(raw.trim().to_string()).filter(|value| !value.is_empty()),
+        TomlValue::Table(table) => table
+            .get("version")
+            .and_then(TomlValue::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        _ => None,
+    }
 }
 
 #[cfg(feature = "native-compile")]
@@ -2062,22 +2099,21 @@ fn manifest_dependency_exact_version(
     manifest: &TomlValue,
     dependency_name: &str,
 ) -> Option<String> {
-    let dependency = manifest
-        .get("dependencies")
-        .and_then(TomlValue::as_table)
-        .and_then(|table| table.get(dependency_name))?;
-    match dependency {
-        TomlValue::String(raw) => manifest_exact_dependency_version(raw),
-        TomlValue::Table(table) => {
-            let raw = table
-                .get("version")
-                .and_then(TomlValue::as_str)
-                .map(str::trim)
-                .filter(|value| !value.is_empty())?;
-            manifest_exact_dependency_version(raw)
-        }
-        _ => None,
+    manifest_dependency_version_raw(manifest, dependency_name)
+        .as_deref()
+        .and_then(manifest_exact_dependency_version)
+}
+
+#[cfg(feature = "native-compile")]
+fn manifest_dependency_invalid_pinned_version(
+    manifest: &TomlValue,
+    dependency_name: &str,
+) -> Option<String> {
+    let raw = manifest_dependency_version_raw(manifest, dependency_name)?;
+    if raw.trim().starts_with('=') && manifest_exact_dependency_version(&raw).is_none() {
+        return Some(raw.trim().to_string());
     }
+    None
 }
 
 #[cfg(feature = "native-compile")]
@@ -2211,6 +2247,16 @@ fn resolve_native_toolchain_requirement(
             edition,
             requested_major_minor: parse_cairo_version_major_minor(&requested_version)
                 .map(format_cairo_version_major_minor),
+            requested_version: Some(requested_version),
+            request_source: Some(NativeToolchainRequestSource::ManifestDependencyVersion),
+        });
+    }
+    if let Some(requested_version) =
+        manifest_dependency_invalid_pinned_version(manifest, "starknet")
+    {
+        return Ok(NativeToolchainRequirement {
+            edition,
+            requested_major_minor: None,
             requested_version: Some(requested_version),
             request_source: Some(NativeToolchainRequestSource::ManifestDependencyVersion),
         });

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -2398,7 +2398,7 @@ impl NativeCompileSupportIssue {
     fn reason(&self) -> String {
         match self {
             Self::LegacyEditionRequiresPinnedCairoVersion { edition } => format!(
-                "native compile could not resolve an exact Cairo toolchain for legacy edition {edition}; pin [package].cairo-version, commit a lockfile with an exact starknet version, or let `scarb metadata` resolve dependencies once before retrying"
+                "native compile could not resolve an exact Cairo toolchain for legacy edition {edition}; native compile requires an exact [package].cairo-version for legacy edition {edition}, or a committed lockfile/resolved metadata entry with an exact starknet version"
             ),
             Self::UnsupportedManifestConstraint { requested } => format!(
                 "native compile requires an exact cairo-version (major.minor[.patch]); unsupported constraint `{requested}`"
@@ -2708,10 +2708,18 @@ fn native_compile_support_issue_with_compiler(
 fn select_native_toolchain_from_requirement(
     requirement: &NativeToolchainRequirement,
 ) -> Result<std::result::Result<NativeToolchainSelection, NativeCompileSupportIssue>> {
-    if let Some(issue) = native_compile_support_issue_with_compiler(
+    select_native_toolchain_from_requirement_with_compiler(
         requirement,
         native_cairo_lang_compiler_version(),
-    ) {
+    )
+}
+
+#[cfg(feature = "native-compile")]
+fn select_native_toolchain_from_requirement_with_compiler(
+    requirement: &NativeToolchainRequirement,
+    compiler: &str,
+) -> Result<std::result::Result<NativeToolchainSelection, NativeCompileSupportIssue>> {
+    if let Some(issue) = native_compile_support_issue_with_compiler(requirement, compiler) {
         if matches!(
             issue,
             NativeCompileSupportIssue::CompilerVersionMismatch { .. }
@@ -2916,9 +2924,16 @@ fn ensure_native_toolchain_requirement_supported_with_compiler(
     requirement: &NativeToolchainRequirement,
     compiler: &str,
 ) -> Result<()> {
-    let Some(issue) = native_compile_support_issue_with_compiler(requirement, compiler) else {
+    let Err(issue) = select_native_toolchain_from_requirement_with_compiler(requirement, compiler)?
+    else {
         return Ok(());
     };
+    log_native_compile_support_issue(&issue, compiler);
+    Err(native_fallback_eligible_error(issue.reason()))
+}
+
+#[cfg(feature = "native-compile")]
+fn log_native_compile_support_issue(issue: &NativeCompileSupportIssue, compiler: &str) {
     match &issue {
         NativeCompileSupportIssue::LegacyEditionRequiresPinnedCairoVersion { edition } => {
             tracing::warn!(
@@ -2942,7 +2957,6 @@ fn ensure_native_toolchain_requirement_supported_with_compiler(
             );
         }
     }
-    Err(native_fallback_eligible_error(issue.reason()))
 }
 
 #[cfg(all(feature = "native-compile", test))]

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -2544,8 +2544,17 @@ starknet = "={requested_version}"
         json["diagnostics"][0]["toolchain_expected"],
         requested_major_minor
     );
+    let diagnostic_json = json["diagnostics"][0]
+        .as_object()
+        .expect("diagnostic should serialize as an object");
     assert!(
-        json["diagnostics"][0]["toolchain_found"].is_null(),
+        diagnostic_json.contains_key("toolchain_found"),
+        "unproductized lane diagnostics should serialize toolchain_found explicitly"
+    );
+    assert!(
+        diagnostic_json
+            .get("toolchain_found")
+            .is_some_and(serde_json::Value::is_null),
         "unproductized lane diagnostics should explicitly expose no found helper"
     );
     let commands = json["diagnostics"][0]["next_commands"]
@@ -2582,6 +2591,65 @@ starknet = "={requested_version}"
         requested_major_minor
     );
     assert_eq!(json["toolchain"]["requested_version"], requested_version);
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn native_support_report_keeps_invalid_unproductized_helper_manual() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let requested_major_minor = "2.5";
+    let requested_version = "2.5.3";
+    let helper_env = native_toolchain_env_var_name_for_major_minor(requested_major_minor);
+    let dir = unique_test_dir("uc-native-support-unproductized-helper-invalid");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2023_11"
+cairo-version = "{requested_version}"
+"#
+        ),
+    )
+    .expect("write manifest");
+    let invalid_helper_path = dir.join("missing-reviewed-helper");
+    let _helper =
+        ScopedDynamicEnvVar::set_with_lock(&_guard, helper_env.clone(), &invalid_helper_path);
+
+    let report = native_support_report_from_manifest_path(&manifest_path)
+        .expect("invalid unproductized helper should still return support JSON");
+    assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert_eq!(
+        report.issue_kind.as_deref(),
+        Some("unsupported_toolchain_helper_lane")
+    );
+    let json = serde_json::to_value(&report).expect("support report should serialize");
+    assert_eq!(json["diagnostics"][0]["code"], "UCN1006");
+    assert_eq!(
+        json["diagnostics"][0]["safe_automated_action"],
+        "manual_legacy_adapter_required"
+    );
+    assert_eq!(
+        json["diagnostics"][0]["toolchain_found"],
+        invalid_helper_path.display().to_string()
+    );
+    let fixes = json["diagnostics"][0]["how_to_fix"]
+        .as_array()
+        .expect("how_to_fix should stay an array");
+    let commands = json["diagnostics"][0]["next_commands"]
+        .as_array()
+        .expect("next_commands should stay an array");
+    assert!(
+        fixes.iter().chain(commands.iter()).all(|entry| !entry
+            .as_str()
+            .unwrap_or_default()
+            .contains("build_native_toolchain_helper")),
+        "invalid helpers for unproductized lanes must stay on manual remediation"
+    );
 
     fs::remove_dir_all(&dir).ok();
 }
@@ -2663,6 +2731,8 @@ fn native_support_report_from_manifest_path_allows_reviewed_unproductized_helper
 
     let dir = unique_test_dir("uc-native-support-unproductized-helper-env");
     fs::create_dir_all(&dir).expect("create temp dir");
+    fs::create_dir_all(dir.join("src")).expect("create src dir");
+    fs::write(dir.join("src/lib.cairo"), "fn main() {}\n").expect("write lib.cairo");
     let manifest_path = dir.join("Scarb.toml");
     fs::write(
         &manifest_path,
@@ -2708,6 +2778,22 @@ cairo-version = "{requested_version}"
         toolchain.compiler_version.as_deref(),
         Some(requested_version)
     );
+    let fake_corelib_src = dir.join("toolchain/corelib/src");
+    create_mock_native_corelib(&fake_corelib_src);
+    let _corelib = ScopedEnvVar::set_with_lock(&_guard, "UC_NATIVE_CORELIB_SRC", &fake_corelib_src);
+    let common = BuildCommonArgs {
+        manifest_path: Some(manifest_path.clone()),
+        package: None,
+        workspace: false,
+        features: Vec::new(),
+        offline: true,
+        release: false,
+        profile: None,
+    };
+    let context = build_native_compile_context(&common, &manifest_path, &dir)
+        .expect("reviewed helper env should let build preflight pass");
+    assert_eq!(context.package_name, "demo");
+    assert_eq!(context.crate_name, "demo");
 
     fs::remove_dir_all(&dir).ok();
 }

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -388,6 +388,81 @@ fn daemon_build_request_roundtrip_preserves_async_cache_persist() {
     assert!(request.native_fallback_to_scarb);
 }
 
+#[cfg(all(feature = "native-compile", unix))]
+#[test]
+fn execute_daemon_build_rejects_external_helper_native_request() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let requested_major_minor = "2.5";
+    let requested_version = "2.5.3";
+    let helper_env = native_toolchain_env_var_name_for_major_minor(requested_major_minor);
+    let dir = unique_test_dir("uc-daemon-native-external-helper");
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2023_11"
+
+[dependencies]
+starknet = "={requested_version}"
+"#
+        ),
+    )
+    .expect("write manifest");
+    let helper_path = dir.join("uc-cairo25-helper.sh");
+    write_fake_uc_support_helper(
+        &helper_path,
+        &NativeSupportReport {
+            schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+            manifest_path: manifest_path.display().to_string(),
+            status: NativeSupportStatus::Supported,
+            supported: true,
+            reason: None,
+            compiler_version: Some(requested_version.to_string()),
+            package_cairo_version: None,
+            issue_kind: None,
+            toolchain: None,
+            diagnostics: Vec::new(),
+        },
+    );
+    let _helper = ScopedDynamicEnvVar::set_with_lock(&_guard, helper_env, &helper_path);
+
+    let request = DaemonBuildRequest {
+        protocol_version: DAEMON_PROTOCOL_VERSION.to_string(),
+        manifest_path: manifest_path.display().to_string(),
+        package: None,
+        workspace: false,
+        features: Vec::new(),
+        offline: true,
+        release: false,
+        profile: None,
+        async_cache_persist: false,
+        capture_output: true,
+        compile_backend: DaemonBuildBackend::Native,
+        native_fallback_to_scarb: false,
+    };
+    let err = execute_daemon_build(request)
+        .expect_err("daemon native build should reject external helper requests");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("daemon native build requires external native toolchain helper"),
+        "error should reject daemon helper routing: {rendered}"
+    );
+    assert!(
+        rendered.contains(&helper_path.display().to_string()),
+        "error should name the helper that cannot be carried into the daemon request: {rendered}"
+    );
+    assert!(
+        native_error_allows_scarb_fallback(&err),
+        "daemon helper rejection should remain scarb-fallback eligible"
+    );
+
+    fs::remove_dir_all(&dir).ok();
+}
+
 #[cfg(feature = "native-compile")]
 #[test]
 fn native_compile_session_heap_estimate_scales_with_tracked_source_bytes() {
@@ -2741,7 +2816,9 @@ fn native_support_report_from_manifest_path_allows_reviewed_unproductized_helper
 name = "demo"
 version = "0.1.0"
 edition = "2023_11"
-cairo-version = "{requested_version}"
+
+[dependencies]
+starknet = "={requested_version}"
 "#
         ),
     )
@@ -2756,7 +2833,7 @@ cairo-version = "{requested_version}"
             supported: true,
             reason: None,
             compiler_version: Some(requested_version.to_string()),
-            package_cairo_version: Some(requested_version.to_string()),
+            package_cairo_version: None,
             issue_kind: None,
             toolchain: None,
             diagnostics: Vec::new(),
@@ -2777,6 +2854,14 @@ cairo-version = "{requested_version}"
     assert_eq!(
         toolchain.compiler_version.as_deref(),
         Some(requested_version)
+    );
+    assert_eq!(
+        toolchain.request_source,
+        Some(NativeToolchainRequestSource::ManifestDependencyVersion)
+    );
+    assert_eq!(
+        toolchain.requested_major_minor.as_deref(),
+        Some(requested_major_minor)
     );
     let fake_corelib_src = dir.join("toolchain/corelib/src");
     create_mock_native_corelib(&fake_corelib_src);

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -1873,9 +1873,10 @@ cairo-version = "{compiler_major}.{}.0"
         .expect("older-minor manifest should parse");
         let err = ensure_native_manifest_cairo_version_supported(&older_minor_manifest)
             .expect_err("older minor cairo-version should be rejected");
+        let rendered = format!("{err:#}");
         assert!(
-            format!("{err:#}").contains("requires the same cairo major.minor"),
-            "error should explain that native compile requires the same major.minor"
+            rendered.contains("helper lane") || rendered.contains("same cairo major.minor"),
+            "error should explain that native compile needs a compatible lane: {rendered}"
         );
         assert!(
             native_error_allows_scarb_fallback(&err),
@@ -1895,9 +1896,11 @@ cairo-version = "{compiler_major}.{}.0"
     .expect("incompatible manifest should parse");
     let err = ensure_native_manifest_cairo_version_supported(&incompatible_manifest)
         .expect_err("newer minor cairo-version should be rejected");
+    let rendered = format!("{err:#}");
     assert!(
-        format!("{err:#}").contains("incompatible with package cairo-version"),
-        "error should describe cairo-version mismatch"
+        rendered.contains("helper lane")
+            || rendered.contains("incompatible with package cairo-version"),
+        "error should describe the required native lane: {rendered}"
     );
     assert!(
         native_error_allows_scarb_fallback(&err),
@@ -2064,7 +2067,7 @@ cairo-version = "{compiler_major}.{compiler_minor}.0"
         });
     let Some(requested_major_minor) = requested_major_minor else {
         fs::remove_dir_all(&dir).ok();
-        return;
+        panic!("expected at least one productized external helper lane different from the builtin compiler lane; unsupported-helper path was not exercised");
     };
     let helper_env = native_toolchain_env_var_name_for_major_minor(&requested_major_minor);
     let _helper = ScopedDynamicEnvVar::unset_with_lock(&_guard, helper_env);
@@ -2539,12 +2542,86 @@ starknet = "={requested_version}"
         }),
         "diagnostic should tell agents to keep this workload in the support matrix"
     );
+    assert!(
+        fixes.iter().all(|fix| !fix
+            .as_str()
+            .unwrap_or_default()
+            .contains("build_native_toolchain_helper")),
+        "agents must not be told to run the productized helper builder in how_to_fix for unsupported lanes"
+    );
     assert_eq!(json["toolchain"]["source"], "external_helper");
     assert_eq!(
         json["toolchain"]["requested_major_minor"],
         requested_major_minor
     );
     assert_eq!(json["toolchain"]["requested_version"], requested_version);
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn build_native_compile_context_rejects_unproductized_helper_lane() {
+    let _guard = integration_env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let requested_major_minor = "2.5";
+    let requested_version = "2.5.3";
+    let helper_env = native_toolchain_env_var_name_for_major_minor(requested_major_minor);
+    let _helper = ScopedDynamicEnvVar::unset_with_lock(&_guard, helper_env.clone());
+    assert!(
+        !native_toolchain_helper_lane_is_productized(requested_major_minor),
+        "this regression documents the current Cairo 2.5 build preflight boundary; update it when a real 2.5 adapter lands"
+    );
+
+    let dir = unique_test_dir("uc-native-context-unproductized-helper");
+    fs::create_dir_all(dir.join("src")).expect("failed to create src directory");
+    fs::write(dir.join("src/lib.cairo"), "fn main() {}\n").expect("failed to write lib.cairo");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo-native"
+version = "0.1.0"
+edition = "2023_11"
+cairo-version = "{requested_version}"
+
+[dependencies]
+starknet = "={requested_version}"
+"#
+        ),
+    )
+    .expect("failed to write manifest");
+
+    let common = BuildCommonArgs {
+        manifest_path: Some(manifest_path.clone()),
+        package: None,
+        workspace: false,
+        features: Vec::new(),
+        offline: true,
+        release: false,
+        profile: None,
+    };
+    let err = build_native_compile_context(&common, &manifest_path, &dir)
+        .expect_err("unproductized helper lane should fail during native build preflight");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("Cairo 2.5 helper lane"),
+        "error should classify the required helper lane: {rendered}"
+    );
+    assert!(
+        rendered.contains(&helper_env),
+        "error should expose the reviewed helper env var for manual adapters: {rendered}"
+    );
+    assert!(
+        rendered.contains("native-supported"),
+        "error should avoid marking this workload supported without a reviewed adapter: {rendered}"
+    );
+    assert!(
+        native_error_allows_scarb_fallback(&err),
+        "unproductized helper lane failures should remain scarb-fallback eligible"
+    );
 
     fs::remove_dir_all(&dir).ok();
 }

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -2103,6 +2103,33 @@ cairo-version = "{requested_major_minor}.0"
     );
 }
 
+#[cfg(feature = "native-compile")]
+#[test]
+fn productized_native_toolchain_helper_lanes_match_workspace_metadata() {
+    let workspace_manifest_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../Cargo.toml");
+    let workspace_manifest = fs::read_to_string(&workspace_manifest_path)
+        .expect("workspace Cargo.toml should be readable");
+    let workspace_manifest: TomlValue =
+        toml::from_str(&workspace_manifest).expect("workspace Cargo.toml should parse");
+    let helpers = workspace_manifest
+        .get("workspace")
+        .and_then(TomlValue::as_table)
+        .and_then(|workspace| workspace.get("metadata"))
+        .and_then(TomlValue::as_table)
+        .and_then(|metadata| metadata.get("uc-native-toolchain-helpers"))
+        .and_then(TomlValue::as_table)
+        .expect("workspace helper-builder metadata should exist");
+    let mut metadata_lanes = helpers.keys().cloned().collect::<Vec<_>>();
+    metadata_lanes.sort();
+    let mut packaged_lanes = productized_native_toolchain_helper_lanes();
+    packaged_lanes.sort();
+    assert_eq!(
+        packaged_lanes, metadata_lanes,
+        "PRODUCTIZED_NATIVE_TOOLCHAIN_HELPER_LANES must stay in sync with workspace.metadata.uc-native-toolchain-helpers"
+    );
+}
+
 #[cfg(all(feature = "native-compile", unix))]
 #[test]
 fn select_native_toolchain_from_manifest_path_uses_lockfile_lane_helper() {

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -2030,6 +2030,7 @@ edition = "2023_01"
 #[cfg(feature = "native-compile")]
 #[test]
 fn native_support_report_from_manifest_path_marks_supported_and_unsupported_manifests() {
+    let _guard = integration_env_lock().lock().unwrap();
     let dir = unique_test_dir("uc-native-support-report");
     fs::create_dir_all(&dir).expect("create temp dir");
     let manifest_path = dir.join("Scarb.toml");
@@ -2055,6 +2056,19 @@ cairo-version = "{compiler_major}.{compiler_minor}.0"
     assert!(supported_report.supported);
     assert!(supported_report.reason.is_none());
 
+    let requested_major_minor = productized_native_toolchain_helper_lanes()
+        .into_iter()
+        .find(|lane| {
+            parse_cairo_version_major_minor(lane)
+                .is_some_and(|lane_version| lane_version != (compiler_major, compiler_minor))
+        });
+    let Some(requested_major_minor) = requested_major_minor else {
+        fs::remove_dir_all(&dir).ok();
+        return;
+    };
+    let helper_env = native_toolchain_env_var_name_for_major_minor(&requested_major_minor);
+    let _helper = ScopedDynamicEnvVar::unset_with_lock(&_guard, helper_env);
+
     fs::write(
         &manifest_path,
         format!(
@@ -2062,9 +2076,8 @@ cairo-version = "{compiler_major}.{compiler_minor}.0"
 name = "demo"
 version = "0.1.0"
 edition = "2024_07"
-cairo-version = "{compiler_major}.{}.0"
-"#,
-            compiler_minor.saturating_add(1)
+cairo-version = "{requested_major_minor}.0"
+"#
         ),
     )
     .expect("write unsupported manifest");
@@ -2443,6 +2456,154 @@ cairo-version = "{requested_version}"
         requested_major_minor
     );
     assert_eq!(json["toolchain"]["requested_version"], requested_version);
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn native_support_report_from_manifest_path_reports_unproductized_helper_lane() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let requested_major_minor = "2.5";
+    let requested_version = "2.5.3";
+    let helper_env = native_toolchain_env_var_name_for_major_minor(requested_major_minor);
+    let _helper = ScopedDynamicEnvVar::unset_with_lock(&_guard, helper_env.clone());
+    assert!(
+        !native_toolchain_helper_lane_is_productized(requested_major_minor),
+        "this regression documents the current Cairo 2.5 boundary; update it when a real 2.5 adapter lands"
+    );
+
+    let dir = unique_test_dir("uc-native-support-unproductized-helper-lane");
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2023_11"
+cairo-version = "{requested_version}"
+
+[dependencies]
+starknet = "={requested_version}"
+"#
+        ),
+    )
+    .expect("write manifest");
+
+    let report = native_support_report_from_manifest_path(&manifest_path)
+        .expect("unproductized helper lane should still return support JSON");
+    assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert!(!report.supported);
+    assert_eq!(
+        report.issue_kind.as_deref(),
+        Some("unsupported_toolchain_helper_lane")
+    );
+    let json = serde_json::to_value(&report).expect("support report should serialize");
+    assert_eq!(json["diagnostics"][0]["code"], "UCN1006");
+    assert_eq!(
+        json["diagnostics"][0]["category"],
+        "toolchain_lane_unsupported"
+    );
+    assert_eq!(
+        json["diagnostics"][0]["safe_automated_action"],
+        "manual_legacy_adapter_required"
+    );
+    assert_eq!(
+        json["diagnostics"][0]["toolchain_expected"],
+        requested_major_minor
+    );
+    assert!(
+        json["diagnostics"][0]["toolchain_found"].is_null(),
+        "unproductized lane diagnostics should explicitly expose no found helper"
+    );
+    let commands = json["diagnostics"][0]["next_commands"]
+        .as_array()
+        .expect("next_commands should stay an array");
+    assert!(
+        commands.iter().all(|cmd| !cmd
+            .as_str()
+            .unwrap_or_default()
+            .contains("build_native_toolchain_helper")),
+        "agents must not be told to run the productized helper builder for unsupported lanes"
+    );
+    let fixes = json["diagnostics"][0]["how_to_fix"]
+        .as_array()
+        .expect("how_to_fix should stay an array");
+    assert!(
+        fixes.iter().any(|fix| {
+            fix.as_str()
+                .unwrap_or_default()
+                .contains("native_unsupported")
+        }),
+        "diagnostic should tell agents to keep this workload in the support matrix"
+    );
+    assert_eq!(json["toolchain"]["source"], "external_helper");
+    assert_eq!(
+        json["toolchain"]["requested_major_minor"],
+        requested_major_minor
+    );
+    assert_eq!(json["toolchain"]["requested_version"], requested_version);
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(all(feature = "native-compile", unix))]
+#[test]
+fn native_support_report_from_manifest_path_allows_reviewed_unproductized_helper_env() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let requested_major_minor = "2.5";
+    let requested_version = "2.5.3";
+    let helper_env = native_toolchain_env_var_name_for_major_minor(requested_major_minor);
+
+    let dir = unique_test_dir("uc-native-support-unproductized-helper-env");
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2023_11"
+cairo-version = "{requested_version}"
+"#
+        ),
+    )
+    .expect("write manifest");
+    let helper_path = dir.join("uc-cairo25-helper.sh");
+    write_fake_uc_support_helper(
+        &helper_path,
+        &NativeSupportReport {
+            schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+            manifest_path: manifest_path.display().to_string(),
+            status: NativeSupportStatus::Supported,
+            supported: true,
+            reason: None,
+            compiler_version: Some(requested_version.to_string()),
+            package_cairo_version: Some(requested_version.to_string()),
+            issue_kind: None,
+            toolchain: None,
+            diagnostics: Vec::new(),
+        },
+    );
+    let _helper = ScopedDynamicEnvVar::set_with_lock(&_guard, helper_env, &helper_path);
+
+    let report = native_support_report_from_manifest_path(&manifest_path)
+        .expect("reviewed external helper should be allowed even for unproductized lanes");
+    assert_eq!(report.status, NativeSupportStatus::Supported);
+    assert!(report.supported);
+    let toolchain = report.toolchain.expect("toolchain should be populated");
+    assert_eq!(toolchain.source, NativeToolchainSource::ExternalHelper);
+    assert_eq!(
+        toolchain.binary_path.as_deref(),
+        Some(helper_path.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        toolchain.compiler_version.as_deref(),
+        Some(requested_version)
+    );
 
     fs::remove_dir_all(&dir).ok();
 }

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -1950,8 +1950,8 @@ cairo-version = "{compiler_major}.{}.0"
             .expect_err("older minor cairo-version should be rejected");
         let rendered = format!("{err:#}");
         assert!(
-            rendered.contains("helper lane") || rendered.contains("same cairo major.minor"),
-            "error should explain that native compile needs a compatible lane: {rendered}"
+            rendered.contains("helper lane"),
+            "error should explain that native compile needs an explicit helper lane: {rendered}"
         );
         assert!(
             native_error_allows_scarb_fallback(&err),
@@ -1973,8 +1973,7 @@ cairo-version = "{compiler_major}.{}.0"
         .expect_err("newer minor cairo-version should be rejected");
     let rendered = format!("{err:#}");
     assert!(
-        rendered.contains("helper lane")
-            || rendered.contains("incompatible with package cairo-version"),
+        rendered.contains("helper lane"),
         "error should describe the required native lane: {rendered}"
     );
     assert!(
@@ -2103,6 +2102,53 @@ edition = "2023_01"
             .contains("could not resolve an exact Cairo toolchain for legacy edition 2023_01"),
         "report should explain why legacy floating manifests are unsupported"
     );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn native_support_report_from_manifest_path_rejects_non_exact_pinned_dependency_constraint() {
+    let dir = unique_test_dir("uc-native-support-report-invalid-pinned-dependency");
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2023_11"
+
+[dependencies]
+starknet = "=2.5.x"
+"#,
+    )
+    .expect("write invalid dependency manifest");
+
+    let report = native_support_report_from_manifest_path(&manifest_path)
+        .expect("invalid pinned dependency should still produce a report");
+    assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert!(!report.supported);
+    assert_eq!(
+        report.issue_kind.as_deref(),
+        Some("unsupported_manifest_constraint")
+    );
+    let json = serde_json::to_value(&report).expect("support report should serialize");
+    assert_eq!(json["diagnostics"][0]["code"], "UCN1002");
+    assert_eq!(json["diagnostics"][0]["toolchain_expected"], "=2.5.x");
+    assert_eq!(
+        json["toolchain"]["request_source"],
+        "manifest_dependency_version"
+    );
+    assert_eq!(json["toolchain"]["requested_version"], "=2.5.x");
+    assert!(
+        report
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("unsupported constraint `=2.5.x`"),
+        "report should classify malformed pinned dependency versions as unsupported constraints"
+    );
+
+    fs::remove_dir_all(&dir).ok();
 }
 
 #[cfg(feature = "native-compile")]
@@ -2678,6 +2724,8 @@ fn native_support_report_keeps_invalid_unproductized_helper_manual() {
     let requested_version = "2.5.3";
     let helper_env = native_toolchain_env_var_name_for_major_minor(requested_major_minor);
     let dir = unique_test_dir("uc-native-support-unproductized-helper-invalid");
+    fs::create_dir_all(dir.join("src")).expect("create src dir");
+    fs::write(dir.join("src/lib.cairo"), "fn main() {}\n").expect("write lib.cairo");
     let manifest_path = dir.join("Scarb.toml");
     fs::write(
         &manifest_path,
@@ -2724,6 +2772,38 @@ cairo-version = "{requested_version}"
             .unwrap_or_default()
             .contains("build_native_toolchain_helper")),
         "invalid helpers for unproductized lanes must stay on manual remediation"
+    );
+    let common = BuildCommonArgs {
+        manifest_path: Some(manifest_path.clone()),
+        package: None,
+        workspace: false,
+        features: Vec::new(),
+        offline: true,
+        release: false,
+        profile: None,
+    };
+    let err = build_native_compile_context(&common, &manifest_path, &dir)
+        .expect_err("invalid unproductized helper should fail build preflight");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("Cairo 2.5 helper lane"),
+        "build preflight should preserve the unsupported helper-lane branch: {rendered}"
+    );
+    assert!(
+        rendered.contains(&invalid_helper_path.display().to_string()),
+        "build preflight should name the invalid helper path: {rendered}"
+    );
+    assert!(
+        rendered.contains("reviewed"),
+        "build preflight should keep this path on manual reviewed-helper remediation: {rendered}"
+    );
+    assert!(
+        !rendered.contains("build_native_toolchain_helper"),
+        "build preflight must not tell agents to run the productized helper builder for unproductized lanes: {rendered}"
+    );
+    assert!(
+        native_error_allows_scarb_fallback(&err),
+        "invalid unproductized helper lane failures should remain scarb-fallback eligible"
     );
 
     fs::remove_dir_all(&dir).ok();

--- a/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
+++ b/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
@@ -104,6 +104,13 @@ The demo should show the agent path, not only the human path:
 6. Agent runs the benchmark/support matrix.
 7. Agent reports supported/fallback/build-failed cases without parsing terminal prose.
 
+The demo should also show the stop state:
+
+1. A Cairo lane is requested that this release does not productize.
+2. Agent reads `UCN1006` from JSON.
+3. Agent does not run the helper builder.
+4. Agent classifies the workload as `native_unsupported` with the diagnostic reason attached.
+
 ## Source-Backed Design Basis
 
 - AGENTS.md is the repo-instructions surface for coding agents: <https://agents.md/>

--- a/docs/NATIVE_TOOLCHAIN_HELPERS.md
+++ b/docs/NATIVE_TOOLCHAIN_HELPERS.md
@@ -48,7 +48,7 @@ The helper-lane compatibility shims are covered by targeted regressions for:
 
 If a repo needs an external helper lane, doctor will report the missing or invalid `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN` env var before a build starts.
 
-If a repo asks for a lane that is not productized by this release, `uc support native --format json` emits `UCN1006` with `safe_automated_action=manual_legacy_adapter_required`. Agents must keep that repo in the support matrix as `native_unsupported` unless a reviewed compatible helper binary is supplied explicitly through the reported helper env var.
+If a repo asks for a lane that is not productized by this release, `uc support native --manifest-path <Scarb.toml> --format json` emits `UCN1006` with `safe_automated_action=manual_legacy_adapter_required`. Agents must pass `--manifest-path` and keep that repo in the support matrix as `native_unsupported` unless a reviewed compatible helper binary is supplied explicitly through the reported helper env var.
 
 ## Cairo 2.5 Boundary
 

--- a/docs/NATIVE_TOOLCHAIN_HELPERS.md
+++ b/docs/NATIVE_TOOLCHAIN_HELPERS.md
@@ -4,6 +4,7 @@
 
 - The active binary provides the builtin lane for its baked-in `cairo-lang` version.
 - Older lanes, such as Cairo `2.14`, are supplied via external helper binaries.
+- Only lanes listed under `workspace.metadata.uc-native-toolchain-helpers` in `Cargo.toml` are productized for automatic helper building.
 
 ## Build The Cairo 2.14 Helper
 
@@ -45,3 +46,11 @@ The helper-lane compatibility shims are covered by targeted regressions for:
 ```
 
 If a repo needs an external helper lane, doctor will report the missing or invalid `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN` env var before a build starts.
+
+If a repo asks for a lane that is not productized by this release, `uc support native --format json` emits `UCN1006` with `safe_automated_action=manual_legacy_adapter_required`. Agents must keep that repo in the support matrix as `native_unsupported` unless a reviewed compatible helper binary is supplied explicitly through the reported helper env var.
+
+## Cairo 2.5 Boundary
+
+Cairo `2.5` is not a productized helper-builder lane in this release. It is older than the Cairo `2.6` split that introduced `cairo-lang-starknet-classes`, and it also predates several native compile APIs used by the current helper shim. Supporting it requires a dedicated legacy compatibility adapter rather than a metadata-only helper lane.
+
+Until that adapter exists, Cairo `2.5` workloads should be included in support matrices and classified as `native_unsupported`, not excluded from the benchmark/support story.

--- a/docs/NATIVE_TOOLCHAIN_HELPERS.md
+++ b/docs/NATIVE_TOOLCHAIN_HELPERS.md
@@ -5,6 +5,7 @@
 - The active binary provides the builtin lane for its baked-in `cairo-lang` version.
 - Older lanes, such as Cairo `2.14`, are supplied via external helper binaries.
 - Only lanes listed under `workspace.metadata.uc-native-toolchain-helpers` in `Cargo.toml` are productized for automatic helper building.
+- `uc-cli` also keeps a packaged productized-lane list for diagnostics, so packaged builds can emit `UCN1006` without depending on the workspace root manifest at compile time.
 
 ## Build The Cairo 2.14 Helper
 

--- a/docs/agent/AGENT_DIAGNOSTICS.md
+++ b/docs/agent/AGENT_DIAGNOSTICS.md
@@ -80,6 +80,14 @@ Configured native toolchain helper is invalid.
 - Safe action: `rebuild_helper_lane`
 - Agent behavior: rebuild the helper or point the environment variable at an executable helper binary.
 
+### UCN1006
+
+Native toolchain helper lane is not productized.
+
+- Category: `toolchain_lane_unsupported`
+- Safe action: `manual_legacy_adapter_required`
+- Agent behavior: do not run the helper builder for this lane. Keep the workload in the support matrix as `native_unsupported` unless a reviewed compatible helper binary is explicitly supplied or a dedicated compatibility adapter lands.
+
 ### UCN2001
 
 Native preflight downgraded to Scarb.
@@ -114,7 +122,7 @@ Agents may perform only safe actions by default:
 - `inspect_native_support_then_retry`
 - `use_native_enabled_binary`
 
-Agents must not edit Cairo source, dependency ranges, lockfiles, or release metadata unless the user or calling tool explicitly grants source-edit permission.
+Agents must not edit Cairo source, dependency ranges, lockfiles, release metadata, or legacy toolchain adapter code unless the user or calling tool explicitly grants source-edit permission. Diagnostics with `safe_automated_action=manual_legacy_adapter_required` are stop-and-report states, not autonomous fix states.
 
 ## Compatibility Notes
 

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -38,7 +38,7 @@ If diagnostic `UCN1004` has `safe_automated_action=build_helper_lane`, run the h
 
 Then export the printed env var and rerun support probing.
 
-If diagnostic `UCN1006` has `safe_automated_action=manual_legacy_adapter_required`, do not run the helper builder for that lane. Report the workload as `native_unsupported`, or use an explicitly reviewed helper binary via the reported `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN` env var.
+If diagnostic `UCN1006` has `safe_automated_action=manual_legacy_adapter_required`, do not run the helper builder for that lane. Report the workload as `native_unsupported`, or use an explicitly reviewed helper binary via the reported `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN` env var. After setting a reviewed helper env var, rerun `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN=/abs/path/to/helper-uc uc support native --manifest-path /abs/path/to/Scarb.toml --format json` before final classification; the rerun validates the helper and lets the lane proceed past `manual_legacy_adapter_required`.
 
 ## Build Report
 

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -38,6 +38,8 @@ If diagnostic `UCN1004` has `safe_automated_action=build_helper_lane`, run the h
 
 Then export the printed env var and rerun support probing.
 
+If diagnostic `UCN1006` has `safe_automated_action=manual_legacy_adapter_required`, do not run the helper builder for that lane. Report the workload as `native_unsupported`, or use an explicitly reviewed helper binary via the reported `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN` env var.
+
 ## Build Report
 
 ```sh

--- a/scripts/tests/doctor_test.sh
+++ b/scripts/tests/doctor_test.sh
@@ -34,7 +34,7 @@ if [[ "$manifest" == *"helper-missing"* ]]; then
   printf '{"manifest_path":"%s","status":"unsupported","supported":false,"reason":"native compile requires a Cairo 2.14.0 helper lane, but `UC_NATIVE_TOOLCHAIN_2_14_BIN` is unset","issue_kind":"missing_toolchain_helper","diagnostics":[{"code":"UCN1004","category":"toolchain_lane_unavailable","severity":"error","title":"Required native toolchain helper is missing","what_happened":"The project requires native Cairo 2.14.0, but `UC_NATIVE_TOOLCHAIN_2_14_BIN` is not configured.","why":"native compile requires a Cairo 2.14.0 helper lane, but `UC_NATIVE_TOOLCHAIN_2_14_BIN` is unset","how_to_fix":["Set `UC_NATIVE_TOOLCHAIN_2_14_BIN` to the path of a uc binary built with the required cairo-lang lane."],"retryable":false,"fallback_used":false,"toolchain_expected":"2.14.0","toolchain_found":null}]}
 ' "$manifest"
 elif [[ "$manifest" == *"helper-unproductized"* ]]; then
-  printf '{"manifest_path":"%s","status":"unsupported","supported":false,"reason":"native compile requires a Cairo 2.5 helper lane, but this release only productizes helper building for 2.14; keep this workload native_unsupported","issue_kind":"unsupported_toolchain_helper_lane","diagnostics":[{"code":"UCN1006","category":"toolchain_lane_unsupported","severity":"error","title":"Native toolchain helper lane is not productized","what_happened":"The project requires native Cairo 2.5, but this uc release cannot build that helper lane automatically.","why":"native compile requires a Cairo 2.5 helper lane, but this release only productizes helper building for 2.14","how_to_fix":["Keep this workload in the support matrix as native_unsupported."],"retryable":false,"fallback_used":false,"toolchain_expected":"2.5","toolchain_found":null}]}
+  printf '{"manifest_path":"%s","status":"unsupported","supported":false,"reason":"native compile requires a Cairo 2.5 helper lane, but this release only productizes helper building for 2.14; keep this workload native_unsupported","issue_kind":"unsupported_toolchain_helper_lane","diagnostics":[{"code":"UCN1006","category":"toolchain_lane_unsupported","severity":"error","title":"Native toolchain helper lane is not productized","what_happened":"The project requires native Cairo 2.5, but this uc release cannot build that helper lane automatically.","why":"native compile requires a Cairo 2.5 helper lane, but this release only productizes helper building for 2.14","how_to_fix":["Keep this workload in the support matrix as native_unsupported."],"safe_automated_action":"manual_legacy_adapter_required","retryable":false,"fallback_used":false,"toolchain_expected":"2.5","toolchain_found":null}]}
 ' "$manifest"
 elif [[ "$manifest" == *"/malformed-json/"* ]]; then
   printf '{"manifest_path":'
@@ -95,6 +95,12 @@ test_doctor_manifest_probe_warns_for_unproductized_helper_lane() {
   grep -q '\[ok\] native support .*supported/Scarb.toml' "$stdout_path"
   grep -q '\[warn\] native support .*helper-unproductized/Scarb.toml.*UCN1006' "$stdout_path"
   grep -q 'native_unsupported' "$stdout_path"
+  if grep 'helper-unproductized/Scarb.toml.*UCN1006' "$stdout_path" \
+    | grep -Eq 'build_native_toolchain_helper|build_helper_lane|safe_automated_action.*build_helper_lane'; then
+    echo "UCN1006 doctor warning must not suggest automated helper builds" >&2
+    cat "$stdout_path" >&2
+    return 1
+  fi
   grep -q 'doctor passed' "$stdout_path"
 }
 

--- a/scripts/tests/doctor_test.sh
+++ b/scripts/tests/doctor_test.sh
@@ -33,6 +33,9 @@ done
 if [[ "$manifest" == *"helper-missing"* ]]; then
   printf '{"manifest_path":"%s","status":"unsupported","supported":false,"reason":"native compile requires a Cairo 2.14.0 helper lane, but `UC_NATIVE_TOOLCHAIN_2_14_BIN` is unset","issue_kind":"missing_toolchain_helper","diagnostics":[{"code":"UCN1004","category":"toolchain_lane_unavailable","severity":"error","title":"Required native toolchain helper is missing","what_happened":"The project requires native Cairo 2.14.0, but `UC_NATIVE_TOOLCHAIN_2_14_BIN` is not configured.","why":"native compile requires a Cairo 2.14.0 helper lane, but `UC_NATIVE_TOOLCHAIN_2_14_BIN` is unset","how_to_fix":["Set `UC_NATIVE_TOOLCHAIN_2_14_BIN` to the path of a uc binary built with the required cairo-lang lane."],"retryable":false,"fallback_used":false,"toolchain_expected":"2.14.0","toolchain_found":null}]}
 ' "$manifest"
+elif [[ "$manifest" == *"helper-unproductized"* ]]; then
+  printf '{"manifest_path":"%s","status":"unsupported","supported":false,"reason":"native compile requires a Cairo 2.5 helper lane, but this release only productizes helper building for 2.14; keep this workload native_unsupported","issue_kind":"unsupported_toolchain_helper_lane","diagnostics":[{"code":"UCN1006","category":"toolchain_lane_unsupported","severity":"error","title":"Native toolchain helper lane is not productized","what_happened":"The project requires native Cairo 2.5, but this uc release cannot build that helper lane automatically.","why":"native compile requires a Cairo 2.5 helper lane, but this release only productizes helper building for 2.14","how_to_fix":["Keep this workload in the support matrix as native_unsupported."],"retryable":false,"fallback_used":false,"toolchain_expected":"2.5","toolchain_found":null}]}
+' "$manifest"
 elif [[ "$manifest" == *"/malformed-json/"* ]]; then
   printf '{"manifest_path":'
 else
@@ -74,6 +77,25 @@ test_doctor_manifest_probe_fails_for_missing_helper_lane() {
   grep -q '\[ok\] native support .*supported/Scarb.toml' "$stdout_path"
   grep -q '\[missing\] native support .*helper-missing/Scarb.toml.*UCN1004' "$stdout_path"
   grep -q 'UC_NATIVE_TOOLCHAIN_2_14_BIN' "$stdout_path"
+}
+
+test_doctor_manifest_probe_warns_for_unproductized_helper_lane() {
+  local cases_root="$TMP_DIR/unproductized-helper-cases"
+  local mock_bin_dir="$TMP_DIR/unproductized-helper-bin"
+  local mock_uc="$mock_bin_dir/uc"
+  local stdout_path="$TMP_DIR/unproductized-helper.out"
+  mkdir -p "$mock_bin_dir"
+  write_mock_uc_bin "$mock_uc"
+  write_manifest "$cases_root" supported
+  write_manifest "$cases_root" helper-unproductized
+
+  "$DOCTOR_SCRIPT" --uc-bin "$mock_uc" \
+    --manifest-path "$cases_root/supported/Scarb.toml" \
+    --manifest-path "$cases_root/helper-unproductized/Scarb.toml" >"$stdout_path" 2>&1
+  grep -q '\[ok\] native support .*supported/Scarb.toml' "$stdout_path"
+  grep -q '\[warn\] native support .*helper-unproductized/Scarb.toml.*UCN1006' "$stdout_path"
+  grep -q 'native_unsupported' "$stdout_path"
+  grep -q 'doctor passed' "$stdout_path"
 }
 
 test_doctor_requires_python_tomllib() {
@@ -233,6 +255,8 @@ test_doctor_manifest_probe_reports_invalid_json_without_aborting() {
 
 run_test "doctor_manifest_probe_fails_for_missing_helper_lane" \
   test_doctor_manifest_probe_fails_for_missing_helper_lane
+run_test "doctor_manifest_probe_warns_for_unproductized_helper_lane" \
+  test_doctor_manifest_probe_warns_for_unproductized_helper_lane
 run_test "doctor_requires_python_tomllib" \
   test_doctor_requires_python_tomllib
 run_test "doctor_manifest_probe_reports_missing_jq_without_aborting" \


### PR DESCRIPTION
## Summary

- Add `UCN1006` for Cairo lanes that are not productized by the helper builder, so agents do not try to build nonexistent helper lanes.
- Keep user-supplied reviewed helper binaries allowed through `UC_NATIVE_TOOLCHAIN_<major>_<minor>_BIN`.
- Document the Cairo 2.5 boundary and update agent quickstart/launch-minimum guidance.
- Add Rust and doctor-shell regressions for missing-vs-unproductized helper lanes.

## Validation

- `make bootstrap && make doctor && make agent-validate`
- `cargo test -p uc-cli native_support_report --features native-compile`
- `bash scripts/tests/doctor_test.sh`
- `make agent-validate`
- `make local-ci`
- pre-push hook: `make local-ci`
- Real manifest probe: Braavos factory Cairo 2.5.3 now reports `issue_kind=unsupported_toolchain_helper_lane`, diagnostic `UCN1006`, action `manual_legacy_adapter_required`.

## Notes

This does not claim Cairo 2.5 native support. It makes the support matrix and agent behavior truthful: Cairo 2.5 remains `native_unsupported` until a dedicated legacy adapter or reviewed helper binary exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distinguishes productized vs non-productized native helper lanes; emits UCN1006 with remediation hints and blocks native requests for unproductized lanes unless a reviewed helper is supplied.

* **Bug Fixes**
  * More deterministic toolchain/lane selection and manifest parsing; avoids silent fallback to missing/invalid helpers.

* **Documentation**
  * Clarified native helper policy (including Cairo 2.5) and UCN1006 guidance; updated agent quickstart and diagnostics.

* **Tests**
  * Expanded tests for UCN1006, preflight/daemon gating, and deterministic reporting; test harness treats UCN1006 as a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->