### PR TITLE
Decouple native support corpus claim

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -194,7 +194,10 @@ a combined JSON/Markdown artifact with:
     this is the safe wording for corpora deduplicated by `class_hash` or
     `source_package`
   - `.claim_guard.native_supported_claim_text` only when
-    `.claim_guard.safe_to_say_all_items_native_supported=true`
+    `.claim_guard.safe_to_say_all_items_native_supported=true`; this support
+    claim is scoped to the pinned corpus items and is independent of complete
+    deployed-contract coverage. It does not imply a compiled-all deployed
+    address claim or a stable benchmark claim.
 
 Do not turn sample-corpus output into launch copy. A `coverage=sample` corpus is
 valid for smoke testing the artifact path, but the generated claim guard will

--- a/benchmarks/scripts/run_deployed_contract_corpus.sh
+++ b/benchmarks/scripts/run_deployed_contract_corpus.sh
@@ -427,7 +427,7 @@ jq -n \
      and ($corpus[0].deduplication.key == "none")
      and (($corpus[0].deduplication.input_count // 0) == item_count);
    def native_all:
-     all_items_native_supported;
+     all_items_native_supported and (failed_native_benchmarks == 0);
    def deduplication_phrase:
      if $corpus[0].deduplication.key == "none" then
        "without deduplication"

--- a/benchmarks/scripts/run_deployed_contract_corpus.sh
+++ b/benchmarks/scripts/run_deployed_contract_corpus.sh
@@ -406,13 +406,16 @@ jq -n \
      ([ $corpus[0].items[] | select(.source_kind != "deployed_contract") ] | length);
    def failed_native_benchmarks:
      ([ $bench[0].cases[] | select(.benchmark_status == "failed") ] | length);
-   def compiled_without_dedup_guard:
-     ($corpus[0].selection.coverage == "complete_deployed_contracts")
-     and (non_deployed_item_count == 0)
+   def all_items_native_supported:
+     (item_count > 0)
      and ((counts.native_supported // 0) == item_count)
      and ((counts.fallback_used // 0) == 0)
      and ((counts.native_unsupported // 0) == 0)
-     and ((counts.build_failed // 0) == 0)
+     and ((counts.build_failed // 0) == 0);
+   def compiled_without_dedup_guard:
+     ($corpus[0].selection.coverage == "complete_deployed_contracts")
+     and (non_deployed_item_count == 0)
+     and all_items_native_supported
      and (failed_native_benchmarks == 0);
    def valid_selected_unit_accounting:
      ($corpus[0].deduplication.key != "none")
@@ -424,7 +427,7 @@ jq -n \
      and ($corpus[0].deduplication.key == "none")
      and (($corpus[0].deduplication.input_count // 0) == item_count);
    def native_all:
-     compiled_selected_units;
+     all_items_native_supported;
    def deduplication_phrase:
      if $corpus[0].deduplication.key == "none" then
        "without deduplication"
@@ -487,7 +490,7 @@ jq -n \
        ),
        native_supported_claim_text: (
          if native_all then
-           "Every item in the pinned \($corpus[0].chain) deployed-contract corpus was native-supported in this run."
+           "Every item in the pinned \($corpus[0].chain) corpus was native-supported in this run."
          else null end
        )
      }

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -743,6 +743,11 @@ test_native_benchmark_failure_blocks_native_support_claim() {
     cat "$json_path" >&2
     return 1
   fi
+  if ! grep -q "build .*fails-bench.* disallow=1" "$TEST_TMP_DIR/native-bench-fail/uc.args"; then
+    echo "expected fails-bench to fail during strict native benchmark build" >&2
+    cat "$TEST_TMP_DIR/native-bench-fail/uc.args" >&2
+    return 1
+  fi
   assert_contains "$reason" "one or more native-supported benchmark cases failed"
   assert_contains "$markdown_text" "Native-supported claim: <not safe for this artifact>"
 }

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -93,6 +93,10 @@ if [[ "$1" == "build" ]]; then
         ;;
     esac
   done
+  if [[ "$manifest" == *"fails-bench"* && "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" == "1" ]]; then
+    printf 'build %s disallow=%s report=%s\n' "$manifest" "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" "$report_path" >> "$args_log"
+    exit 17
+  fi
   if [[ "$seen_offline" -ne 1 ]]; then
     echo "missing uc --offline" >&2
     exit 23
@@ -676,23 +680,71 @@ test_complete_non_deduped_count_mismatch_blocks_deployed_contract_claim() {
   [[ -f "$json_path" ]] || { echo "missing corpus benchmark json: $json_path" >&2; return 1; }
   [[ -f "$md_path" ]] || { echo "missing corpus benchmark markdown: $md_path" >&2; return 1; }
 
-  local safe selected_safe all_supported claim selected_claim reason markdown_text
+  local safe selected_safe all_supported claim selected_claim native_claim reason markdown_text
   safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
   selected_safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus' "$json_path")"
   all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"
   claim="$(jq -r '.claim_guard.compiled_all_claim_text // ""' "$json_path")"
   selected_claim="$(jq -r '.claim_guard.selected_units_claim_text // ""' "$json_path")"
+  native_claim="$(jq -r '.claim_guard.native_supported_claim_text // ""' "$json_path")"
   reason="$(jq -r '.claim_guard.reason' "$json_path")"
   markdown_text="$(cat "$md_path")"
-  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$all_supported" != "true" || -n "$claim" || -n "$selected_claim" ]]; then
+  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$all_supported" != "true" || -n "$claim" || -n "$selected_claim" || -z "$native_claim" ]]; then
     echo "non-deduped corpus with mismatched counts should not emit deployed-address or selected-unit claims" >&2
     cat "$json_path" >&2
     return 1
   fi
   assert_contains "$reason" "deduplication.input_count does not equal item_count"
   assert_contains "$reason" "address coverage is incomplete"
+  assert_contains "$native_claim" "Every item in the pinned"
   assert_contains "$markdown_text" "Compiled-all claim: <not safe for this artifact>"
   assert_contains "$markdown_text" "Selected-unit claim: <not safe for this artifact>"
+  assert_contains "$markdown_text" "Native-supported claim: Every item in the pinned"
+}
+
+test_native_benchmark_failure_blocks_native_support_claim() {
+  local corpus_dir="$TEST_TMP_DIR/native-bench-fail/corpora"
+  local case_root="$TEST_TMP_DIR/native-bench-fail/cases"
+  local results_dir="$TEST_TMP_DIR/native-bench-fail/results"
+  local mock_bin_dir="$TEST_TMP_DIR/native-bench-fail/mock-bin"
+  mkdir -p "$corpus_dir" "$case_root" "$results_dir" "$mock_bin_dir"
+  write_manifest_case "$case_root" "fails-bench"
+  write_mock_uc_bin "$mock_bin_dir/uc"
+  write_mock_scarb_bin "$mock_bin_dir/scarb"
+
+  local item stdout_text json_path md_path safe selected_safe all_supported reason native_claim markdown_text benchmark_status
+  item="$(item_json fails-bench "../cases/fails-bench/Scarb.toml" "0xfailsbench" "2.14.0")"
+  write_corpus_file "$corpus_dir/corpus.json" complete_deployed_contracts none "$item"
+
+  stdout_text="$(
+    PATH="$mock_bin_dir:$PATH" \
+    MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/native-bench-fail/uc.args" \
+    MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/native-bench-fail/scarb.args" \
+    "$CORPUS_SCRIPT" \
+      --uc-bin "$mock_bin_dir/uc" \
+      --results-dir "$results_dir" \
+      --runs 1 \
+      --cold-runs 1 \
+      --warm-settle-seconds 0 \
+      --corpus "$corpus_dir/corpus.json"
+  )"
+
+  json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
+  md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
+  safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
+  selected_safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus' "$json_path")"
+  all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"
+  reason="$(jq -r '.claim_guard.reason' "$json_path")"
+  native_claim="$(jq -r '.claim_guard.native_supported_claim_text // ""' "$json_path")"
+  benchmark_status="$(jq -r '.benchmark.cases[] | select(.tag=="fails-bench") | .benchmark_status' "$json_path")"
+  markdown_text="$(cat "$md_path")"
+  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$all_supported" != "false" || "$benchmark_status" != "failed" || -n "$native_claim" ]]; then
+    echo "native benchmark failure should block all safe claims" >&2
+    cat "$json_path" >&2
+    return 1
+  fi
+  assert_contains "$reason" "one or more native-supported benchmark cases failed"
+  assert_contains "$markdown_text" "Native-supported claim: <not safe for this artifact>"
 }
 
 test_complete_corpus_with_declared_class_blocks_deployed_claim() {
@@ -806,6 +858,8 @@ run_test "complete_non_deduped_corpus_emits_deployed_contract_claim" \
   test_complete_non_deduped_corpus_emits_deployed_contract_claim
 run_test "complete_non_deduped_count_mismatch_blocks_deployed_contract_claim" \
   test_complete_non_deduped_count_mismatch_blocks_deployed_contract_claim
+run_test "native_benchmark_failure_blocks_native_support_claim" \
+  test_native_benchmark_failure_blocks_native_support_claim
 run_test "complete_corpus_with_declared_class_blocks_deployed_claim" \
   test_complete_corpus_with_declared_class_blocks_deployed_claim
 run_test "rejects_empty_declared_class_contract_address" \

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -596,21 +596,24 @@ test_sample_corpus_blocks_compiled_all_claim() {
   json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
   [[ -f "$json_path" ]] || { echo "missing corpus benchmark json: $json_path" >&2; return 1; }
 
-  local safe reason native_supported all_supported claim native_claim markdown_text md_path
+  local safe selected_safe reason native_supported all_supported claim selected_claim native_claim markdown_text md_path
   md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
   safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
+  selected_safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus' "$json_path")"
   reason="$(jq -r '.claim_guard.reason' "$json_path")"
   native_supported="$(jq -r '.summary.support_matrix.native_supported' "$json_path")"
   all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"
   claim="$(jq -r '.claim_guard.compiled_all_claim_text // ""' "$json_path")"
+  selected_claim="$(jq -r '.claim_guard.selected_units_claim_text // ""' "$json_path")"
   native_claim="$(jq -r '.claim_guard.native_supported_claim_text // ""' "$json_path")"
   markdown_text="$(cat "$md_path")"
-  if [[ "$safe" != "false" || "$reason" != *"coverage is sample"* || "$native_supported" != "2" || "$all_supported" != "true" || -n "$claim" || -z "$native_claim" ]]; then
+  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$reason" != *"coverage is sample"* || "$native_supported" != "2" || "$all_supported" != "true" || -n "$claim" || -n "$selected_claim" || -z "$native_claim" ]]; then
     echo "sample corpus should not emit launch claim" >&2
     cat "$json_path" >&2
     return 1
   fi
   assert_contains "$native_claim" "Every item in the pinned"
+  assert_contains "$markdown_text" "Selected-unit claim: <not safe for this artifact>"
   assert_contains "$markdown_text" "Native-supported claim: Every item in the pinned"
 }
 
@@ -764,7 +767,7 @@ test_complete_corpus_with_declared_class_blocks_deployed_claim() {
   write_mock_uc_bin "$mock_bin_dir/uc"
   write_mock_scarb_bin "$mock_bin_dir/scarb"
 
-  local item stdout_text json_path md_path safe all_supported reason source_kind_count claim markdown_text native_claim
+  local item stdout_text json_path md_path safe selected_safe all_supported reason source_kind_count claim selected_claim markdown_text native_claim
   item="$(item_json class-only "../cases/class-only/Scarb.toml" "0xclass" "2.14.0")"
   item="$(jq '.source_kind = "declared_class" | del(.contract_address)' <<<"$item")"
   write_corpus_file "$corpus_dir/corpus.json" complete_deployed_contracts class_hash "$item"
@@ -785,17 +788,20 @@ test_complete_corpus_with_declared_class_blocks_deployed_claim() {
   json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
   md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
   safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
+  selected_safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus' "$json_path")"
   all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"
   reason="$(jq -r '.claim_guard.reason' "$json_path")"
   source_kind_count="$(jq -r '.summary.source_kind_counts.declared_class' "$json_path")"
   claim="$(jq -r '.claim_guard.compiled_all_claim_text // ""' "$json_path")"
+  selected_claim="$(jq -r '.claim_guard.selected_units_claim_text // ""' "$json_path")"
   native_claim="$(jq -r '.claim_guard.native_supported_claim_text // ""' "$json_path")"
   markdown_text="$(cat "$md_path")"
-  if [[ "$safe" != "false" || "$all_supported" != "true" || "$reason" != "corpus contains non-deployed source_kind rows" || "$source_kind_count" != "1" || -n "$claim" || -z "$native_claim" ]]; then
-    echo "declared_class corpus item should block deployed-contract launch claim" >&2
+  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$all_supported" != "true" || "$reason" != "corpus contains non-deployed source_kind rows" || "$source_kind_count" != "1" || -n "$claim" || -n "$selected_claim" || -z "$native_claim" ]]; then
+    echo "declared_class corpus item should block deployed-contract and selected-unit launch claims" >&2
     cat "$json_path" >&2
     return 1
   fi
+  assert_contains "$markdown_text" "Selected-unit claim: <not safe for this artifact>"
   assert_contains "$markdown_text" "| class-only | declared_class | declared-class:0xclass |"
 }
 

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -731,6 +731,8 @@ test_native_benchmark_failure_blocks_native_support_claim() {
 
   json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
   md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
+  [[ -f "$json_path" ]] || { echo "missing corpus benchmark json: $json_path" >&2; return 1; }
+  [[ -f "$md_path" ]] || { echo "missing corpus benchmark markdown: $md_path" >&2; return 1; }
   safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
   selected_safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus' "$json_path")"
   all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -592,16 +592,22 @@ test_sample_corpus_blocks_compiled_all_claim() {
   json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
   [[ -f "$json_path" ]] || { echo "missing corpus benchmark json: $json_path" >&2; return 1; }
 
-  local safe reason native_supported claim
+  local safe reason native_supported all_supported claim native_claim markdown_text md_path
+  md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
   safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
   reason="$(jq -r '.claim_guard.reason' "$json_path")"
   native_supported="$(jq -r '.summary.support_matrix.native_supported' "$json_path")"
+  all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"
   claim="$(jq -r '.claim_guard.compiled_all_claim_text // ""' "$json_path")"
-  if [[ "$safe" != "false" || "$reason" != *"coverage is sample"* || "$native_supported" != "2" || -n "$claim" ]]; then
+  native_claim="$(jq -r '.claim_guard.native_supported_claim_text // ""' "$json_path")"
+  markdown_text="$(cat "$md_path")"
+  if [[ "$safe" != "false" || "$reason" != *"coverage is sample"* || "$native_supported" != "2" || "$all_supported" != "true" || -n "$claim" || -z "$native_claim" ]]; then
     echo "sample corpus should not emit launch claim" >&2
     cat "$json_path" >&2
     return 1
   fi
+  assert_contains "$native_claim" "Every item in the pinned"
+  assert_contains "$markdown_text" "Native-supported claim: Every item in the pinned"
 }
 
 test_complete_class_deduped_corpus_emits_selected_unit_claim_only() {
@@ -678,7 +684,7 @@ test_complete_non_deduped_count_mismatch_blocks_deployed_contract_claim() {
   selected_claim="$(jq -r '.claim_guard.selected_units_claim_text // ""' "$json_path")"
   reason="$(jq -r '.claim_guard.reason' "$json_path")"
   markdown_text="$(cat "$md_path")"
-  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$all_supported" != "false" || -n "$claim" || -n "$selected_claim" ]]; then
+  if [[ "$safe" != "false" || "$selected_safe" != "false" || "$all_supported" != "true" || -n "$claim" || -n "$selected_claim" ]]; then
     echo "non-deduped corpus with mismatched counts should not emit deployed-address or selected-unit claims" >&2
     cat "$json_path" >&2
     return 1
@@ -699,7 +705,7 @@ test_complete_corpus_with_declared_class_blocks_deployed_claim() {
   write_mock_uc_bin "$mock_bin_dir/uc"
   write_mock_scarb_bin "$mock_bin_dir/scarb"
 
-  local item stdout_text json_path md_path safe reason source_kind_count claim markdown_text
+  local item stdout_text json_path md_path safe all_supported reason source_kind_count claim markdown_text native_claim
   item="$(item_json class-only "../cases/class-only/Scarb.toml" "0xclass" "2.14.0")"
   item="$(jq '.source_kind = "declared_class" | del(.contract_address)' <<<"$item")"
   write_corpus_file "$corpus_dir/corpus.json" complete_deployed_contracts class_hash "$item"
@@ -720,11 +726,13 @@ test_complete_corpus_with_declared_class_blocks_deployed_claim() {
   json_path="$(extract_labeled_path "Corpus Benchmark JSON" <<<"$stdout_text")"
   md_path="$(extract_labeled_path "Corpus Benchmark Markdown" <<<"$stdout_text")"
   safe="$(jq -r '.claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus' "$json_path")"
+  all_supported="$(jq -r '.claim_guard.safe_to_say_all_items_native_supported' "$json_path")"
   reason="$(jq -r '.claim_guard.reason' "$json_path")"
   source_kind_count="$(jq -r '.summary.source_kind_counts.declared_class' "$json_path")"
   claim="$(jq -r '.claim_guard.compiled_all_claim_text // ""' "$json_path")"
+  native_claim="$(jq -r '.claim_guard.native_supported_claim_text // ""' "$json_path")"
   markdown_text="$(cat "$md_path")"
-  if [[ "$safe" != "false" || "$reason" != "corpus contains non-deployed source_kind rows" || "$source_kind_count" != "1" || -n "$claim" ]]; then
+  if [[ "$safe" != "false" || "$all_supported" != "true" || "$reason" != "corpus contains non-deployed source_kind rows" || "$source_kind_count" != "1" || -n "$claim" || -z "$native_claim" ]]; then
     echo "declared_class corpus item should block deployed-contract launch claim" >&2
     cat "$json_path" >&2
     return 1

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -93,10 +93,6 @@ if [[ "$1" == "build" ]]; then
         ;;
     esac
   done
-  if [[ "$manifest" == *"fails-bench"* && "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" == "1" ]]; then
-    printf 'build %s disallow=%s report=%s\n' "$manifest" "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" "$report_path" >> "$args_log"
-    exit 17
-  fi
   if [[ "$seen_offline" -ne 1 ]]; then
     echo "missing uc --offline" >&2
     exit 23
@@ -104,6 +100,10 @@ if [[ "$1" == "build" ]]; then
   if [[ "$seen_daemon_off" -ne 1 ]]; then
     echo "missing uc --daemon-mode off" >&2
     exit 24
+  fi
+  if [[ "$manifest" == *"fails-bench"* && "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" == "1" ]]; then
+    printf 'build %s disallow=%s report=%s\n' "$manifest" "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" "$report_path" >> "$args_log"
+    exit 17
   fi
   printf 'build %s disallow=%s report=%s\n' "$manifest" "${UC_NATIVE_DISALLOW_SCARB_FALLBACK:-}" "$report_path" >> "$args_log"
   compile_backend="uc_native"

--- a/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
+++ b/docs/AGENT_FIRST_LAUNCH_MINIMUM_2026-04-24.md
@@ -85,6 +85,9 @@ Required evidence for that line:
 - Support matrix with every excluded case explained.
 - Host metadata, binary SHA, helper lane SHA, flags, and sample counts inherited
   from the embedded real-repo benchmark artifact.
+- If `claim_guard.safe_to_say_all_items_native_supported=true`, the support
+  claim is bounded to the pinned corpus items. It is useful for agent routing,
+  but it is not a deployed-contract universe claim.
 - `claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus=true` in
   the generated corpus artifact. This requires a complete deployed-contract
   snapshot and no `declared_class` rows.

--- a/docs/BENCHMARK_PLAN.md
+++ b/docs/BENCHMARK_PLAN.md
@@ -57,6 +57,10 @@ Benchmark reports must separate:
 - `native_unsupported`: native support probe rejected the repo before timed execution
 - `build_failed`: auto-build failed before backend classification completed
 
+The generated `native_supported` claim is scoped to the pinned corpus items. It
+can be true for a sample corpus, but it must not be reused as a complete
+deployed-contract coverage claim.
+
 Examples of native-ineligible reasons that should be reported explicitly:
 - exact `cairo-version` mismatch against the native compiler
 - legacy package editions (`2023_01`, `2023_10`, `2023_11`) without an exact `[package].cairo-version`

--- a/docs/LAUNCH_EVIDENCE_2026-04-25.md
+++ b/docs/LAUNCH_EVIDENCE_2026-04-25.md
@@ -1,6 +1,6 @@
 # Launch Evidence Checkpoint 2026-04-25
 
-This checkpoint records the current local evidence for the agent-first Cairo compiler launch path. It is support and benchmark evidence for a reviewed two-item sample, not a deployed-contract universe claim.
+This checkpoint records the current local evidence for the agent-first Cairo compiler launch path. It is support evidence and diagnostic benchmark output for a reviewed two-item sample, not a deployed-contract universe claim and not a launch-grade speed claim.
 
 ## Evidence Bundle
 
@@ -8,21 +8,20 @@ This checkpoint records the current local evidence for the agent-first Cairo com
 - Source inventory: `$EVIDENCE_ROOT/reviewed-source-inventory.json`
 - Source index: `$EVIDENCE_ROOT/pinned-source-index.json`
 - Generated corpus: `$EVIDENCE_ROOT/generated-corpus.json`
-- Corpus benchmark JSON: `$EVIDENCE_ROOT/results/deployed-contract-corpus-bench-20260425-180015.json`
-- Corpus benchmark Markdown: `$EVIDENCE_ROOT/results/deployed-contract-corpus-bench-20260425-180015.md`
-- Real-repo benchmark JSON: `$EVIDENCE_ROOT/results/real-repo-bench-20260425-180015.json`
-- Real-repo benchmark Markdown: `$EVIDENCE_ROOT/results/real-repo-bench-20260425-180015.md`
+- Corpus benchmark JSON: `$EVIDENCE_ROOT/results-current-final/deployed-contract-corpus-bench-20260425-201850.json`
+- Corpus benchmark Markdown: `$EVIDENCE_ROOT/results-current-final/deployed-contract-corpus-bench-20260425-201850.md`
+- Real-repo benchmark JSON: `$EVIDENCE_ROOT/results-current-final/real-repo-bench-20260425-201850.json`
+- Real-repo benchmark Markdown: `$EVIDENCE_ROOT/results-current-final/real-repo-bench-20260425-201850.md`
 
 ## Generation Commands
 
 ```bash
 export UC_REPO_ROOT="$(pwd)"
-export EVIDENCE_ROOT="/path/to/external/uc-launch-evidence-20260425"
+export EVIDENCE_ROOT="/path/to/external/uc-launch-evidence-20260425-pr48"
 export UC_NATIVE_TOOLCHAIN_2_14_BIN="$HOME/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc"
 
 cd "$UC_REPO_ROOT"
 cargo build -p uc-cli --release
-./scripts/build_native_toolchain_helper.sh --lane 2.14 --output "$UC_NATIVE_TOOLCHAIN_2_14_BIN"
 
 ./benchmarks/scripts/build_deployed_contract_source_index.sh \
   --inventory "$EVIDENCE_ROOT/reviewed-source-inventory.json" \
@@ -35,11 +34,22 @@ cargo build -p uc-cli --release
 ./benchmarks/scripts/run_deployed_contract_corpus.sh \
   --uc-bin "$UC_REPO_ROOT/target/release/uc" \
   --corpus "$EVIDENCE_ROOT/generated-corpus.json" \
-  --results-dir "$EVIDENCE_ROOT/results" \
+  --results-dir "$EVIDENCE_ROOT/results-current-final" \
   --runs 3 \
   --cold-runs 3 \
   --warm-settle-seconds 2.2
 ```
+
+## Corpus Scope
+
+- Corpus id: `starknet-reviewed-local-source-sample-2026-04-25`
+- Chain label: `starknet-reviewed-local-source-sample`
+- Coverage: `sample`
+- Snapshot id: `local-reviewed-source-sample-2026-04-25-pr48`
+- Items: `2`
+- Source kinds: `deployed_contract=1`, `declared_class=1`
+- Cairo versions: `2.14.0` through `2.14.0`
+- Deduplication: `class_hash`, `input_count=2`, `deduped_count=2`
 
 ## Support Matrix
 
@@ -48,9 +58,11 @@ cargo build -p uc-cli --release
 | `monero_atomic_lock_sepolia` | `deployed_contract` | `2.14.0` | `native_supported` | `uc_native_external_helper` | `false` |
 | `braavos_account_v1_2_0_class` | `declared_class` | `2.14.0` | `native_supported` | `uc_native_external_helper` | `false` |
 
-Summary: `native_supported=2`, `fallback_used=0`, `native_unsupported=0`, `build_failed=0`.
+Summary: `native_supported=2`, `fallback_used=0`, `native_unsupported=0`, `build_failed=0`, `unstable_lane_count=1`.
 
-## Same-Window Benchmark Results
+## Same-Window Benchmark Output
+
+This run is not launch-grade speed evidence because `unstable_lane_count=1`. Keep it as diagnostic support evidence only until a same-window rerun passes the stability guard.
 
 Lane and conditions:
 
@@ -62,15 +74,19 @@ Lane and conditions:
 - Host: Apple M3 Pro, `Mac15,7`, macOS `26.4.1` build `25E253`, `aarch64-apple-darwin`.
 - Runs: warm runs `3`, cold runs `3`, warm settle `2.2s`.
 - CPU pinning: not set on this macOS host.
-- uc binary SHA-256: `22da63681dfcd6a5429cbcf096638ac08618f71cb2987f3616b59c2b7ce5cb99`.
+- uc binary SHA-256: `3b4557707f3681ba3ebc34012adb2fe5a861ccb73f79f8e7b4948a8e4ef0bed0`.
 - Cairo 2.14 helper SHA-256: `b184a564ebd1b9761cc20ef8a11594aba2e4b355b348cfc5875a26d040ea27a3`.
 
 | Item | Cold Scarb p95 (ms) | Cold uc p95 (ms) | Cold speedup | Warm Scarb p95 (ms) | Warm uc p95 (ms) | Warm speedup |
 |---|---:|---:|---:|---:|---:|---:|
-| `monero_atomic_lock_sepolia` | 14365.929 | 7173.073 | 2.003x | 8027.459 | 33.547 | 239.288x |
-| `braavos_account_v1_2_0_class` | 5121.310 | 4225.745 | 1.212x | 5465.849 | 56.151 | 97.343x |
+| `monero_atomic_lock_sepolia` | 10069.652 | 6244.161 | 1.613x | 5939.758 | 36.852 | 161.179x |
+| `braavos_account_v1_2_0_class` | 4291.033 | 13619.110 | 0.315x | 15965.993 | 75.151 | 212.452x |
 
-The monero Scarb warm-noop lane was marked unstable by the harness: p50 `6586.095ms`, p95 `8027.459ms`, max `8187.611ms`, p95/p50 ratio `1.219`.
+Stability warning:
+
+| Item | Tool | Stage | p50 (ms) | p95 (ms) | max (ms) | p95/p50 | max/p50 |
+|---|---|---|---:|---:|---:|---:|---:|
+| `braavos_account_v1_2_0_class` | `scarb` | `build.warm_noop` | 4691.155 | 15965.993 | 17218.753 | 3.403 | 3.670 |
 
 ## Native Frontend Profile
 
@@ -78,21 +94,24 @@ The build reports include phase telemetry for the native cold classification bui
 
 | Item | `native_frontend_compile_ms` | `native_casm_ms` | Contracts compiled |
 |---|---:|---:|---:|
-| `monero_atomic_lock_sepolia` | 6620.065 | 276.651 | 1 |
-| `braavos_account_v1_2_0_class` | 2698.329 | 429.709 | 3 |
+| `monero_atomic_lock_sepolia` | 5547.938 | 259.500 | 1 |
+| `braavos_account_v1_2_0_class` | 2533.680 | 401.005 | 3 |
 
 Monero remains the right next profiling target: most cold `uc` time is still in `native_frontend_compile`.
 
 ## Artifact Hashes
 
 ```text
-b326e0a9cbcaeeef78073328933b81c133378b66d32c0d6e828d4c8df86bb5b5  deployed-contract-corpus-bench-20260425-180015.json
-061159118082bb5ad43db28f54a75d7e2a4b45747223a9adf8c472cb20f8a36b  deployed-contract-corpus-bench-20260425-180015.md
-b2a470abe9ed1082e39527848f426ebb476367ef0492524733df533121f0a0cb  real-repo-bench-20260425-180015.json
-0ac8179b1a4b80031ba5edb3439f7b9ff59c37c796f401879bf391225d24ebfb  real-repo-bench-20260425-180015.md
-9b4f86866dc9d896bc8848d84174632478b28565cdf46d6e85e0a15f8c7c0f42  generated-corpus.json
-fbb75e2284a08cc2b6e96d4e7be4abc739af85506354490da66097a9170e9205  pinned-source-index.json
-b62d46619e475bb5ca3a6f7d45a551bc93d10fe3cdebfb819823959611479493  reviewed-source-inventory.json
+1fe7c1a777dc565cb918c4c72bb6aaf63f2a79427871ff1e126e710bd4cbfb42  reviewed-source-inventory.json
+4b55caa829353f6b0c5fb56a0f2175db975716774652614f86a0940c6f4b17e3  pinned-source-index.json
+2eb32ce9c2d1c57a279388bf3eae1982b74decf1c329c991c741ba7aa9f3d921  generated-corpus.json
+3b4557707f3681ba3ebc34012adb2fe5a861ccb73f79f8e7b4948a8e4ef0bed0  target/release/uc
+d67bcf16d83a8b5140188f405b42d5e68d3cd4a40d3d6565eeea1d9f234a810a  results-current-final/deployed-contract-corpus-bench-20260425-201850.json
+26982507475eb5ba1c544963f106f3ddd890a88f311bce4961408f8c454392ab  results-current-final/real-repo-bench-20260425-201850.json
+cec9bfbdbdd2ee8a74f2b622882b9eb04e159a6bfd67e4a3a1811f2ff9e345e3  results-current-final/real-repo-braavos_account_v1_2_0_class-uc-auto-build-report.json
+f9b76b840f44efcd89259a4671ad6f62b8a70b0034526bff950feb9faf64624f  results-current-final/real-repo-monero_atomic_lock_sepolia-uc-auto-build-report.json
+99aceb3776cd871412972f086596f30095dace9e07871b541f2d560d8c25c2e7  results-current-final/deployed-contract-corpus-bench-20260425-201850.md
+aacc93c4e12ecff5e8c2cd7e2e2ce9926dee3fb853471b1102648a520bcdb7fb  results-current-final/real-repo-bench-20260425-201850.md
 ```
 
 To verify the artifact hashes, set `EVIDENCE_ROOT` to the evidence directory or
@@ -103,19 +122,31 @@ cd "$EVIDENCE_ROOT"
 shasum -a 256 -c checksums.txt
 ```
 
+For `target/release/uc`, run `shasum -a 256 "$UC_REPO_ROOT/target/release/uc"`.
+
 ## Claim Boundary
 
 Safe to say internally:
 
-> The current two-item Cairo `2.14.0` sample classifies monero and Braavos as native-supported with no fallback and no build failures, and the same-window benchmark artifact shows material warm-noop speedups plus positive cold p95 speedups.
+> Every item in the pinned `starknet-reviewed-local-source-sample` corpus was native-supported in this run.
+
+Also safe to say internally:
+
+> The current two-item Cairo `2.14.0` sample classifies monero and Braavos as native-supported with no fallback and no build failures.
 
 Not safe to say yet:
 
 > We compiled every deployed contract in a Starknet corpus.
+
+Also not safe to say from this exact artifact:
+
+> The current same-window benchmark artifact supports a launch-grade speedup claim.
 
 Reasons:
 
 - `selection.coverage` is `sample`, not `complete_deployed_contracts`.
 - The corpus has one `deployed_contract` row and one `declared_class` row.
 - `claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus=false`.
-- Launch-grade evidence still needs a complete deployed-contract snapshot or an explicitly named bounded corpus with immutable hosting.
+- `claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus=false`.
+- `summary.unstable_lane_count=1`, so speed numbers are diagnostic only.
+- Launch-grade deployed-contract evidence still needs a complete deployed-contract snapshot or an explicitly named bounded complete deployed-contract corpus with immutable hosting.

--- a/docs/LAUNCH_EVIDENCE_2026-04-25.md
+++ b/docs/LAUNCH_EVIDENCE_2026-04-25.md
@@ -105,7 +105,6 @@ Monero remains the right next profiling target: most cold `uc` time is still in 
 1fe7c1a777dc565cb918c4c72bb6aaf63f2a79427871ff1e126e710bd4cbfb42  reviewed-source-inventory.json
 4b55caa829353f6b0c5fb56a0f2175db975716774652614f86a0940c6f4b17e3  pinned-source-index.json
 2eb32ce9c2d1c57a279388bf3eae1982b74decf1c329c991c741ba7aa9f3d921  generated-corpus.json
-3b4557707f3681ba3ebc34012adb2fe5a861ccb73f79f8e7b4948a8e4ef0bed0  target/release/uc
 d67bcf16d83a8b5140188f405b42d5e68d3cd4a40d3d6565eeea1d9f234a810a  results-current-final/deployed-contract-corpus-bench-20260425-201850.json
 26982507475eb5ba1c544963f106f3ddd890a88f311bce4961408f8c454392ab  results-current-final/real-repo-bench-20260425-201850.json
 cec9bfbdbdd2ee8a74f2b622882b9eb04e159a6bfd67e4a3a1811f2ff9e345e3  results-current-final/real-repo-braavos_account_v1_2_0_class-uc-auto-build-report.json


### PR DESCRIPTION
## Summary

- Decouple the item-scoped native-support claim from complete deployed-contract coverage claims.
- Keep deployed-address and selected-unit claims strict: complete deployed coverage, no declared-class rows, no fallback/unsupported/build failures, no native benchmark failures, and correct dedup accounting are still required.
- Add tests for sample corpora, declared-class rows, and non-deduped count mismatches so support claims can be true while deployed-universe claims remain false.
- Refresh the launch evidence checkpoint with the current branch binary and the patched claim boundary.

## Evidence

Current reviewed two-item Cairo 2.14.0 sample:

- `native_supported=2`
- `fallback_used=0`
- `native_unsupported=0`
- `build_failed=0`
- `claim_guard.safe_to_say_all_items_native_supported=true`
- `claim_guard.safe_to_say_compiled_all_deployed_contracts_in_corpus=false`
- `claim_guard.safe_to_say_compiled_all_selected_deployed_units_in_corpus=false`

Safe claim from this artifact:

> Every item in the pinned `starknet-reviewed-local-source-sample` corpus was native-supported in this run.

Unsafe claims remain blocked:

- “We compiled every deployed contract in a Starknet corpus.”
- “This exact artifact supports a launch-grade speedup claim.”

The latest patched artifact has `unstable_lane_count=1`, so `docs/LAUNCH_EVIDENCE_2026-04-25.md` keeps speed numbers diagnostic-only.

## Local validation

- `./benchmarks/scripts/tests/deployed_contract_corpus_test.sh`
- `git diff --check`
- `make validate-bench-scripts`
- `make agent-validate`
- `make local-ci`
- normal `git push` with pre-push hook, no `--no-verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that “native-supported” benchmark claims apply only to the pinned corpus items; added explicit claim-boundary wording across benchmark docs, evidence checklists, and launch evidence; updated reporting, stability guidance, corpus scope, and artifact references.

* **Tests**
  * Strengthened test suite to gate native-supported claims, ensure failing native benchmarks block those claims, and validate claim wording in generated markdown.

* **Benchmark tooling**
  * Tightened gating so native-supported claims require full native support across the pinned corpus and adjusted claim wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->