### PR TITLE
[codex] Record rejected Cairo 2.14 estimate-size experiment

### DIFF
--- a/docs/research/MONERO_NATIVE_FRONTEND_PROFILE_2026-04-25.md
+++ b/docs/research/MONERO_NATIVE_FRONTEND_PROFILE_2026-04-25.md
@@ -139,12 +139,17 @@ Keep same-window reruns for before/after comparisons. Do not compare a new helpe
 
 After adding the helper-lane patch surface, a local Cairo `2.14` helper patch changed `cairo_lang_lowering::db::estimate_size` from a plain helper function into a `#[salsa::tracked]` query. The hypothesis was that repeated inlining size checks would reuse per-function dummy Sierra/CASM size estimates without changing generated Sierra/CASM.
 
-Validation result:
+Historical local validation result. These bullets describe a removed local experiment; the patch file and generated helpers are not present in-tree:
 
-- The patch applied cleanly through `toolchains/cairo-2.14/patches/cairo-lang-lowering.patch`.
-- `./scripts/build_native_toolchain_helper.sh --lane 2.14 --check-only` passed all four targeted helper tests.
-- A release helper built successfully.
-- Same-window monero harness reruns did not produce a clean win:
+- A local helper-lane patch applied cleanly when placed in the Cairo `2.14` lane `patch-dir`.
+- `./scripts/build_native_toolchain_helper.sh --lane 2.14 --check-only` passed all four targeted helper tests with that local patch present.
+- A local release helper built successfully from that patched staging tree.
+- Same-window monero harness reruns did not produce a clean win under this local lane:
+  - suite: `benchmarks/scripts/run_real_repo_benchmarks.sh`
+  - workload: `/Users/espejelomar/StarkNet/monero-starknet-atomic-swap/cairo/Scarb.toml`
+  - host: Apple M3 Pro, arm64, 18 GiB RAM, macOS 26.4.1
+  - samples: `--cold-runs 3`, `--runs 3`, `--warm-settle-seconds 1.0`, `--timeout-secs 240`
+  - flags/env: helper binaries were used directly as `--uc-bin`; `UC_PHASE_TIMING=1`; offline builds; daemon mode off inside the harness
   - reference helper `uc` cold p95: `7085.773 ms`
   - patched helper `uc` cold p95: `12392.042 ms`
   - reference helper `uc` warm no-op p95: `48.570 ms`

--- a/docs/research/MONERO_NATIVE_FRONTEND_PROFILE_2026-04-25.md
+++ b/docs/research/MONERO_NATIVE_FRONTEND_PROFILE_2026-04-25.md
@@ -134,3 +134,25 @@ export UC_PHASE_TIMING=1
 ```
 
 Keep same-window reruns for before/after comparisons. Do not compare a new helper patch against older local artifacts from a different time window.
+
+## Rejected Experiment: Tracked `estimate_size` Query
+
+After adding the helper-lane patch surface, a local Cairo `2.14` helper patch changed `cairo_lang_lowering::db::estimate_size` from a plain helper function into a `#[salsa::tracked]` query. The hypothesis was that repeated inlining size checks would reuse per-function dummy Sierra/CASM size estimates without changing generated Sierra/CASM.
+
+Validation result:
+
+- The patch applied cleanly through `toolchains/cairo-2.14/patches/cairo-lang-lowering.patch`.
+- `./scripts/build_native_toolchain_helper.sh --lane 2.14 --check-only` passed all four targeted helper tests.
+- A release helper built successfully.
+- Same-window monero harness reruns did not produce a clean win:
+  - reference helper `uc` cold p95: `7085.773 ms`
+  - patched helper `uc` cold p95: `12392.042 ms`
+  - reference helper `uc` warm no-op p95: `48.570 ms`
+  - patched helper `uc` warm no-op p95: `43.530 ms`
+
+The patched run window was noisy: Scarb cold p95 in the same harness moved from `11821.282 ms` to `39337.630 ms`, so the numbers are not suitable as public benchmark evidence. The important engineering decision is still clear: this patch did not produce a clean real-harness improvement, so it was removed and should not be shipped as a perf PR.
+
+Artifacts from the rejected local run were written under ignored paths:
+
+- `benchmarks/results/cairo214-estimate-size-reference-20260425-100237/`
+- `benchmarks/results/cairo214-estimate-size-patched-20260425-100442/`


### PR DESCRIPTION
## Summary

- records the Cairo 2.14 helper-lane `estimate_size` tracked-query experiment
- captures the compile/test validation that passed
- records the same-window monero harness result and why the patch was not shipped
- keeps the actual optimization patch removed because it did not produce a clean real-harness win

## Validation

- `make agent-validate`
- `git diff --check`
- pre-push local gate selected `agent-validate` and passed

## Decision

No perf PR from this experiment. The patched helper compiled and passed targeted tests, but the real monero harness did not improve cleanly, and the run window was too noisy for any public benchmark claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated research notes to record an internal experiment: the patch applied cleanly and targeted tests/builds passed; observed performance regressions in some runs with minor warm-path changes in others; rerun noise noted making results unsuitable for public benchmarking; benchmark artifact locations recorded for internal review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->