### PR TITLE
Harden agent report schema contracts

### DIFF
--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -590,7 +590,7 @@ struct NativeDiagnostic {
     docs_url: String,
     what_happened: String,
     why: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     how_to_fix: Vec<String>,
     #[serde(default)]
     next_commands: Vec<String>,
@@ -1275,7 +1275,7 @@ struct BuildReport {
     compile_backend: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     native_toolchain: Option<NativeToolchainReport>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     diagnostics: Vec<NativeDiagnostic>,
 }
 

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -475,6 +475,91 @@ fn project_inspect_cli_accepts_json_format_and_report_path() {
 }
 
 #[test]
+fn required_agent_arrays_serialize_when_empty() {
+    let diagnostic = NativeDiagnostic {
+        schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+        code: "UCN0001".to_string(),
+        category: "internal_error".to_string(),
+        severity: NativeDiagnosticSeverity::Error,
+        title: "Internal error".to_string(),
+        docs_url: native_diagnostic_docs_url("UCN0001"),
+        what_happened: "an internal error occurred".to_string(),
+        why: "the compiler could not complete the requested action".to_string(),
+        how_to_fix: Vec::new(),
+        next_commands: Vec::new(),
+        safe_automated_action: "none".to_string(),
+        retryable: false,
+        fallback_used: false,
+        toolchain_expected: None,
+        toolchain_found: None,
+    };
+    let diagnostic_json = serde_json::to_value(&diagnostic).expect("diagnostic should serialize");
+    assert_eq!(diagnostic_json["how_to_fix"], serde_json::json!([]));
+    assert_eq!(diagnostic_json["next_commands"], serde_json::json!([]));
+
+    let report = BuildReport {
+        schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+        generated_at_epoch_ms: 1,
+        engine: "uc".to_string(),
+        daemon_used: false,
+        manifest_path: "/tmp/workspace/Scarb.toml".to_string(),
+        workspace_root: "/tmp/workspace".to_string(),
+        profile: "dev".to_string(),
+        session_key: "test-session".to_string(),
+        command: vec!["uc".to_string(), "build".to_string()],
+        exit_code: 0,
+        elapsed_ms: 1.0,
+        cache_hit: false,
+        fingerprint: "test-fingerprint".to_string(),
+        artifact_count: 0,
+        phase_telemetry: None,
+        compile_backend: None,
+        native_toolchain: None,
+        diagnostics: Vec::new(),
+    };
+    let report_json = serde_json::to_value(&report).expect("build report should serialize");
+    assert_eq!(report_json["diagnostics"], serde_json::json!([]));
+}
+
+#[test]
+fn report_schemas_match_nullable_option_output() {
+    let replay_schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../docs/agent/schemas/replay-report.schema.json"
+    ))
+    .expect("replay report schema should parse");
+    assert_eq!(
+        replay_schema["properties"]["manifest_path"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        replay_schema["properties"]["exit_code"]["type"],
+        serde_json::json!(["integer", "null"])
+    );
+    assert_eq!(
+        replay_schema["properties"]["blocked_reason"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert!(replay_schema["properties"]["selected_support"]["anyOf"]
+        .as_array()
+        .expect("selected_support should use anyOf")
+        .iter()
+        .any(|entry| entry == &serde_json::json!({"type": "null"})));
+
+    let safe_action_schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../docs/agent/schemas/safe-action-report.schema.json"
+    ))
+    .expect("safe-action report schema should parse");
+    assert_eq!(
+        safe_action_schema["properties"]["exit_code"]["type"],
+        serde_json::json!(["integer", "null"])
+    );
+    assert_eq!(
+        safe_action_schema["properties"]["blocked_reason"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+}
+
+#[test]
 fn project_inspect_report_summarizes_manifest_lockfile_and_support_without_mutation() {
     let dir = unique_test_dir("uc-project-inspect-report");
     let _cleanup = TestDirCleanup::new(&dir);

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -539,11 +539,35 @@ fn report_schemas_match_nullable_option_output() {
         replay_schema["properties"]["blocked_reason"]["type"],
         serde_json::json!(["string", "null"])
     );
-    assert!(replay_schema["properties"]["selected_support"]["anyOf"]
+    let selected_support_any_of = replay_schema["properties"]["selected_support"]["anyOf"]
         .as_array()
-        .expect("selected_support should use anyOf")
+        .expect("selected_support should use anyOf");
+    assert!(selected_support_any_of
         .iter()
         .any(|entry| entry == &serde_json::json!({"type": "null"})));
+    assert!(
+        selected_support_any_of
+            .iter()
+            .any(|entry| entry.get("$ref").is_some()
+                || entry.get("type") == Some(&serde_json::json!("object"))),
+        "selected_support should preserve a non-null schema branch"
+    );
+    let replay_required = replay_schema["required"]
+        .as_array()
+        .expect("replay schema should list required fields");
+    for optional_field in [
+        "manifest_path",
+        "selected_support",
+        "exit_code",
+        "blocked_reason",
+    ] {
+        assert!(
+            !replay_required
+                .iter()
+                .any(|field| field.as_str() == Some(optional_field)),
+            "{optional_field} should stay optional in replay schema"
+        );
+    }
 
     let safe_action_schema: serde_json::Value = serde_json::from_str(include_str!(
         "../../../docs/agent/schemas/safe-action-report.schema.json"
@@ -557,6 +581,17 @@ fn report_schemas_match_nullable_option_output() {
         safe_action_schema["properties"]["blocked_reason"]["type"],
         serde_json::json!(["string", "null"])
     );
+    let safe_action_required = safe_action_schema["required"]
+        .as_array()
+        .expect("safe-action schema should list required fields");
+    for optional_field in ["exit_code", "blocked_reason"] {
+        assert!(
+            !safe_action_required
+                .iter()
+                .any(|field| field.as_str() == Some(optional_field)),
+            "{optional_field} should stay optional in safe-action schema"
+        );
+    }
 }
 
 #[test]

--- a/docs/LAUNCH_EVIDENCE_2026-04-25.md
+++ b/docs/LAUNCH_EVIDENCE_2026-04-25.md
@@ -1,0 +1,96 @@
+# Launch Evidence Checkpoint 2026-04-25
+
+This checkpoint records the current local evidence for the agent-first Cairo compiler launch path. It is support and benchmark evidence for a reviewed two-item sample, not a deployed-contract universe claim.
+
+## Evidence Bundle
+
+- Evidence root: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425`
+- Source inventory: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/reviewed-source-inventory.json`
+- Source index: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/pinned-source-index.json`
+- Generated corpus: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/generated-corpus.json`
+- Corpus benchmark JSON: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/deployed-contract-corpus-bench-20260425-180015.json`
+- Corpus benchmark Markdown: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/deployed-contract-corpus-bench-20260425-180015.md`
+- Real-repo benchmark JSON: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/real-repo-bench-20260425-180015.json`
+- Real-repo benchmark Markdown: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/real-repo-bench-20260425-180015.md`
+
+## Generation Commands
+
+```bash
+cargo build -p uc-cli --release
+./scripts/build_native_toolchain_helper.sh --lane 2.14 --output "$HOME/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc"
+export UC_NATIVE_TOOLCHAIN_2_14_BIN="$HOME/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc"
+
+./benchmarks/scripts/build_deployed_contract_source_index.sh \
+  --inventory /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/reviewed-source-inventory.json \
+  --out /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/pinned-source-index.json
+
+./benchmarks/scripts/generate_deployed_contract_corpus.sh \
+  --source-index /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/pinned-source-index.json \
+  --out /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/generated-corpus.json
+
+./benchmarks/scripts/run_deployed_contract_corpus.sh \
+  --uc-bin /Users/espejelomar/StarkNet/uc-launch-evidence-pr-20260425/target/release/uc \
+  --corpus /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/generated-corpus.json \
+  --results-dir /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results \
+  --runs 3 \
+  --cold-runs 3 \
+  --warm-settle-seconds 2.2
+```
+
+## Support Matrix
+
+| Item | Source kind | Cairo version | Classification | Backend | Fallback used |
+|---|---|---:|---|---|---|
+| `monero_atomic_lock_sepolia` | `deployed_contract` | `2.14.0` | `native_supported` | `uc_native_external_helper` | `false` |
+| `braavos_account_v1_2_0_class` | `declared_class` | `2.14.0` | `native_supported` | `uc_native_external_helper` | `false` |
+
+Summary: `native_supported=2`, `fallback_used=0`, `native_unsupported=0`, `build_failed=0`.
+
+## Same-Window Benchmark Results
+
+| Item | Cold Scarb p95 (ms) | Cold uc p95 (ms) | Cold speedup | Warm Scarb p95 (ms) | Warm uc p95 (ms) | Warm speedup |
+|---|---:|---:|---:|---:|---:|---:|
+| `monero_atomic_lock_sepolia` | 14365.929 | 7173.073 | 2.003x | 8027.459 | 33.547 | 239.288x |
+| `braavos_account_v1_2_0_class` | 5121.310 | 4225.745 | 1.212x | 5465.849 | 56.151 | 97.343x |
+
+The monero Scarb warm-noop lane was marked unstable by the harness: p50 `6586.095ms`, p95 `8027.459ms`, max `8187.611ms`, p95/p50 `1.219`.
+
+## Native Frontend Profile
+
+The build reports include phase telemetry for the native cold classification builds:
+
+| Item | `native_frontend_compile_ms` | `native_casm_ms` | Contracts compiled |
+|---|---:|---:|---:|
+| `monero_atomic_lock_sepolia` | 6620.065 | 276.651 | 1 |
+| `braavos_account_v1_2_0_class` | 2698.329 | 429.709 | 3 |
+
+Monero remains the right next profiling target: most cold `uc` time is still in `native_frontend_compile`.
+
+## Artifact Hashes
+
+```text
+b326e0a9cbcaeeef78073328933b81c133378b66d32c0d6e828d4c8df86bb5b5  deployed-contract-corpus-bench-20260425-180015.json
+061159118082bb5ad43db28f54a75d7e2a4b45747223a9adf8c472cb20f8a36b  deployed-contract-corpus-bench-20260425-180015.md
+b2a470abe9ed1082e39527848f426ebb476367ef0492524733df533121f0a0cb  real-repo-bench-20260425-180015.json
+0ac8179b1a4b80031ba5edb3439f7b9ff59c37c796f401879bf391225d24ebfb  real-repo-bench-20260425-180015.md
+9b4f86866dc9d896bc8848d84174632478b28565cdf46d6e85e0a15f8c7c0f42  generated-corpus.json
+fbb75e2284a08cc2b6e96d4e7be4abc739af85506354490da66097a9170e9205  pinned-source-index.json
+b62d46619e475bb5ca3a6f7d45a551bc93d10fe3cdebfb819823959611479493  reviewed-source-inventory.json
+```
+
+## Claim Boundary
+
+Safe to say internally:
+
+> The current two-item Cairo `2.14.0` sample classifies monero and Braavos as native-supported with no fallback and no build failures, and the same-window benchmark artifact shows material warm-noop speedups plus positive cold p95 speedups.
+
+Not safe to say yet:
+
+> We compiled every deployed contract in a Starknet corpus.
+
+Reasons:
+
+- `selection.coverage` is `sample`, not `complete_deployed_contracts`.
+- The corpus has one `deployed_contract` row and one `declared_class` row.
+- `claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus=false`.
+- Launch-grade evidence still needs a complete deployed-contract snapshot or an explicitly named bounded corpus with immutable hosting.

--- a/docs/LAUNCH_EVIDENCE_2026-04-25.md
+++ b/docs/LAUNCH_EVIDENCE_2026-04-25.md
@@ -16,22 +16,26 @@ This checkpoint records the current local evidence for the agent-first Cairo com
 ## Generation Commands
 
 ```bash
-cargo build -p uc-cli --release
-./scripts/build_native_toolchain_helper.sh --lane 2.14 --output "$HOME/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc"
+export UC_REPO_ROOT="/Users/espejelomar/StarkNet/uc-launch-evidence-pr-20260425"
+export EVIDENCE_ROOT="/Users/espejelomar/StarkNet/uc-launch-evidence-20260425"
 export UC_NATIVE_TOOLCHAIN_2_14_BIN="$HOME/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc"
 
+cd "$UC_REPO_ROOT"
+cargo build -p uc-cli --release
+./scripts/build_native_toolchain_helper.sh --lane 2.14 --output "$UC_NATIVE_TOOLCHAIN_2_14_BIN"
+
 ./benchmarks/scripts/build_deployed_contract_source_index.sh \
-  --inventory /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/reviewed-source-inventory.json \
-  --out /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/pinned-source-index.json
+  --inventory "$EVIDENCE_ROOT/reviewed-source-inventory.json" \
+  --out "$EVIDENCE_ROOT/pinned-source-index.json"
 
 ./benchmarks/scripts/generate_deployed_contract_corpus.sh \
-  --source-index /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/pinned-source-index.json \
-  --out /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/generated-corpus.json
+  --source-index "$EVIDENCE_ROOT/pinned-source-index.json" \
+  --out "$EVIDENCE_ROOT/generated-corpus.json"
 
 ./benchmarks/scripts/run_deployed_contract_corpus.sh \
-  --uc-bin /Users/espejelomar/StarkNet/uc-launch-evidence-pr-20260425/target/release/uc \
-  --corpus /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/generated-corpus.json \
-  --results-dir /Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results \
+  --uc-bin "$UC_REPO_ROOT/target/release/uc" \
+  --corpus "$EVIDENCE_ROOT/generated-corpus.json" \
+  --results-dir "$EVIDENCE_ROOT/results" \
   --runs 3 \
   --cold-runs 3 \
   --warm-settle-seconds 2.2
@@ -47,6 +51,19 @@ export UC_NATIVE_TOOLCHAIN_2_14_BIN="$HOME/.uc/toolchain-helpers/uc-cairo214-hel
 Summary: `native_supported=2`, `fallback_used=0`, `native_unsupported=0`, `build_failed=0`.
 
 ## Same-Window Benchmark Results
+
+Lane and conditions:
+
+- Benchmark lane: `run_deployed_contract_corpus.sh` wrapping `run_real_repo_benchmarks.sh`.
+- Benchmark stages: `build.cold` and `build.warm_noop`.
+- Native lane: Cairo `2.14.0` external helper via `UC_NATIVE_TOOLCHAIN_2_14_BIN`.
+- uc backend: `uc_native_external_helper`.
+- Baseline: `scarb 2.14.0 (682b29e13 2025-11-25)`.
+- Host: Apple M3 Pro, `Mac15,7`, macOS `26.4.1` build `25E253`, `aarch64-apple-darwin`.
+- Runs: warm runs `3`, cold runs `3`, warm settle `2.2s`.
+- CPU pinning: not set on this macOS host.
+- uc binary SHA-256: `22da63681dfcd6a5429cbcf096638ac08618f71cb2987f3616b59c2b7ce5cb99`.
+- Cairo 2.14 helper SHA-256: `b184a564ebd1b9761cc20ef8a11594aba2e4b355b348cfc5875a26d040ea27a3`.
 
 | Item | Cold Scarb p95 (ms) | Cold uc p95 (ms) | Cold speedup | Warm Scarb p95 (ms) | Warm uc p95 (ms) | Warm speedup |
 |---|---:|---:|---:|---:|---:|---:|

--- a/docs/LAUNCH_EVIDENCE_2026-04-25.md
+++ b/docs/LAUNCH_EVIDENCE_2026-04-25.md
@@ -4,20 +4,20 @@ This checkpoint records the current local evidence for the agent-first Cairo com
 
 ## Evidence Bundle
 
-- Evidence root: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425`
-- Source inventory: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/reviewed-source-inventory.json`
-- Source index: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/pinned-source-index.json`
-- Generated corpus: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/generated-corpus.json`
-- Corpus benchmark JSON: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/deployed-contract-corpus-bench-20260425-180015.json`
-- Corpus benchmark Markdown: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/deployed-contract-corpus-bench-20260425-180015.md`
-- Real-repo benchmark JSON: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/real-repo-bench-20260425-180015.json`
-- Real-repo benchmark Markdown: `/Users/espejelomar/StarkNet/uc-launch-evidence-20260425/results/real-repo-bench-20260425-180015.md`
+- Evidence root: `$EVIDENCE_ROOT`
+- Source inventory: `$EVIDENCE_ROOT/reviewed-source-inventory.json`
+- Source index: `$EVIDENCE_ROOT/pinned-source-index.json`
+- Generated corpus: `$EVIDENCE_ROOT/generated-corpus.json`
+- Corpus benchmark JSON: `$EVIDENCE_ROOT/results/deployed-contract-corpus-bench-20260425-180015.json`
+- Corpus benchmark Markdown: `$EVIDENCE_ROOT/results/deployed-contract-corpus-bench-20260425-180015.md`
+- Real-repo benchmark JSON: `$EVIDENCE_ROOT/results/real-repo-bench-20260425-180015.json`
+- Real-repo benchmark Markdown: `$EVIDENCE_ROOT/results/real-repo-bench-20260425-180015.md`
 
 ## Generation Commands
 
 ```bash
-export UC_REPO_ROOT="/Users/espejelomar/StarkNet/uc-launch-evidence-pr-20260425"
-export EVIDENCE_ROOT="/Users/espejelomar/StarkNet/uc-launch-evidence-20260425"
+export UC_REPO_ROOT="$(pwd)"
+export EVIDENCE_ROOT="/path/to/external/uc-launch-evidence-20260425"
 export UC_NATIVE_TOOLCHAIN_2_14_BIN="$HOME/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc"
 
 cd "$UC_REPO_ROOT"

--- a/docs/LAUNCH_EVIDENCE_2026-04-25.md
+++ b/docs/LAUNCH_EVIDENCE_2026-04-25.md
@@ -70,7 +70,7 @@ Lane and conditions:
 | `monero_atomic_lock_sepolia` | 14365.929 | 7173.073 | 2.003x | 8027.459 | 33.547 | 239.288x |
 | `braavos_account_v1_2_0_class` | 5121.310 | 4225.745 | 1.212x | 5465.849 | 56.151 | 97.343x |
 
-The monero Scarb warm-noop lane was marked unstable by the harness: p50 `6586.095ms`, p95 `8027.459ms`, max `8187.611ms`, p95/p50 `1.219`.
+The monero Scarb warm-noop lane was marked unstable by the harness: p50 `6586.095ms`, p95 `8027.459ms`, max `8187.611ms`, p95/p50 ratio `1.219`.
 
 ## Native Frontend Profile
 
@@ -93,6 +93,14 @@ b2a470abe9ed1082e39527848f426ebb476367ef0492524733df533121f0a0cb  real-repo-benc
 9b4f86866dc9d896bc8848d84174632478b28565cdf46d6e85e0a15f8c7c0f42  generated-corpus.json
 fbb75e2284a08cc2b6e96d4e7be4abc739af85506354490da66097a9170e9205  pinned-source-index.json
 b62d46619e475bb5ca3a6f7d45a551bc93d10fe3cdebfb819823959611479493  reviewed-source-inventory.json
+```
+
+To verify the artifact hashes, set `EVIDENCE_ROOT` to the evidence directory or
+run from that directory, copy the lines above into `checksums.txt`, then run:
+
+```bash
+cd "$EVIDENCE_ROOT"
+shasum -a 256 -c checksums.txt
 ```
 
 ## Claim Boundary

--- a/docs/agent/schemas/replay-report.schema.json
+++ b/docs/agent/schemas/replay-report.schema.json
@@ -22,12 +22,17 @@
     "execute_requested": { "type": "boolean" },
     "executed": { "type": "boolean" },
     "command": { "type": "array", "items": { "type": "string" } },
-    "manifest_path": { "type": "string" },
+    "manifest_path": { "type": ["string", "null"] },
     "original_error": { "type": "string" },
-    "selected_support": { "$ref": "native-support-report.schema.json" },
-    "exit_code": { "type": "integer" },
+    "selected_support": {
+      "anyOf": [
+        { "$ref": "native-support-report.schema.json" },
+        { "type": "null" }
+      ]
+    },
+    "exit_code": { "type": ["integer", "null"] },
     "stdout": { "type": "string" },
     "stderr": { "type": "string" },
-    "blocked_reason": { "type": "string" }
+    "blocked_reason": { "type": ["string", "null"] }
   }
 }

--- a/docs/agent/schemas/safe-action-report.schema.json
+++ b/docs/agent/schemas/safe-action-report.schema.json
@@ -21,9 +21,9 @@
     "dry_run": { "type": "boolean" },
     "command": { "type": "array", "items": { "type": "string" } },
     "executed": { "type": "boolean" },
-    "exit_code": { "type": "integer" },
+    "exit_code": { "type": ["integer", "null"] },
     "stdout": { "type": "string" },
     "stderr": { "type": "string" },
-    "blocked_reason": { "type": "string" }
+    "blocked_reason": { "type": ["string", "null"] }
   }
 }


### PR DESCRIPTION
## Summary

- Keep required agent JSON arrays present even when empty: `NativeDiagnostic.how_to_fix` and `BuildReport.diagnostics` now serialize as `[]`.
- Align replay and safe-action schemas with the actual nullable output for optional fields.
- Add focused tests for required empty-array serialization, nullable schema contracts, non-null schema branches, and optional-field required-list regressions.
- Record the current 2026-04-25 launch evidence checkpoint for the two-item Cairo 2.14 sample, including monero/Braavos support classification, same-window benchmark numbers, phase telemetry, claim boundaries, and artifact hashes.

## Evidence checkpoint

Latest local evidence bundle is referenced in the checked-in doc via `$EVIDENCE_ROOT` rather than an absolute local path.

- `monero_atomic_lock_sepolia`: `native_supported`, Cairo `2.14.0`, no fallback.
- `braavos_account_v1_2_0_class`: `native_supported`, Cairo `2.14.0`, no fallback.
- Same-window p95 cold speedups: monero `2.003x`, Braavos `1.212x`.
- Same-window p95 warm-noop speedups: monero `239.288x`, Braavos `97.343x`.
- Claim guard still blocks deployed-universe language because this is sample coverage with one deployed-contract row and one declared-class row.

## Validation

- `make bootstrap`
- `make doctor`
- `make agent-validate`
- `cargo test -p uc-cli required_agent_arrays_serialize_when_empty -- --nocapture`
- `cargo test -p uc-cli report_schemas_match_nullable_option_output -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo build -p uc-cli --release`
- `scripts/doctor.sh --uc-bin <repo>/target/release/uc --manifest-path <evidence>/sources/monero/Scarb.toml --manifest-path <evidence>/sources/braavos_account/Scarb.toml`
- `benchmarks/scripts/run_deployed_contract_corpus.sh --uc-bin <repo>/target/release/uc --corpus <evidence>/generated-corpus.json --results-dir <evidence>/results --runs 3 --cold-runs 3 --warm-settle-seconds 2.2`
- `make validate-bench-scripts`
- `make local-ci`
- pre-push hook: `make local-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests ensuring agent JSON always includes required array fields (even when empty) and validates schema nullability rules.

* **Documentation**
  * Added a launch-evidence checkpoint recording build steps, benchmark results, artifact hashes, and measured timings.

* **Bug Fixes**
  * Serialization now emits empty arrays for diagnostic/report lists.
  * Agent JSON schemas updated to allow several fields to be nullable for greater flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->