### PR TITLE
[codex] Add source-kind guard to deployed corpus evidence

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -170,6 +170,10 @@ each item to a local `Scarb.toml`, runs `run_real_repo_benchmarks.sh`, and emits
 a combined JSON/Markdown artifact with:
 
 - the pinned chain/snapshot/block-range selection,
+- a per-item `source_kind`:
+  - `deployed_contract` rows must include `contract_address`
+  - `declared_class` rows benchmark class source evidence but do not count as
+    deployed-contract coverage
 - deduplication and source/license policy metadata,
 - Cairo version min/max across the corpus,
 - a support matrix for `native_supported`, `native_unsupported`,
@@ -178,8 +182,8 @@ a combined JSON/Markdown artifact with:
   - `.claim_guard.compiled_all_claim_text` only when
     `.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus=true`;
     this requires `coverage=complete_deployed_contracts`, every item classified
-    as `native_supported`, no fallback, no unsupported rows, no build failures,
-    and no failed native benchmark cases
+    as `source_kind=deployed_contract` and `native_supported`, no fallback, no
+    unsupported rows, no build failures, and no failed native benchmark cases
   - `.claim_guard.native_supported_claim_text` only when
     `.claim_guard.safe_to_say_all_items_native_supported=true`
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -174,6 +174,9 @@ a combined JSON/Markdown artifact with:
   - `deployed_contract` rows must include `contract_address`
   - `declared_class` rows benchmark class source evidence but do not count as
     deployed-contract coverage
+  - legacy rows without `source_kind` are read as `deployed_contract` for
+    backward compatibility, but new reviewed inventories should set it
+    explicitly
 - deduplication and source/license policy metadata,
 - Cairo version min/max across the corpus,
 - a support matrix for `native_supported`, `native_unsupported`,

--- a/benchmarks/corpora/deployed-contract-corpus.example.json
+++ b/benchmarks/corpora/deployed-contract-corpus.example.json
@@ -20,6 +20,7 @@
   "items": [
     {
       "tag": "example-contract",
+      "source_kind": "deployed_contract",
       "contract_address": "0x0",
       "class_hash": "0x0",
       "source_ref": "local fixture",

--- a/benchmarks/corpora/deployed-contract-corpus.schema.json
+++ b/benchmarks/corpora/deployed-contract-corpus.schema.json
@@ -40,13 +40,17 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["tag", "source_kind", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "required": ["tag", "class_hash", "source_ref", "manifest_path", "cairo_version"],
         "allOf": [
           {
             "if": {
               "properties": { "source_kind": { "const": "deployed_contract" } },
               "required": ["source_kind"]
             },
+            "then": { "required": ["contract_address"] }
+          },
+          {
+            "if": { "not": { "required": ["source_kind"] } },
             "then": { "required": ["contract_address"] }
           }
         ],

--- a/benchmarks/corpora/deployed-contract-corpus.schema.json
+++ b/benchmarks/corpora/deployed-contract-corpus.schema.json
@@ -40,9 +40,22 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["tag", "contract_address", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "required": ["tag", "source_kind", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "allOf": [
+          {
+            "if": {
+              "properties": { "source_kind": { "const": "deployed_contract" } },
+              "required": ["source_kind"]
+            },
+            "then": { "required": ["contract_address"] }
+          }
+        ],
         "properties": {
           "tag": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+          "source_kind": {
+            "enum": ["deployed_contract", "declared_class"],
+            "description": "Whether this row represents a deployed contract address or declared class source evidence."
+          },
           "contract_address": { "type": "string", "minLength": 1 },
           "class_hash": { "type": "string", "minLength": 1 },
           "source_ref": { "type": "string", "minLength": 1 },

--- a/benchmarks/corpora/deployed-contract-source-index.example.json
+++ b/benchmarks/corpora/deployed-contract-source-index.example.json
@@ -24,6 +24,7 @@
   "items": [
     {
       "tag": "sample_scarb_smoke",
+      "source_kind": "deployed_contract",
       "contract_address": "0x0",
       "class_hash": "0xsample",
       "source_ref": "benchmarks/corpora/source-fixtures/scarb_smoke in this repository",

--- a/benchmarks/corpora/deployed-contract-source-index.schema.json
+++ b/benchmarks/corpora/deployed-contract-source-index.schema.json
@@ -58,13 +58,17 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["tag", "source_kind", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "required": ["tag", "class_hash", "source_ref", "manifest_path", "cairo_version"],
         "allOf": [
           {
             "if": {
               "properties": { "source_kind": { "const": "deployed_contract" } },
               "required": ["source_kind"]
             },
+            "then": { "required": ["contract_address"] }
+          },
+          {
+            "if": { "not": { "required": ["source_kind"] } },
             "then": { "required": ["contract_address"] }
           }
         ],

--- a/benchmarks/corpora/deployed-contract-source-index.schema.json
+++ b/benchmarks/corpora/deployed-contract-source-index.schema.json
@@ -58,9 +58,22 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["tag", "contract_address", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "required": ["tag", "source_kind", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "allOf": [
+          {
+            "if": {
+              "properties": { "source_kind": { "const": "deployed_contract" } },
+              "required": ["source_kind"]
+            },
+            "then": { "required": ["contract_address"] }
+          }
+        ],
         "properties": {
           "tag": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+          "source_kind": {
+            "enum": ["deployed_contract", "declared_class"],
+            "description": "Whether this row represents a deployed contract address or declared class source evidence."
+          },
           "contract_address": { "type": "string", "minLength": 1 },
           "class_hash": { "type": "string", "minLength": 1 },
           "source_ref": { "type": "string", "minLength": 1 },

--- a/benchmarks/corpora/deployed-contract-source-inventory.example.json
+++ b/benchmarks/corpora/deployed-contract-source-inventory.example.json
@@ -22,6 +22,7 @@
   "records": [
     {
       "tag": "sample_counter",
+      "source_kind": "deployed_contract",
       "contract_address": "0x0123",
       "class_hash": "0x0456",
       "source_ref": "benchmarks/corpora/source-fixtures/scarb_smoke in this repository",

--- a/benchmarks/corpora/deployed-contract-source-inventory.schema.json
+++ b/benchmarks/corpora/deployed-contract-source-inventory.schema.json
@@ -83,13 +83,17 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["tag", "source_kind", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "required": ["tag", "class_hash", "source_ref", "manifest_path", "cairo_version"],
         "allOf": [
           {
             "if": {
               "properties": { "source_kind": { "const": "deployed_contract" } },
               "required": ["source_kind"]
             },
+            "then": { "required": ["contract_address"] }
+          },
+          {
+            "if": { "not": { "required": ["source_kind"] } },
             "then": { "required": ["contract_address"] }
           }
         ],

--- a/benchmarks/corpora/deployed-contract-source-inventory.schema.json
+++ b/benchmarks/corpora/deployed-contract-source-inventory.schema.json
@@ -83,9 +83,22 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["tag", "contract_address", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "required": ["tag", "source_kind", "class_hash", "source_ref", "manifest_path", "cairo_version"],
+        "allOf": [
+          {
+            "if": {
+              "properties": { "source_kind": { "const": "deployed_contract" } },
+              "required": ["source_kind"]
+            },
+            "then": { "required": ["contract_address"] }
+          }
+        ],
         "properties": {
           "tag": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+          "source_kind": {
+            "enum": ["deployed_contract", "declared_class"],
+            "description": "Whether this row represents a deployed contract address or declared class source evidence."
+          },
           "contract_address": { "type": "string", "minLength": 1 },
           "class_hash": { "type": "string", "minLength": 1 },
           "source_ref": { "type": "string", "minLength": 1 },

--- a/benchmarks/scripts/build_deployed_contract_source_index.sh
+++ b/benchmarks/scripts/build_deployed_contract_source_index.sh
@@ -119,6 +119,7 @@ DEDUP_KEYS = {"key", "rules"}
 SOURCE_AVAILABILITY_KEYS = {"policy", "notes"}
 RECORD_KEYS = {
     "tag",
+    "source_kind",
     "contract_address",
     "class_hash",
     "source_ref",
@@ -131,6 +132,7 @@ RECORD_KEYS = {
 }
 SOURCE_INDEX_ITEM_KEYS = {
     "tag",
+    "source_kind",
     "contract_address",
     "class_hash",
     "source_ref",
@@ -265,6 +267,13 @@ for index, raw_record in enumerate(records):
     seen_tags.add(tag)
 
     class_hash = require_str(record, "class_hash", f"inventory.records[{index}]")
+    source_kind = require_str(record, "source_kind", f"inventory.records[{index}]")
+    if source_kind not in {"deployed_contract", "declared_class"}:
+        fail(f"inventory.records[{index}].source_kind must be deployed_contract or declared_class")
+    if source_kind == "deployed_contract":
+        require_str(record, "contract_address", f"inventory.records[{index}]")
+    else:
+        optional_str(record, "contract_address", f"inventory.records[{index}]")
     manifest_raw = require_str(record, "manifest_path", f"inventory.records[{index}]")
     manifest_path = resolve_manifest_path(manifest_raw, tag)
     source_package_id = record.get("source_package_id")
@@ -275,7 +284,7 @@ for index, raw_record in enumerate(records):
 
     normalized = {key: record[key] for key in SOURCE_INDEX_ITEM_KEYS if key in record}
     normalized["manifest_path"] = os.path.relpath(manifest_path, out_dir)
-    normalized["contract_address"] = require_str(record, "contract_address", f"inventory.records[{index}]")
+    normalized["source_kind"] = source_kind
     normalized["source_ref"] = require_str(record, "source_ref", f"inventory.records[{index}]")
     normalized["cairo_version"] = require_str(record, "cairo_version", f"inventory.records[{index}]")
     for optional_key in ["scarb_version", "license", "notes"]:

--- a/benchmarks/scripts/build_deployed_contract_source_index.sh
+++ b/benchmarks/scripts/build_deployed_contract_source_index.sh
@@ -184,6 +184,13 @@ def optional_str(obj, key, ctx):
         fail(f"{ctx}.{key} must be a string")
 
 
+def optional_non_empty_str(obj, key, ctx):
+    if key in obj:
+        value = obj.get(key)
+        if not isinstance(value, str) or not value:
+            fail(f"{ctx}.{key} must be a non-empty string")
+
+
 def require_int(obj, key, ctx):
     value = obj.get(key)
     if type(value) is not int or value < 0:
@@ -267,13 +274,15 @@ for index, raw_record in enumerate(records):
     seen_tags.add(tag)
 
     class_hash = require_str(record, "class_hash", f"inventory.records[{index}]")
-    source_kind = require_str(record, "source_kind", f"inventory.records[{index}]")
+    source_kind = record.get("source_kind", "deployed_contract")
+    if not isinstance(source_kind, str) or not source_kind:
+        fail(f"inventory.records[{index}].source_kind must be deployed_contract or declared_class")
     if source_kind not in {"deployed_contract", "declared_class"}:
         fail(f"inventory.records[{index}].source_kind must be deployed_contract or declared_class")
     if source_kind == "deployed_contract":
         require_str(record, "contract_address", f"inventory.records[{index}]")
     else:
-        optional_str(record, "contract_address", f"inventory.records[{index}]")
+        optional_non_empty_str(record, "contract_address", f"inventory.records[{index}]")
     manifest_raw = require_str(record, "manifest_path", f"inventory.records[{index}]")
     manifest_path = resolve_manifest_path(manifest_raw, tag)
     source_package_id = record.get("source_package_id")

--- a/benchmarks/scripts/generate_deployed_contract_corpus.sh
+++ b/benchmarks/scripts/generate_deployed_contract_corpus.sh
@@ -151,6 +151,12 @@ def optional_str(obj, key, ctx):
     if key in obj and not isinstance(obj.get(key), str):
         fail(f"{ctx}.{key} must be a string")
 
+def optional_non_empty_str(obj, key, ctx):
+    if key in obj:
+        value = obj.get(key)
+        if not isinstance(value, str) or not value:
+            fail(f"{ctx}.{key} must be a non-empty string")
+
 def require_int(obj, key, ctx):
     value = obj.get(key)
     if type(value) is not int or value < 0:
@@ -237,13 +243,15 @@ for index, raw_item in enumerate(items):
     seen_tags.add(tag)
 
     class_hash = require_str(item, "class_hash", f"source_index.items[{index}]")
-    source_kind = require_str(item, "source_kind", f"source_index.items[{index}]")
+    source_kind = item.get("source_kind", "deployed_contract")
+    if not isinstance(source_kind, str) or not source_kind:
+        fail(f"source_index.items[{index}].source_kind must be deployed_contract or declared_class")
     if source_kind not in {"deployed_contract", "declared_class"}:
         fail(f"source_index.items[{index}].source_kind must be deployed_contract or declared_class")
     if source_kind == "deployed_contract":
         require_str(item, "contract_address", f"source_index.items[{index}]")
     else:
-        optional_str(item, "contract_address", f"source_index.items[{index}]")
+        optional_non_empty_str(item, "contract_address", f"source_index.items[{index}]")
     if dedupe_key == "class_hash":
         if class_hash in seen_class_hashes:
             fail(f"duplicate class_hash in class_hash-deduped source index: {class_hash}")

--- a/benchmarks/scripts/generate_deployed_contract_corpus.sh
+++ b/benchmarks/scripts/generate_deployed_contract_corpus.sh
@@ -107,6 +107,7 @@ DEDUP_KEYS = {"key", "input_count", "deduped_count", "rules"}
 SOURCE_AVAILABILITY_KEYS = {"policy", "notes"}
 ITEM_KEYS = {
     "tag",
+    "source_kind",
     "contract_address",
     "class_hash",
     "source_ref",
@@ -236,6 +237,13 @@ for index, raw_item in enumerate(items):
     seen_tags.add(tag)
 
     class_hash = require_str(item, "class_hash", f"source_index.items[{index}]")
+    source_kind = require_str(item, "source_kind", f"source_index.items[{index}]")
+    if source_kind not in {"deployed_contract", "declared_class"}:
+        fail(f"source_index.items[{index}].source_kind must be deployed_contract or declared_class")
+    if source_kind == "deployed_contract":
+        require_str(item, "contract_address", f"source_index.items[{index}]")
+    else:
+        optional_str(item, "contract_address", f"source_index.items[{index}]")
     if dedupe_key == "class_hash":
         if class_hash in seen_class_hashes:
             fail(f"duplicate class_hash in class_hash-deduped source index: {class_hash}")
@@ -246,7 +254,7 @@ for index, raw_item in enumerate(items):
 
     normalized = {key: item[key] for key in ITEM_KEYS if key in item}
     normalized["manifest_path"] = str(manifest_path)
-    normalized["contract_address"] = require_str(item, "contract_address", f"source_index.items[{index}]")
+    normalized["source_kind"] = source_kind
     normalized["source_ref"] = require_str(item, "source_ref", f"source_index.items[{index}]")
     normalized["cairo_version"] = require_str(item, "cairo_version", f"source_index.items[{index}]")
     for optional_key in ["scarb_version", "license", "notes"]:

--- a/benchmarks/scripts/run_deployed_contract_corpus.sh
+++ b/benchmarks/scripts/run_deployed_contract_corpus.sh
@@ -262,6 +262,7 @@ for index, item in enumerate(items):
         item,
         {
             "tag",
+            "source_kind",
             "contract_address",
             "class_hash",
             "source_ref",
@@ -280,6 +281,13 @@ for index, item in enumerate(items):
         fail(f"duplicate corpus item tag: {tag}")
     seen_tags.add(tag)
     class_hash = require_str(item, "class_hash", f"corpus.items[{index}]")
+    source_kind = require_str(item, "source_kind", f"corpus.items[{index}]")
+    if source_kind not in {"deployed_contract", "declared_class"}:
+        fail(f"corpus.items[{index}].source_kind must be deployed_contract or declared_class")
+    if source_kind == "deployed_contract":
+        require_str(item, "contract_address", f"corpus.items[{index}]")
+    else:
+        optional_str(item, "contract_address", f"corpus.items[{index}]")
     if dedupe_key == "class_hash":
         if class_hash in seen_class_hashes:
             fail(f"duplicate class_hash in class_hash-deduped corpus: {class_hash}")
@@ -293,7 +301,7 @@ for index, item in enumerate(items):
         fail(f"manifest_path does not exist for {tag}: {manifest_path}")
     normalized = dict(item)
     normalized["manifest_path"] = str(manifest_path)
-    normalized["contract_address"] = require_str(item, "contract_address", f"corpus.items[{index}]")
+    normalized["source_kind"] = source_kind
     normalized["source_ref"] = require_str(item, "source_ref", f"corpus.items[{index}]")
     normalized["cairo_version"] = require_str(item, "cairo_version", f"corpus.items[{index}]")
     for optional_key in ["scarb_version", "license", "notes"]:
@@ -306,6 +314,10 @@ normalized_doc["items"] = normalized_items
 normalized_doc["summary"] = {
     "item_count": len(normalized_items),
     "unique_class_hash_count": len({item["class_hash"] for item in normalized_items}),
+    "source_kind_counts": {
+        kind: sum(1 for item in normalized_items if item["source_kind"] == kind)
+        for kind in sorted({item["source_kind"] for item in normalized_items})
+    },
     "cairo_version_min": versions[0],
     "cairo_version_max": versions[-1],
     "cairo_versions": versions,
@@ -382,10 +394,13 @@ jq -n \
   --slurpfile bench "$REAL_JSON" \
   'def counts: $bench[0].summary.support_matrix;
    def item_count: ($corpus[0].summary.item_count // 0);
+   def non_deployed_item_count:
+     ([ $corpus[0].items[] | select(.source_kind != "deployed_contract") ] | length);
    def failed_native_benchmarks:
      ([ $bench[0].cases[] | select(.benchmark_status == "failed") ] | length);
    def compiled_all:
      ($corpus[0].selection.coverage == "complete_deployed_contracts")
+     and (non_deployed_item_count == 0)
      and ((counts.native_supported // 0) == item_count)
      and ((counts.fallback_used // 0) == 0)
      and ((counts.native_unsupported // 0) == 0)
@@ -404,6 +419,7 @@ jq -n \
      summary: {
        item_count: $corpus[0].summary.item_count,
        unique_class_hash_count: $corpus[0].summary.unique_class_hash_count,
+       source_kind_counts: ($corpus[0].summary.source_kind_counts // {}),
        cairo_version_min: $corpus[0].summary.cairo_version_min,
        cairo_version_max: $corpus[0].summary.cairo_version_max,
        support_matrix: counts,
@@ -415,6 +431,8 @@ jq -n \
        reason: (
          if $corpus[0].selection.coverage != "complete_deployed_contracts" then
            "corpus selection coverage is sample, not complete_deployed_contracts"
+         elif non_deployed_item_count != 0 then
+           "corpus contains non-deployed source_kind rows"
          elif (counts.fallback_used // 0) != 0 then
            "one or more corpus items used fallback"
          elif (counts.native_unsupported // 0) != 0 then
@@ -478,12 +496,21 @@ jq -n \
     | "| \(.key) | \(.value) |"
   ' "$OUT_JSON"
   echo
+  echo "## Source Kind Summary"
+  echo "| Source Kind | Count |"
+  echo "|---|---:|"
+  jq -r '
+    .summary.source_kind_counts
+    | to_entries[]
+    | "| \(.key) | \(.value) |"
+  ' "$OUT_JSON"
+  echo
   echo "## Corpus Items"
-  echo "| Tag | Contract Address | Class Hash | Cairo Version | Source Ref | Manifest |"
-  echo "|---|---|---|---|---|---|"
+  echo "| Tag | Source Kind | Address/Class Ref | Class Hash | Cairo Version | Source Ref | Manifest |"
+  echo "|---|---|---|---|---|---|---|"
   jq -r '
     .corpus.items[]
-    | "| \(.tag) | \(.contract_address) | \(.class_hash) | \(.cairo_version) | \(.source_ref) | \(.manifest_path) |"
+    | "| \(.tag) | \(.source_kind) | \(if .source_kind == "deployed_contract" then .contract_address else "declared-class:" + .class_hash end) | \(.class_hash) | \(.cairo_version) | \(.source_ref) | \(.manifest_path) |"
   ' "$OUT_JSON"
   echo
   echo "## Real Repo Benchmark Summary"

--- a/benchmarks/scripts/run_deployed_contract_corpus.sh
+++ b/benchmarks/scripts/run_deployed_contract_corpus.sh
@@ -189,6 +189,12 @@ def optional_str(obj, key, ctx):
     if key in obj and not isinstance(obj.get(key), str):
         fail(f"{ctx}.{key} must be a string")
 
+def optional_non_empty_str(obj, key, ctx):
+    if key in obj:
+        value = obj.get(key)
+        if not isinstance(value, str) or not value:
+            fail(f"{ctx}.{key} must be a non-empty string")
+
 def require_int(obj, key, ctx):
     value = obj.get(key)
     if type(value) is not int or value < 0:
@@ -281,13 +287,15 @@ for index, item in enumerate(items):
         fail(f"duplicate corpus item tag: {tag}")
     seen_tags.add(tag)
     class_hash = require_str(item, "class_hash", f"corpus.items[{index}]")
-    source_kind = require_str(item, "source_kind", f"corpus.items[{index}]")
+    source_kind = item.get("source_kind", "deployed_contract")
+    if not isinstance(source_kind, str) or not source_kind:
+        fail(f"corpus.items[{index}].source_kind must be deployed_contract or declared_class")
     if source_kind not in {"deployed_contract", "declared_class"}:
         fail(f"corpus.items[{index}].source_kind must be deployed_contract or declared_class")
     if source_kind == "deployed_contract":
         require_str(item, "contract_address", f"corpus.items[{index}]")
     else:
-        optional_str(item, "contract_address", f"corpus.items[{index}]")
+        optional_non_empty_str(item, "contract_address", f"corpus.items[{index}]")
     if dedupe_key == "class_hash":
         if class_hash in seen_class_hashes:
             fail(f"duplicate class_hash in class_hash-deduped corpus: {class_hash}")

--- a/benchmarks/scripts/tests/build_deployed_contract_source_index_test.sh
+++ b/benchmarks/scripts/tests/build_deployed_contract_source_index_test.sh
@@ -266,6 +266,37 @@ test_accepts_declared_class_without_contract_address() {
   fi
 }
 
+test_rejects_empty_declared_class_contract_address() {
+  local inventory_dir="$TEST_TMP_DIR/declared-class-empty/inventory"
+  local case_root="$inventory_dir/cases"
+  mkdir -p "$inventory_dir"
+  write_manifest_case "$case_root" "a"
+  local record
+  record="$(inventory_record_json class_only "cases/a/Scarb.toml" "0xclass" "2.14.0")"
+  write_inventory_file "$inventory_dir/inventory.json" sample class_hash "$record"
+  mutate_inventory "$inventory_dir/inventory.json" '.records[0].source_kind = "declared_class" | .records[0].contract_address = ""'
+  expect_builder_failure "$inventory_dir/inventory.json" "inventory.records[0].contract_address must be a non-empty string"
+}
+
+test_normalizes_legacy_missing_source_kind_as_deployed_contract() {
+  local inventory_dir="$TEST_TMP_DIR/legacy-source-kind/inventory"
+  local case_root="$inventory_dir/cases"
+  mkdir -p "$inventory_dir"
+  write_manifest_case "$case_root" "a"
+  local record source_index_path stdout_text
+  record="$(inventory_record_json legacy "cases/a/Scarb.toml" "0xlegacy" "2.14.0")"
+  write_inventory_file "$inventory_dir/inventory.json" sample class_hash "$record"
+  mutate_inventory "$inventory_dir/inventory.json" 'del(.records[0].source_kind)'
+
+  stdout_text="$("$BUILDER_SCRIPT" --inventory "$inventory_dir/inventory.json" --out "$inventory_dir/source-index.json")"
+  source_index_path="$(extract_labeled_path "Source index JSON" <<<"$stdout_text")"
+  if [[ "$(jq -r '.items[0].source_kind' "$source_index_path")" != "deployed_contract" ]]; then
+    echo "legacy missing source_kind should normalize to deployed_contract" >&2
+    cat "$source_index_path" >&2
+    return 1
+  fi
+}
+
 test_rejects_outside_output_directory() {
   local inventory_dir="$TEST_TMP_DIR/outside-out/inventory"
   local case_root="$inventory_dir/cases"
@@ -316,6 +347,8 @@ run_test "rejects manifest path traversal" test_rejects_manifest_path_traversal
 run_test "rejects source_package dedupe without id" test_rejects_source_package_dedupe_without_id
 run_test "rejects null source_package_id when present" test_rejects_null_source_package_id_when_present
 run_test "accepts declared_class without contract_address" test_accepts_declared_class_without_contract_address
+run_test "rejects empty declared_class contract_address" test_rejects_empty_declared_class_contract_address
+run_test "normalizes legacy missing source_kind as deployed_contract" test_normalizes_legacy_missing_source_kind_as_deployed_contract
 run_test "rejects outside output directory" test_rejects_outside_output_directory
 run_test "rejects inventory output overwrite aliases" test_rejects_inventory_output_overwrite_aliases
 

--- a/benchmarks/scripts/tests/build_deployed_contract_source_index_test.sh
+++ b/benchmarks/scripts/tests/build_deployed_contract_source_index_test.sh
@@ -63,6 +63,7 @@ inventory_record_json() {
     --arg source_package_id "$source_package_id" \
     '{
       tag: $tag,
+      source_kind: "deployed_contract",
       contract_address: "0x123",
       class_hash: $class_hash,
       source_ref: "local inventory fixture",
@@ -246,6 +247,25 @@ test_rejects_null_source_package_id_when_present() {
   expect_builder_failure "$inventory_dir/inventory.json" "inventory.records[0].source_package_id must be a non-empty string"
 }
 
+test_accepts_declared_class_without_contract_address() {
+  local inventory_dir="$TEST_TMP_DIR/declared-class/inventory"
+  local case_root="$inventory_dir/cases"
+  mkdir -p "$inventory_dir"
+  write_manifest_case "$case_root" "a"
+  local record source_index_path stdout_text
+  record="$(inventory_record_json class_only "cases/a/Scarb.toml" "0xclass" "2.14.0")"
+  write_inventory_file "$inventory_dir/inventory.json" sample class_hash "$record"
+  mutate_inventory "$inventory_dir/inventory.json" '.records[0].source_kind = "declared_class" | del(.records[0].contract_address)'
+
+  stdout_text="$("$BUILDER_SCRIPT" --inventory "$inventory_dir/inventory.json" --out "$inventory_dir/source-index.json")"
+  source_index_path="$(extract_labeled_path "Source index JSON" <<<"$stdout_text")"
+  if [[ "$(jq -r '.items[0].source_kind' "$source_index_path")" != "declared_class" || "$(jq -r '.items[0] | has("contract_address")' "$source_index_path")" != "false" ]]; then
+    echo "declared class source-index row should not require or synthesize contract_address" >&2
+    cat "$source_index_path" >&2
+    return 1
+  fi
+}
+
 test_rejects_outside_output_directory() {
   local inventory_dir="$TEST_TMP_DIR/outside-out/inventory"
   local case_root="$inventory_dir/cases"
@@ -295,6 +315,7 @@ run_test "rejects duplicate tags and absolute manifest" test_rejects_duplicate_t
 run_test "rejects manifest path traversal" test_rejects_manifest_path_traversal
 run_test "rejects source_package dedupe without id" test_rejects_source_package_dedupe_without_id
 run_test "rejects null source_package_id when present" test_rejects_null_source_package_id_when_present
+run_test "accepts declared_class without contract_address" test_accepts_declared_class_without_contract_address
 run_test "rejects outside output directory" test_rejects_outside_output_directory
 run_test "rejects inventory output overwrite aliases" test_rejects_inventory_output_overwrite_aliases
 

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -260,6 +260,7 @@ item_json() {
     --arg cairo_version "$cairo_version" \
     '{
       tag: $tag,
+      source_kind: "deployed_contract",
       contract_address: "0x123",
       class_hash: $class_hash,
       source_ref: "local test fixture",
@@ -616,6 +617,49 @@ test_complete_supported_corpus_emits_bounded_claim() {
   assert_contains "$markdown_text" "Compiled-all claim: We compiled every contract"
 }
 
+test_complete_corpus_with_declared_class_blocks_deployed_claim() {
+  local corpus_dir="$TEST_TMP_DIR/declared-class/corpora"
+  local case_root="$TEST_TMP_DIR/declared-class/cases"
+  local results_dir="$TEST_TMP_DIR/declared-class/results"
+  local mock_bin_dir="$TEST_TMP_DIR/declared-class/mock-bin"
+  mkdir -p "$corpus_dir" "$case_root" "$results_dir" "$mock_bin_dir"
+  write_manifest_case "$case_root" "class-only"
+  write_mock_uc_bin "$mock_bin_dir/uc"
+  write_mock_scarb_bin "$mock_bin_dir/scarb"
+
+  local item stdout_text json_path md_path safe reason source_kind_count claim markdown_text
+  item="$(item_json class-only "../cases/class-only/Scarb.toml" "0xclass" "2.14.0")"
+  item="$(jq '.source_kind = "declared_class" | del(.contract_address)' <<<"$item")"
+  write_corpus_file "$corpus_dir/corpus.json" complete_deployed_contracts class_hash "$item"
+
+  stdout_text="$(
+    PATH="$mock_bin_dir:$PATH" \
+    MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/declared-class/uc.args" \
+    MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/declared-class/scarb.args" \
+    "$CORPUS_SCRIPT" \
+      --uc-bin "$mock_bin_dir/uc" \
+      --results-dir "$results_dir" \
+      --runs 1 \
+      --cold-runs 1 \
+      --warm-settle-seconds 0 \
+      --corpus "$corpus_dir/corpus.json"
+  )"
+
+  json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
+  md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
+  safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
+  reason="$(jq -r '.claim_guard.reason' "$json_path")"
+  source_kind_count="$(jq -r '.summary.source_kind_counts.declared_class' "$json_path")"
+  claim="$(jq -r '.claim_guard.compiled_all_claim_text // ""' "$json_path")"
+  markdown_text="$(cat "$md_path")"
+  if [[ "$safe" != "false" || "$reason" != "corpus contains non-deployed source_kind rows" || "$source_kind_count" != "1" || -n "$claim" ]]; then
+    echo "declared_class corpus item should block deployed-contract launch claim" >&2
+    cat "$json_path" >&2
+    return 1
+  fi
+  assert_contains "$markdown_text" "| class-only | declared_class | declared-class:0xclass |"
+}
+
 run_test "plan_only_normalizes_sample_corpus" \
   test_plan_only_normalizes_sample_corpus
 run_test "rejects_duplicate_tags" \
@@ -636,3 +680,5 @@ run_test "complete_corpus_with_unsupported_blocks_compiled_all_claim" \
   test_complete_corpus_with_unsupported_blocks_compiled_all_claim
 run_test "complete_supported_corpus_emits_bounded_claim" \
   test_complete_supported_corpus_emits_bounded_claim
+run_test "complete_corpus_with_declared_class_blocks_deployed_claim" \
+  test_complete_corpus_with_declared_class_blocks_deployed_claim

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -660,6 +660,48 @@ test_complete_corpus_with_declared_class_blocks_deployed_claim() {
   assert_contains "$markdown_text" "| class-only | declared_class | declared-class:0xclass |"
 }
 
+test_rejects_empty_declared_class_contract_address() {
+  local case_root="$TEST_TMP_DIR/declared-class-empty/cases"
+  local corpus_dir="$TEST_TMP_DIR/declared-class-empty/corpora"
+  local results_dir="$TEST_TMP_DIR/declared-class-empty/results"
+  mkdir -p "$corpus_dir" "$results_dir"
+  write_manifest_case "$case_root" "class-only"
+  local item stderr_path
+  item="$(item_json class-only "../cases/class-only/Scarb.toml" "0xclass" "2.14.0")"
+  item="$(jq '.source_kind = "declared_class" | .contract_address = ""' <<<"$item")"
+  write_corpus_file "$corpus_dir/corpus.json" sample class_hash "$item"
+  stderr_path="$TEST_TMP_DIR/declared-class-empty.err"
+  if "$CORPUS_SCRIPT" --corpus "$corpus_dir/corpus.json" --results-dir "$results_dir" --plan-only >"$TEST_TMP_DIR/declared-class-empty.out" 2>"$stderr_path"; then
+    echo "expected declared_class empty contract_address to be rejected" >&2
+    return 1
+  fi
+  if ! grep -Fq "corpus.items[0].contract_address must be a non-empty string" "$stderr_path"; then
+    echo "expected empty contract_address validation error" >&2
+    cat "$stderr_path" >&2
+    return 1
+  fi
+}
+
+test_normalizes_legacy_missing_source_kind_as_deployed_contract() {
+  local case_root="$TEST_TMP_DIR/legacy-source-kind/cases"
+  local corpus_dir="$TEST_TMP_DIR/legacy-source-kind/corpora"
+  local results_dir="$TEST_TMP_DIR/legacy-source-kind/results"
+  mkdir -p "$corpus_dir" "$results_dir"
+  write_manifest_case "$case_root" "legacy"
+  local item stdout_text json_path
+  item="$(item_json legacy "../cases/legacy/Scarb.toml" "0xlegacy" "2.14.0")"
+  item="$(jq 'del(.source_kind)' <<<"$item")"
+  write_corpus_file "$corpus_dir/corpus.json" sample class_hash "$item"
+
+  stdout_text="$("$CORPUS_SCRIPT" --corpus "$corpus_dir/corpus.json" --results-dir "$results_dir" --plan-only)"
+  json_path="$(extract_labeled_path "Corpus plan JSON" <<<"$stdout_text")"
+  if [[ "$(jq -r '.corpus.items[0].source_kind' "$json_path")" != "deployed_contract" || "$(jq -r '.corpus.summary.source_kind_counts.deployed_contract' "$json_path")" != "1" ]]; then
+    echo "legacy missing source_kind should normalize to deployed_contract" >&2
+    cat "$json_path" >&2
+    return 1
+  fi
+}
+
 run_test "plan_only_normalizes_sample_corpus" \
   test_plan_only_normalizes_sample_corpus
 run_test "rejects_duplicate_tags" \
@@ -682,3 +724,7 @@ run_test "complete_supported_corpus_emits_bounded_claim" \
   test_complete_supported_corpus_emits_bounded_claim
 run_test "complete_corpus_with_declared_class_blocks_deployed_claim" \
   test_complete_corpus_with_declared_class_blocks_deployed_claim
+run_test "rejects_empty_declared_class_contract_address" \
+  test_rejects_empty_declared_class_contract_address
+run_test "normalizes_legacy_missing_source_kind_as_deployed_contract" \
+  test_normalizes_legacy_missing_source_kind_as_deployed_contract

--- a/benchmarks/scripts/tests/generate_deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/generate_deployed_contract_corpus_test.sh
@@ -60,6 +60,7 @@ source_item_json() {
     --arg cairo_version "$cairo_version" \
     '{
       tag: $tag,
+      source_kind: "deployed_contract",
       contract_address: "0x123",
       class_hash: $class_hash,
       source_ref: "local test fixture",
@@ -259,6 +260,26 @@ test_rejects_duplicate_class_hash_when_class_deduped() {
   expect_generator_failure "$index_dir/source-index.json" "duplicate class_hash in class_hash-deduped source index: 0xsame"
 }
 
+test_generates_declared_class_without_contract_address() {
+  local index_dir="$TEST_TMP_DIR/declared-class/index"
+  local case_root="$index_dir/cases"
+  local out_dir="$TEST_TMP_DIR/declared-class/out"
+  mkdir -p "$index_dir" "$out_dir"
+  write_manifest_case "$case_root" "a"
+  local item stdout_text corpus_path
+  item="$(source_item_json class_only "cases/a/Scarb.toml" "0xclass" "2.14.0")"
+  item="$(jq '.source_kind = "declared_class" | del(.contract_address)' <<<"$item")"
+  write_source_index_file "$index_dir/source-index.json" sample class_hash "$item"
+
+  stdout_text="$("$GENERATOR_SCRIPT" --source-index "$index_dir/source-index.json" --out "$out_dir/corpus.json")"
+  corpus_path="$(extract_labeled_path "Corpus JSON" <<<"$stdout_text")"
+  if [[ "$(jq -r '.items[0].source_kind' "$corpus_path")" != "declared_class" || "$(jq -r '.items[0] | has("contract_address")' "$corpus_path")" != "false" ]]; then
+    echo "declared class corpus row should not require or synthesize contract_address" >&2
+    cat "$corpus_path" >&2
+    return 1
+  fi
+}
+
 test_rejects_missing_manifest_path() {
   local index_dir="$TEST_TMP_DIR/missing-manifest/index"
   mkdir -p "$index_dir"
@@ -400,6 +421,8 @@ run_test "rejects_duplicate_tags" \
   test_rejects_duplicate_tags
 run_test "rejects_duplicate_class_hash_when_class_deduped" \
   test_rejects_duplicate_class_hash_when_class_deduped
+run_test "generates_declared_class_without_contract_address" \
+  test_generates_declared_class_without_contract_address
 run_test "rejects_missing_manifest_path" \
   test_rejects_missing_manifest_path
 run_test "rejects_absolute_manifest_path" \

--- a/benchmarks/scripts/tests/generate_deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/generate_deployed_contract_corpus_test.sh
@@ -280,6 +280,38 @@ test_generates_declared_class_without_contract_address() {
   fi
 }
 
+test_rejects_empty_declared_class_contract_address() {
+  local index_dir="$TEST_TMP_DIR/declared-class-empty/index"
+  local case_root="$index_dir/cases"
+  mkdir -p "$index_dir"
+  write_manifest_case "$case_root" "a"
+  local item
+  item="$(source_item_json class_only "cases/a/Scarb.toml" "0xclass" "2.14.0")"
+  item="$(jq '.source_kind = "declared_class" | .contract_address = ""' <<<"$item")"
+  write_source_index_file "$index_dir/source-index.json" sample class_hash "$item"
+  expect_generator_failure "$index_dir/source-index.json" "source_index.items[0].contract_address must be a non-empty string"
+}
+
+test_normalizes_legacy_missing_source_kind_as_deployed_contract() {
+  local index_dir="$TEST_TMP_DIR/legacy-source-kind/index"
+  local case_root="$index_dir/cases"
+  local out_dir="$TEST_TMP_DIR/legacy-source-kind/out"
+  mkdir -p "$index_dir" "$out_dir"
+  write_manifest_case "$case_root" "a"
+  local item stdout_text corpus_path
+  item="$(source_item_json legacy "cases/a/Scarb.toml" "0xlegacy" "2.14.0")"
+  item="$(jq 'del(.source_kind)' <<<"$item")"
+  write_source_index_file "$index_dir/source-index.json" sample class_hash "$item"
+
+  stdout_text="$("$GENERATOR_SCRIPT" --source-index "$index_dir/source-index.json" --out "$out_dir/corpus.json")"
+  corpus_path="$(extract_labeled_path "Corpus JSON" <<<"$stdout_text")"
+  if [[ "$(jq -r '.items[0].source_kind' "$corpus_path")" != "deployed_contract" ]]; then
+    echo "legacy missing source_kind should normalize to deployed_contract" >&2
+    cat "$corpus_path" >&2
+    return 1
+  fi
+}
+
 test_rejects_missing_manifest_path() {
   local index_dir="$TEST_TMP_DIR/missing-manifest/index"
   mkdir -p "$index_dir"
@@ -423,6 +455,10 @@ run_test "rejects_duplicate_class_hash_when_class_deduped" \
   test_rejects_duplicate_class_hash_when_class_deduped
 run_test "generates_declared_class_without_contract_address" \
   test_generates_declared_class_without_contract_address
+run_test "rejects_empty_declared_class_contract_address" \
+  test_rejects_empty_declared_class_contract_address
+run_test "normalizes_legacy_missing_source_kind_as_deployed_contract" \
+  test_normalizes_legacy_missing_source_kind_as_deployed_contract
 run_test "rejects_missing_manifest_path" \
   test_rejects_missing_manifest_path
 run_test "rejects_absolute_manifest_path" \

--- a/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
+++ b/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
@@ -64,6 +64,10 @@ Required evidence for that line:
 - The chain, block range, or index snapshot used to select deployed contracts,
   recorded in `selection`.
 - Cairo/Scarb version extraction rules, recorded per `items[]` row.
+- Source-kind classification per `items[]` row:
+  `deployed_contract` rows require a deployed address, while `declared_class`
+  rows are class-source evidence and cannot support a deployed-contract universe
+  claim.
 - Deduplication rules for repeated class hashes or reused source packages,
   recorded in `deduplication`.
 - License/source availability rules, recorded in `license_policy` or the
@@ -74,13 +78,15 @@ Required evidence for that line:
 - Host metadata, binary SHA, helper lane SHA, flags, and sample counts inherited
   from the embedded real-repo benchmark artifact.
 - `claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus=true` in
-  the generated corpus artifact.
+  the generated corpus artifact. This requires a complete deployed-contract
+  snapshot and no `declared_class` rows.
 
 ## Real-Repo Launch Table
 
 The launch table should always include these columns:
 
 - repo/corpus item
+- source kind
 - Cairo version requested
 - selected native lane
 - support classification

--- a/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
+++ b/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
@@ -67,7 +67,8 @@ Required evidence for that line:
 - Source-kind classification per `items[]` row:
   `deployed_contract` rows require a deployed address, while `declared_class`
   rows are class-source evidence and cannot support a deployed-contract universe
-  claim.
+  claim. Legacy rows without `source_kind` are normalized as
+  `deployed_contract`, but launch inventories should set the field explicitly.
 - Deduplication rules for repeated class hashes or reused source packages,
   recorded in `deduplication`.
 - License/source availability rules, recorded in `license_policy` or the

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -70,6 +70,7 @@ If `.diagnostics[].fallback_used` is true, classify the result as fallback-used 
 Read:
 
 - `.summary.support_matrix`
+- `.summary.source_kind_counts`
 - `.summary.cairo_version_min`
 - `.summary.cairo_version_max`
 - `.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus`
@@ -78,6 +79,11 @@ Read:
 Only use `.claim_guard.compiled_all_claim_text` when the guard is true. If the
 guard is false, report `.claim_guard.reason` and keep the artifact as support
 matrix evidence, not launch copy.
+
+For launch copy that says "deployed contracts", every row must be
+`source_kind=deployed_contract`. `declared_class` rows are valid support
+evidence for class source compatibility, but they intentionally block the
+deployed-contract claim guard.
 
 Treat the source inventory as the durable raw evidence input. The source index
 and generated corpus JSON are deterministic artifacts and should be regenerated

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -85,6 +85,10 @@ For launch copy that says "deployed contracts", every row must be
 evidence for class source compatibility, but they intentionally block the
 deployed-contract claim guard.
 
+Legacy rows that omit `source_kind` are normalized as `deployed_contract` so old
+corpus artifacts remain readable. New reviewed inventories should set
+`source_kind` explicitly.
+
 Treat the source inventory as the durable raw evidence input. The source index
 and generated corpus JSON are deterministic artifacts and should be regenerated
 from the reviewed inventory instead of edited by hand.


### PR DESCRIPTION
## Summary

- Adds `source_kind` to deployed-contract source inventory, source-index, and generated corpus rows.
- Requires `contract_address` only for `source_kind=deployed_contract`; allows `source_kind=declared_class` rows to benchmark declared class source evidence without synthesizing a fake deployed address.
- Updates corpus claim guards so "compiled every deployed contract" can only be emitted for complete corpora made exclusively of deployed-contract rows.
- Updates agent and benchmark docs so support evidence and launch-copy evidence stay separated.

## Evidence

- Final bounded evidence artifact: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/deployed-contract-corpus-bench-20260425-080738.json`
- Support matrix from that artifact: `native_supported=2`, `fallback_used=0`, `native_unsupported=0`, `build_failed=0`
- Source-kind counts: `deployed_contract=1`, `declared_class=1`
- Claim guard remains false because coverage is `sample`, not `complete_deployed_contracts`.

## Validation

- `benchmarks/scripts/tests/build_deployed_contract_source_index_test.sh`
- `benchmarks/scripts/tests/generate_deployed_contract_corpus_test.sh`
- `benchmarks/scripts/tests/deployed_contract_corpus_test.sh`
- `make agent-validate`
- `git diff --check`
- `make doctor`
- pre-push selected gate: `make validate-bench-scripts` plus `make agent-validate`

## Notes

This is intentionally not a performance PR. It fixes the launch evidence model exposed by the monero/Braavos corpus: Braavos currently has declared class source evidence, not a representative deployed account address.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Corpus items now carry explicit source classification (deployed contract vs declared class).
  * New summary metric reporting source-kind counts in corpus outputs.

* **Enhancements**
  * Validation tightened so deployed-contract claims require every item to be a native-supported deployed_contract and meet coverage checks.
  * Corpus tables and outputs show address/class ref and source kind.

* **Tests**
  * Added acceptance and normalization tests covering source-kind handling and legacy defaults.

* **Documentation**
  * Updated guidance and launch checklist to require explicit source-kind and clarified claim-guard rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->