### PR TITLE
Improve corpus benchmark failure diagnostics

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -97,6 +97,9 @@ separately with the exact unsupported reason and are excluded from speedup claim
 If a native-eligible case fails during `scarb` or `uc` execution, the harness
 records that build failure in a separate section with exit code and log path
 instead of aborting the whole benchmark run.
+If dependency prefetch fails before classification, the harness records that
+manifest as a per-case `build_failed` row with the `scarb --offline fetch` log
+path instead of aborting the entire corpus sweep.
 
 ## Build Deployed-Contract Source Index From Inventory
 
@@ -236,7 +239,7 @@ backlog for larger corpora:
 - `UCO2001` / `UCO2002`: failed or unstable benchmark lanes.
 - `UCO3001` through `UCO3007`: phase-level acceleration targets.
 - `UCO4001` / `UCO4002`: bounded launch-evidence candidates.
-- `UCO5001`: diagnostics that are not yet complete enough for agent remediation.
+- `UCO5001`: diagnostics that are missing fields or too generic for agent remediation.
 
 Do not use the opportunity summary as a launch claim by itself. It is an
 experiment-control artifact. Public claims still come only from the benchmark

--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -373,10 +373,17 @@ measurement_failure_json() {
 
 prefetch_manifest_dependencies() {
   local manifest_path="$1"
+  local log_path="${2:-}"
   if [[ -n "${PREFETCHED_MANIFESTS[$manifest_path]:-}" ]]; then
     return
   fi
-  if ! scarb --manifest-path "$manifest_path" --offline fetch >/dev/null; then
+  if [[ -n "$log_path" ]]; then
+    mkdir -p "$(dirname "$log_path")"
+    if ! scarb --manifest-path "$manifest_path" --offline fetch >"$log_path" 2>&1; then
+      echo "scarb fetch failed for manifest_path=$manifest_path (log: $log_path)" >&2
+      return 1
+    fi
+  elif ! scarb --manifest-path "$manifest_path" --offline fetch >/dev/null; then
     echo "scarb fetch failed for manifest_path=$manifest_path" >&2
     return 1
   fi
@@ -412,13 +419,31 @@ classify_support_matrix_case() {
   local source_dir
   source_dir="$(cd "$(dirname "$manifest_path")" && pwd -P)"
   local classify_dir="$TMP_DIR/${tag}-uc-auto-classify"
+  local prefetch_log_path="$RESULTS_DIR/real-repo-${tag}-prefetch.log"
   local log_path="$RESULTS_DIR/real-repo-${tag}-uc-auto-build.log"
   local report_path="$RESULTS_DIR/real-repo-${tag}-uc-auto-build-report.json"
   rm -rf "$classify_dir"
   mkdir -p "$classify_dir"
   cp -PR "$source_dir/." "$classify_dir"
   reset_workload_outputs "$classify_dir"
-  prefetch_manifest_dependencies "$manifest_path"
+  if ! prefetch_manifest_dependencies "$manifest_path" "$prefetch_log_path"; then
+    rm -rf "$classify_dir"
+    jq -n \
+      --argjson native_support "$support_json" \
+      --arg log_path "$prefetch_log_path" \
+      '{
+        classification: "build_failed",
+        compile_backend: null,
+        fallback_used: false,
+        exit_code: 1,
+        elapsed_ms: null,
+        log_path: $log_path,
+        report_path: null,
+        build_report: null,
+        reason: "scarb offline fetch failed before uc auto build classification"
+      }'
+    return 0
+  fi
 
   local -a uc_auto_cmd=(env "UC_NATIVE_BUILD=auto")
   if [[ -n "${UC_NATIVE_CORELIB_SRC:-}" ]]; then
@@ -629,7 +654,29 @@ benchmark_supported_case() {
   local support_matrix_json="$4"
   local source_dir
   source_dir="$(cd "$(dirname "$manifest_path")" && pwd -P)"
-  prefetch_manifest_dependencies "$manifest_path"
+  local prefetch_log_path="$RESULTS_DIR/real-repo-${tag}-prefetch.log"
+  if ! prefetch_manifest_dependencies "$manifest_path" "$prefetch_log_path"; then
+    local prefetch_failure_json
+    prefetch_failure_json="$(measurement_failure_json "prefetch" 1 "$prefetch_log_path")"
+    jq -n \
+      --arg tag "$tag" \
+      --arg manifest_path "$manifest_path" \
+      --argjson native_support "$support_json" \
+      --argjson support_matrix "$support_matrix_json" \
+      --argjson prefetch_failure "$prefetch_failure_json" \
+      '{
+        tag: $tag,
+        manifest_path: $manifest_path,
+        native_support: $native_support,
+        support_matrix: $support_matrix,
+        benchmark_status: "failed",
+        benchmarks: {
+          scarb: { build: { cold: $prefetch_failure, warm_noop: $prefetch_failure } },
+          uc: { build: { cold: $prefetch_failure, warm_noop: $prefetch_failure } }
+        }
+      }'
+    return 0
+  fi
 
   local -a scarb_cmd=(scarb --manifest-path "$manifest_path" --offline build)
   local -a uc_cmd=(env "UC_NATIVE_DISALLOW_SCARB_FALLBACK=1")

--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -377,15 +377,16 @@ prefetch_manifest_dependencies() {
   if [[ -n "${PREFETCHED_MANIFESTS[$manifest_path]:-}" ]]; then
     return
   fi
+  local fetch_exit_code=0
   if [[ -n "$log_path" ]]; then
     mkdir -p "$(dirname "$log_path")"
-    if ! scarb --manifest-path "$manifest_path" --offline fetch >"$log_path" 2>&1; then
-      echo "scarb fetch failed for manifest_path=$manifest_path (log: $log_path)" >&2
-      return 1
-    fi
-  elif ! scarb --manifest-path "$manifest_path" --offline fetch >/dev/null; then
-    echo "scarb fetch failed for manifest_path=$manifest_path" >&2
-    return 1
+    scarb --manifest-path "$manifest_path" --offline fetch >"$log_path" 2>&1 || fetch_exit_code=$?
+  else
+    scarb --manifest-path "$manifest_path" --offline fetch >/dev/null || fetch_exit_code=$?
+  fi
+  if [[ "$fetch_exit_code" -ne 0 ]]; then
+    echo "scarb fetch failed for manifest_path=$manifest_path${log_path:+ (log: $log_path)} exit_code=$fetch_exit_code" >&2
+    return "$fetch_exit_code"
   fi
   PREFETCHED_MANIFESTS["$manifest_path"]=1
 }
@@ -426,16 +427,19 @@ classify_support_matrix_case() {
   mkdir -p "$classify_dir"
   cp -PR "$source_dir/." "$classify_dir"
   reset_workload_outputs "$classify_dir"
-  if ! prefetch_manifest_dependencies "$manifest_path" "$prefetch_log_path"; then
+  local prefetch_exit_code=0
+  prefetch_manifest_dependencies "$manifest_path" "$prefetch_log_path" || prefetch_exit_code=$?
+  if [[ "$prefetch_exit_code" -ne 0 ]]; then
     rm -rf "$classify_dir"
     jq -n \
       --argjson native_support "$support_json" \
       --arg log_path "$prefetch_log_path" \
+      --argjson exit_code "$prefetch_exit_code" \
       '{
         classification: "build_failed",
         compile_backend: null,
         fallback_used: false,
-        exit_code: 1,
+        exit_code: $exit_code,
         elapsed_ms: null,
         log_path: $log_path,
         report_path: null,
@@ -655,9 +659,11 @@ benchmark_supported_case() {
   local source_dir
   source_dir="$(cd "$(dirname "$manifest_path")" && pwd -P)"
   local prefetch_log_path="$RESULTS_DIR/real-repo-${tag}-prefetch.log"
-  if ! prefetch_manifest_dependencies "$manifest_path" "$prefetch_log_path"; then
+  local prefetch_exit_code=0
+  prefetch_manifest_dependencies "$manifest_path" "$prefetch_log_path" || prefetch_exit_code=$?
+  if [[ "$prefetch_exit_code" -ne 0 ]]; then
     local prefetch_failure_json
-    prefetch_failure_json="$(measurement_failure_json "prefetch" 1 "$prefetch_log_path")"
+    prefetch_failure_json="$(measurement_failure_json "prefetch" "$prefetch_exit_code" "$prefetch_log_path")"
     jq -n \
       --arg tag "$tag" \
       --arg manifest_path "$manifest_path" \

--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -22,6 +22,12 @@ REQUIRED_DIAGNOSTIC_FIELDS = {
     "toolchain_expected",
     "toolchain_found",
 }
+GENERIC_DIAGNOSTIC_TEXT = {
+    "compilation failed",
+    "native failed",
+    "native compilation failed",
+    "uc auto build failed",
+}
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -126,6 +132,21 @@ def add_opportunity(opps: list[dict[str, Any]], code: str, severity: str, title:
             "next_action": next_action,
         }
     )
+
+
+def is_generic_diagnostic_text(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip().rstrip(".").lower()
+    return normalized in GENERIC_DIAGNOSTIC_TEXT
+
+
+def diagnostic_quality_issues(diag: dict[str, Any]) -> list[str]:
+    issues = [f"missing {field}" for field in sorted(REQUIRED_DIAGNOSTIC_FIELDS) if field not in diag]
+    for field in ("what_happened", "why"):
+        if is_generic_diagnostic_text(diag.get(field)):
+            issues.append(f"{field} is generic")
+    return issues
 
 
 def unstable_lanes_by_tag(summary: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
@@ -267,14 +288,14 @@ def summarize_case(
         )
 
     for diag in diagnostics:
-        missing = sorted(field for field in REQUIRED_DIAGNOSTIC_FIELDS if field not in diag)
-        if missing:
+        quality_issues = diagnostic_quality_issues(diag)
+        if quality_issues:
             add_opportunity(
                 opps,
                 "UCO5001",
                 "medium",
                 "Diagnostic is not agent-grade",
-                f"Diagnostic {diag.get('code', '<missing-code>')} is missing: {', '.join(missing)}.",
+                f"Diagnostic {diag.get('code', '<missing-code>')} has weak remediation detail: {', '.join(quality_issues)}.",
                 "Extend the diagnostic payload before relying on agents to remediate this class automatically.",
             )
 

--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -149,6 +149,18 @@ def is_generic_diagnostic_text(value: Any) -> bool:
 
 def diagnostic_quality_issues(diag: dict[str, Any]) -> list[str]:
     issues = [f"missing {field}" for field in sorted(REQUIRED_DIAGNOSTIC_FIELDS) if field not in diag]
+    if "schema_version" in diag:
+        schema_version = diag.get("schema_version")
+        if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+            issues.append("schema_version is not an integer")
+    for field in ("code", "category"):
+        value = diag.get(field)
+        if field in diag and (not isinstance(value, str) or not value.strip()):
+            issues.append(f"{field} is empty")
+    for field in ("retryable", "fallback_used"):
+        value = diag.get(field)
+        if field in diag and not isinstance(value, bool):
+            issues.append(f"{field} is not a boolean")
     for field in ("severity", "title", "docs_url", "safe_automated_action"):
         value = diag.get(field)
         if field in diag and (not isinstance(value, str) or not value.strip()):

--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -12,15 +12,19 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 REQUIRED_DIAGNOSTIC_FIELDS = {
+    "schema_version",
     "code",
     "category",
+    "severity",
+    "title",
+    "docs_url",
     "what_happened",
     "why",
     "how_to_fix",
+    "next_commands",
+    "safe_automated_action",
     "retryable",
     "fallback_used",
-    "toolchain_expected",
-    "toolchain_found",
 }
 GENERIC_DIAGNOSTIC_TEXT = {
     "compilation failed",

--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -144,11 +144,23 @@ def is_generic_diagnostic_text(value: Any) -> bool:
     if not isinstance(value, str):
         return False
     normalized = value.strip().rstrip(".").lower()
-    return normalized in GENERIC_DIAGNOSTIC_TEXT or normalized.startswith("uc auto build failed")
+    return normalized in GENERIC_DIAGNOSTIC_TEXT
 
 
 def diagnostic_quality_issues(diag: dict[str, Any]) -> list[str]:
     issues = [f"missing {field}" for field in sorted(REQUIRED_DIAGNOSTIC_FIELDS) if field not in diag]
+    for field in ("severity", "title", "docs_url", "safe_automated_action"):
+        value = diag.get(field)
+        if field in diag and (not isinstance(value, str) or not value.strip()):
+            issues.append(f"{field} is empty")
+    for field in ("how_to_fix", "next_commands"):
+        value = diag.get(field)
+        if field in diag and (
+            not isinstance(value, list)
+            or not value
+            or any(not isinstance(item, str) or not item.strip() for item in value)
+        ):
+            issues.append(f"{field} is empty")
     for field in ("what_happened", "why"):
         raw = diag.get(field)
         if not isinstance(raw, str):

--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -144,7 +144,8 @@ def is_generic_diagnostic_text(value: Any) -> bool:
 def diagnostic_quality_issues(diag: dict[str, Any]) -> list[str]:
     issues = [f"missing {field}" for field in sorted(REQUIRED_DIAGNOSTIC_FIELDS) if field not in diag]
     for field in ("what_happened", "why"):
-        if is_generic_diagnostic_text(diag.get(field)):
+        text = (diag.get(field) or "").strip()
+        if not text or is_generic_diagnostic_text(text):
             issues.append(f"{field} is generic")
     return issues
 

--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -31,6 +31,8 @@ GENERIC_DIAGNOSTIC_TEXT = {
     "native failed",
     "native compilation failed",
     "uc auto build failed",
+    "uc auto build failed before backend classification completed",
+    "uc auto build fell back to the scarb backend",
 }
 
 
@@ -142,13 +144,18 @@ def is_generic_diagnostic_text(value: Any) -> bool:
     if not isinstance(value, str):
         return False
     normalized = value.strip().rstrip(".").lower()
-    return normalized in GENERIC_DIAGNOSTIC_TEXT
+    return normalized in GENERIC_DIAGNOSTIC_TEXT or normalized.startswith("uc auto build failed")
 
 
 def diagnostic_quality_issues(diag: dict[str, Any]) -> list[str]:
     issues = [f"missing {field}" for field in sorted(REQUIRED_DIAGNOSTIC_FIELDS) if field not in diag]
     for field in ("what_happened", "why"):
-        text = (diag.get(field) or "").strip()
+        raw = diag.get(field)
+        if not isinstance(raw, str):
+            if field in diag:
+                issues.append(f"{field} is not a string")
+            continue
+        text = raw.strip()
         if not text or is_generic_diagnostic_text(text):
             issues.append(f"{field} is generic")
     return issues

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -258,13 +258,21 @@ test_complete_but_generic_diagnostic_is_not_agent_grade() {
         "build_report": {
           "diagnostics": [
             {
+              "schema_version": 1,
               "code": "UCN2002",
               "category": "native_fallback_local_native_error",
+              "severity": "warn",
+              "title": "Native local build downgraded to Scarb",
+              "docs_url": "https://github.com/omarespejel/uc/blob/main/docs/agent/AGENT_DIAGNOSTICS.md#ucn2002",
               "what_happened": "   ",
               "why": "Compilation failed.",
               "how_to_fix": [
                 "Review the selected native toolchain lane."
               ],
+              "next_commands": [
+                "uc support native --manifest-path <Scarb.toml> --format json"
+              ],
+              "safe_automated_action": "inspect_native_support_then_retry",
               "retryable": true,
               "fallback_used": true,
               "toolchain_expected": "2.14.0",

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -377,9 +377,114 @@ JSON
   fi
 }
 
+test_remediation_fields_are_validated_without_overmatching() {
+  local fixture="$TEST_TMP_DIR/remediation-field-quality.json"
+  local out_json="$TEST_TMP_DIR/remediation-field-quality-opportunities.json"
+  cat > "$fixture" <<'JSON'
+{
+  "generated_at": "2026-04-25T00:00:00Z",
+  "summary": {
+    "support_matrix": {
+      "native_supported": 2,
+      "fallback_used": 0,
+      "native_unsupported": 0,
+      "build_failed": 0
+    },
+    "unstable_lanes": [],
+    "unstable_lane_count": 0
+  },
+  "cases": [
+    {
+      "tag": "detailed-prefixed-native-failure",
+      "manifest_path": "/tmp/detailed/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": [
+          {
+            "schema_version": 1,
+            "code": "UCN2002",
+            "category": "native_fallback_local_native_error",
+            "severity": "warn",
+            "title": "Native build failed with Cairo diagnostic E0002",
+            "docs_url": "https://github.com/omarespejel/uc/blob/main/docs/agent/AGENT_DIAGNOSTICS.md#ucn2002",
+            "what_happened": "uc auto build failed: error[E0002] Method span could not be called.",
+            "why": "The selected Cairo helper emitted E0002 while compiling a dependency.",
+            "how_to_fix": [
+              "Open the recorded native build log and inspect E0002."
+            ],
+            "next_commands": [
+              "uc replay /tmp/uc-failure.json"
+            ],
+            "safe_automated_action": "record_failure_bundle",
+            "retryable": true,
+            "fallback_used": false
+          }
+        ]
+      },
+      "support_matrix": {
+        "classification": "native_supported",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": false
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    },
+    {
+      "tag": "empty-remediation-fields",
+      "manifest_path": "/tmp/empty-remediation/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": [
+          {
+            "schema_version": 1,
+            "code": "UCN2002",
+            "category": "native_fallback_local_native_error",
+            "severity": "warn",
+            "title": "Native build failed with Cairo diagnostic E0002",
+            "docs_url": " ",
+            "what_happened": "The Cairo helper emitted error E0002 while compiling a dependency.",
+            "why": "The dependency calls a method that is unavailable for the selected core type.",
+            "how_to_fix": [],
+            "next_commands": [],
+            "safe_automated_action": "",
+            "retryable": true,
+            "fallback_used": false
+          }
+        ]
+      },
+      "support_matrix": {
+        "classification": "native_supported",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": false
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    }
+  ]
+}
+JSON
+
+  "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
+
+  local detailed_gap remediation_gap remediation_reason
+  detailed_gap="$(jq -r '.cases[] | select(.tag=="detailed-prefixed-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
+  remediation_gap="$(jq -r '.cases[] | select(.tag=="empty-remediation-fields") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
+  remediation_reason="$(jq -r '.cases[] | select(.tag=="empty-remediation-fields") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
+  assert_json_value "detailed_gap" "$detailed_gap" "false" "$out_json"
+  assert_json_value "remediation_gap" "$remediation_gap" "true" "$out_json"
+  if [[ "$remediation_reason" != *"docs_url is empty"* || "$remediation_reason" != *"how_to_fix is empty"* || "$remediation_reason" != *"next_commands is empty"* || "$remediation_reason" != *"safe_automated_action is empty"* ]]; then
+    echo "expected empty remediation fields to be named in UCO5001 reason" >&2
+    cat "$out_json" >&2
+    exit 1
+  fi
+}
+
 run_test "real_repo_summary_records_opportunities" test_real_repo_summary_records_opportunities
 run_test "deployed_wrapper_preserves_corpus_metadata" test_deployed_wrapper_preserves_corpus_metadata
 run_test "complete_but_generic_diagnostic_is_not_agent_grade" test_complete_but_generic_diagnostic_is_not_agent_grade
 run_test "stock_and_malformed_diagnostic_is_not_agent_grade" test_stock_and_malformed_diagnostic_is_not_agent_grade
+run_test "remediation_fields_are_validated_without_overmatching" test_remediation_fields_are_validated_without_overmatching
 
 echo "All corpus opportunity summary tests passed."

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -260,7 +260,7 @@ test_complete_but_generic_diagnostic_is_not_agent_grade() {
             {
               "code": "UCN2002",
               "category": "native_fallback_local_native_error",
-              "what_happened": "Compilation failed.",
+              "what_happened": "   ",
               "why": "Compilation failed.",
               "how_to_fix": [
                 "Review the selected native toolchain lane."

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -303,8 +303,83 @@ JSON
   fi
 }
 
+test_stock_and_malformed_diagnostic_is_not_agent_grade() {
+  local fixture="$TEST_TMP_DIR/stock-malformed-diagnostic.json"
+  local out_json="$TEST_TMP_DIR/stock-malformed-diagnostic-opportunities.json"
+  cat > "$fixture" <<'JSON'
+{
+  "generated_at": "2026-04-25T00:00:00Z",
+  "summary": {
+    "support_matrix": {
+      "native_supported": 0,
+      "fallback_used": 0,
+      "native_unsupported": 0,
+      "build_failed": 1
+    },
+    "unstable_lanes": [],
+    "unstable_lane_count": 0
+  },
+  "cases": [
+    {
+      "tag": "stock-malformed-native-failure",
+      "manifest_path": "/tmp/stock-malformed/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": false,
+        "reason": "uc auto build failed before backend classification completed",
+        "build_report": {
+          "diagnostics": [
+            {
+              "schema_version": 1,
+              "code": "UCN2002",
+              "category": "native_fallback_local_native_error",
+              "severity": "warn",
+              "title": "Native local build downgraded to Scarb",
+              "docs_url": "https://github.com/omarespejel/uc/blob/main/docs/agent/AGENT_DIAGNOSTICS.md#ucn2002",
+              "what_happened": "uc auto build failed before backend classification completed",
+              "why": {"message": "native build failed"},
+              "how_to_fix": [
+                "Review the selected native toolchain lane."
+              ],
+              "next_commands": [
+                "uc support native --manifest-path <Scarb.toml> --format json"
+              ],
+              "safe_automated_action": "inspect_native_support_then_retry",
+              "retryable": true,
+              "fallback_used": true
+            }
+          ]
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    }
+  ]
+}
+JSON
+
+  "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
+
+  local generic_gap weak_reason
+  generic_gap="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
+  weak_reason="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
+  assert_json_value "generic_gap" "$generic_gap" "true" "$out_json"
+  if [[ "$weak_reason" != *"what_happened is generic"* || "$weak_reason" != *"why is not a string"* ]]; then
+    echo "expected stock and malformed diagnostic fields to be named in UCO5001 reason" >&2
+    cat "$out_json" >&2
+    exit 1
+  fi
+}
+
 run_test "real_repo_summary_records_opportunities" test_real_repo_summary_records_opportunities
 run_test "deployed_wrapper_preserves_corpus_metadata" test_deployed_wrapper_preserves_corpus_metadata
 run_test "complete_but_generic_diagnostic_is_not_agent_grade" test_complete_but_generic_diagnostic_is_not_agent_grade
+run_test "stock_and_malformed_diagnostic_is_not_agent_grade" test_stock_and_malformed_diagnostic_is_not_agent_grade
 
 echo "All corpus opportunity summary tests passed."

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -225,7 +225,78 @@ test_deployed_wrapper_preserves_corpus_metadata() {
   fi
 }
 
+test_complete_but_generic_diagnostic_is_not_agent_grade() {
+  local fixture="$TEST_TMP_DIR/generic-diagnostic.json"
+  local out_json="$TEST_TMP_DIR/generic-diagnostic-opportunities.json"
+  cat > "$fixture" <<'JSON'
+{
+  "generated_at": "2026-04-25T00:00:00Z",
+  "summary": {
+    "support_matrix": {
+      "native_supported": 0,
+      "fallback_used": 0,
+      "native_unsupported": 0,
+      "build_failed": 1
+    },
+    "unstable_lanes": [],
+    "unstable_lane_count": 0
+  },
+  "cases": [
+    {
+      "tag": "generic-native-failure",
+      "manifest_path": "/tmp/generic/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": false,
+        "reason": "Compilation failed.",
+        "build_report": {
+          "diagnostics": [
+            {
+              "code": "UCN2002",
+              "category": "native_fallback_local_native_error",
+              "what_happened": "Compilation failed.",
+              "why": "Compilation failed.",
+              "how_to_fix": [
+                "Review the selected native toolchain lane."
+              ],
+              "retryable": true,
+              "fallback_used": true,
+              "toolchain_expected": "2.14.0",
+              "toolchain_found": "2.14.0"
+            }
+          ]
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    }
+  ]
+}
+JSON
+
+  "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
+
+  local generic_gap weak_reason build_blocker
+  generic_gap="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
+  weak_reason="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
+  build_blocker="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
+  assert_json_value "generic_gap" "$generic_gap" "true" "$out_json"
+  assert_json_value "build_blocker" "$build_blocker" "true" "$out_json"
+  if [[ "$weak_reason" != *"what_happened is generic"* || "$weak_reason" != *"why is generic"* ]]; then
+    echo "expected generic diagnostic fields to be named in UCO5001 reason" >&2
+    cat "$out_json" >&2
+    exit 1
+  fi
+}
+
 run_test "real_repo_summary_records_opportunities" test_real_repo_summary_records_opportunities
 run_test "deployed_wrapper_preserves_corpus_metadata" test_deployed_wrapper_preserves_corpus_metadata
+run_test "complete_but_generic_diagnostic_is_not_agent_grade" test_complete_but_generic_diagnostic_is_not_agent_grade
 
 echo "All corpus opportunity summary tests passed."

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -385,7 +385,7 @@ test_remediation_fields_are_validated_without_overmatching() {
   "generated_at": "2026-04-25T00:00:00Z",
   "summary": {
     "support_matrix": {
-      "native_supported": 2,
+      "native_supported": 3,
       "fallback_used": 0,
       "native_unsupported": 0,
       "build_failed": 0
@@ -461,6 +461,42 @@ test_remediation_fields_are_validated_without_overmatching() {
       },
       "benchmark_status": "skipped",
       "benchmarks": null
+    },
+    {
+      "tag": "wrong-required-types",
+      "manifest_path": "/tmp/wrong-types/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": [
+          {
+            "schema_version": "1",
+            "code": [],
+            "category": {},
+            "severity": "warn",
+            "title": "Native build failed with Cairo diagnostic E0002",
+            "docs_url": "https://github.com/omarespejel/uc/blob/main/docs/agent/AGENT_DIAGNOSTICS.md#ucn2002",
+            "what_happened": "The Cairo helper emitted error E0002 while compiling a dependency.",
+            "why": "The dependency calls a method that is unavailable for the selected core type.",
+            "how_to_fix": [
+              "Open the recorded native build log and inspect E0002."
+            ],
+            "next_commands": [
+              "uc replay /tmp/uc-failure.json"
+            ],
+            "safe_automated_action": "record_failure_bundle",
+            "retryable": "true",
+            "fallback_used": 1
+          }
+        ]
+      },
+      "support_matrix": {
+        "classification": "native_supported",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": false
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
     }
   ]
 }
@@ -468,14 +504,22 @@ JSON
 
   "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
 
-  local detailed_gap remediation_gap remediation_reason
+  local detailed_gap remediation_gap remediation_reason type_gap type_reason
   detailed_gap="$(jq -r '.cases[] | select(.tag=="detailed-prefixed-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
   remediation_gap="$(jq -r '.cases[] | select(.tag=="empty-remediation-fields") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
   remediation_reason="$(jq -r '.cases[] | select(.tag=="empty-remediation-fields") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
+  type_gap="$(jq -r '.cases[] | select(.tag=="wrong-required-types") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
+  type_reason="$(jq -r '.cases[] | select(.tag=="wrong-required-types") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
   assert_json_value "detailed_gap" "$detailed_gap" "false" "$out_json"
   assert_json_value "remediation_gap" "$remediation_gap" "true" "$out_json"
+  assert_json_value "type_gap" "$type_gap" "true" "$out_json"
   if [[ "$remediation_reason" != *"docs_url is empty"* || "$remediation_reason" != *"how_to_fix is empty"* || "$remediation_reason" != *"next_commands is empty"* || "$remediation_reason" != *"safe_automated_action is empty"* ]]; then
     echo "expected empty remediation fields to be named in UCO5001 reason" >&2
+    cat "$out_json" >&2
+    exit 1
+  fi
+  if [[ "$type_reason" != *"schema_version is not an integer"* || "$type_reason" != *"code is empty"* || "$type_reason" != *"category is empty"* || "$type_reason" != *"retryable is not a boolean"* || "$type_reason" != *"fallback_used is not a boolean"* ]]; then
+    echo "expected wrong required field types to be named in UCO5001 reason" >&2
     cat "$out_json" >&2
     exit 1
   fi

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -609,7 +609,8 @@ test_real_repo_benchmark_reports_prefetch_failure_context() {
   write_mock_scarb_bin "$mock_scarb"
   write_manifest_case "$cases_root" "fails-fetch"
 
-  if PATH="$mock_bin_dir:$PATH" \
+  local stdout_text
+  stdout_text="$(PATH="$mock_bin_dir:$PATH" \
     MOCK_UC_ARGS_LOG="$TEST_TMP_DIR/prefetch-uc.args" \
     MOCK_SCARB_ARGS_LOG="$TEST_TMP_DIR/prefetch-scarb.args" \
     "$BENCH_SCRIPT" \
@@ -619,21 +620,42 @@ test_real_repo_benchmark_reports_prefetch_failure_context() {
       --cold-runs 1 \
       --warm-settle-seconds 0 \
       --case "$cases_root/fails-fetch/Scarb.toml" fails-fetch \
-      >"$TEST_TMP_DIR/prefetch.out" 2>"$stderr_path"; then
-    echo "expected prefetch failure to fail the benchmark run" >&2
-    return 1
-  fi
+      2>"$stderr_path")"
 
-  if ! grep -q "forced scarb fetch failure" "$stderr_path"; then
-    echo "expected underlying scarb fetch failure in stderr" >&2
-    cat "$stderr_path" >&2
-    return 1
-  fi
+  local json_path
+  json_path="$(awk -F': ' '/Benchmark JSON:/ {print $2}' <<<"$stdout_text")"
+  local md_path
+  md_path="$(awk -F': ' '/Benchmark Markdown:/ {print $2}' <<<"$stdout_text")"
   local expected_manifest
   expected_manifest="$(cd "$cases_root/fails-fetch" && pwd -P)/Scarb.toml"
+  local classification
+  classification="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.classification' "$json_path")"
+  local benchmark_status
+  benchmark_status="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .benchmark_status' "$json_path")"
+  local log_path
+  log_path="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.log_path' "$json_path")"
+  local reason
+  reason="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.reason' "$json_path")"
+  if [[ "$classification" != "build_failed" || "$benchmark_status" != "skipped" || "$reason" != "scarb offline fetch failed before uc auto build classification" ]]; then
+    echo "expected prefetch failure to be recorded as a per-case build_failed support classification" >&2
+    cat "$json_path" >&2
+    return 1
+  fi
+  if [[ ! -f "$log_path" ]] || ! grep -q "forced scarb fetch failure" "$log_path"; then
+    echo "expected underlying scarb fetch failure in per-case log" >&2
+    cat "${log_path:-/dev/null}" >&2 || true
+    return 1
+  fi
   if ! grep -q "scarb fetch failed for manifest_path=$expected_manifest" "$stderr_path"; then
-    echo "expected manifest-scoped scarb fetch failure context" >&2
+    echo "expected manifest-scoped scarb fetch failure context on stderr" >&2
     cat "$stderr_path" >&2
+    return 1
+  fi
+  local markdown_text
+  markdown_text="$(cat "$md_path")"
+  if [[ "$markdown_text" != *"| fails-fetch | 1 | $log_path | scarb offline fetch failed before uc auto build classification |"* ]]; then
+    echo "expected markdown auto-build classification row for prefetch failure" >&2
+    cat "$md_path" >&2
     return 1
   fi
 }

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -632,11 +632,13 @@ test_real_repo_benchmark_reports_prefetch_failure_context() {
   classification="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.classification' "$json_path")"
   local benchmark_status
   benchmark_status="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .benchmark_status' "$json_path")"
+  local exit_code
+  exit_code="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.exit_code' "$json_path")"
   local log_path
   log_path="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.log_path' "$json_path")"
   local reason
   reason="$(jq -r '.cases[] | select(.tag=="fails-fetch") | .support_matrix.reason' "$json_path")"
-  if [[ "$classification" != "build_failed" || "$benchmark_status" != "skipped" || "$reason" != "scarb offline fetch failed before uc auto build classification" ]]; then
+  if [[ "$classification" != "build_failed" || "$benchmark_status" != "skipped" || "$exit_code" != "18" || "$reason" != "scarb offline fetch failed before uc auto build classification" ]]; then
     echo "expected prefetch failure to be recorded as a per-case build_failed support classification" >&2
     cat "$json_path" >&2
     return 1
@@ -651,9 +653,14 @@ test_real_repo_benchmark_reports_prefetch_failure_context() {
     cat "$stderr_path" >&2
     return 1
   fi
+  if ! grep -q "exit_code=18" "$stderr_path"; then
+    echo "expected real scarb fetch exit code on stderr" >&2
+    cat "$stderr_path" >&2
+    return 1
+  fi
   local markdown_text
   markdown_text="$(cat "$md_path")"
-  if [[ "$markdown_text" != *"| fails-fetch | 1 | $log_path | scarb offline fetch failed before uc auto build classification |"* ]]; then
+  if [[ "$markdown_text" != *"| fails-fetch | 18 | $log_path | scarb offline fetch failed before uc auto build classification |"* ]]; then
     echo "expected markdown auto-build classification row for prefetch failure" >&2
     cat "$md_path" >&2
     return 1

--- a/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
+++ b/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
@@ -77,12 +77,14 @@ expand coverage, surface blockers, and produce an agent-readable backlog.
 
 Artifacts:
 
-- Cases file: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/cases.tsv`
-- Benchmark JSON: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/results/real-repo-bench-20260426-011206.json`
-- Benchmark Markdown: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/results/real-repo-bench-20260426-011206.md`
-- Opportunity JSON: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/corpus-opportunities.json`
-- Opportunity Markdown: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/corpus-opportunities.md`
-- Cairo 2.14 helper: `/Users/espejelomar/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`
+- Evidence root: `<abs/path>/uc-20-contract-experiment-20260425`
+- Cases file: `<evidence-root>/cases.tsv`
+- Benchmark JSON: `<evidence-root>/results/real-repo-bench-20260426-011206.json`
+- Benchmark Markdown: `<evidence-root>/results/real-repo-bench-20260426-011206.md`
+- Opportunity JSON: `<evidence-root>/corpus-opportunities.json`
+- Opportunity Markdown: `<evidence-root>/corpus-opportunities.md`
+- Cairo 2.14 helper: `${UC_NATIVE_TOOLCHAIN_2_14_BIN}`, produced by
+  `./scripts/build_native_toolchain_helper.sh --lane 2.14`
 
 Support matrix:
 

--- a/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
+++ b/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
@@ -128,7 +128,8 @@ Low-sample same-window observed ratios for native-supported rows:
 - Benchmark lane: `benchmarks/scripts/run_real_repo_benchmarks.sh` real-repo
   lane, comparing `scarb build` against `uc build --engine uc --daemon-mode off
   --offline`.
-- Stages: `build.cold` p95 and `build.warm_noop` p95.
+- Stages: `build.cold` observed value and `build.warm_noop` observed value
+  from a single-sample diagnostic run.
 - Sample settings: `--runs 1`, `--cold-runs 1`,
   `--warm-settle-seconds 0`, `--timeout-secs 180`.
 - Host condition: local ad hoc macOS developer workstation run; no pinned CPU,
@@ -137,7 +138,7 @@ Low-sample same-window observed ratios for native-supported rows:
   real-repo diagnostic sweep. The ratios below are backlog triage signals only,
   not launch speed claims.
 
-| Tag | Cold p95 observed ratio | Warm no-op p95 observed ratio | Launch-use status |
+| Tag | Cold observed ratio (single-sample) | Warm no-op observed ratio (single-sample) | Launch-use status |
 |---|---:|---:|---|
 | `braavos_account` | 1.196x | 34.334x | Diagnostic only; cold speedup weak. |
 | `monero_atomic_swap` | 1.211x | 135.222x | Diagnostic only; cold speedup weak. |

--- a/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
+++ b/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
@@ -63,8 +63,89 @@ The summary script emits stable `UCO*` codes:
 | `UCO3007` | Native session prepare is material | Inspect helper/session setup overhead. |
 | `UCO4001` | Launch evidence candidate | Keep only if benchmark claim guards also pass. |
 | `UCO4002` | Strong warm no-op speedup | Quote only with sample, lane, host, and stability caveats. |
-| `UCO5001` | Diagnostic is not agent-grade | Extend diagnostic fields before automated remediation. |
+| `UCO5001` | Diagnostic is not agent-grade | Extend missing or generic diagnostic detail before automated remediation. |
 
 ## Launch Boundary
 
 The 20-contract corpus is an experiment harness first. It becomes launch evidence only after support and claim guards are true for the exact artifact being quoted.
+
+## 2026-04-26 Local 20-Case Sweep
+
+This sweep is diagnostic evidence, not launch copy. It used `--runs 1`,
+`--cold-runs 1`, and no pinned-host strict stability window. The purpose was to
+expand coverage, surface blockers, and produce an agent-readable backlog.
+
+Artifacts:
+
+- Cases file: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/cases.tsv`
+- Benchmark JSON: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/results/real-repo-bench-20260426-011206.json`
+- Benchmark Markdown: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/results/real-repo-bench-20260426-011206.md`
+- Opportunity JSON: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/corpus-opportunities.json`
+- Opportunity Markdown: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/corpus-opportunities.md`
+- Cairo 2.14 helper: `/Users/espejelomar/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`
+
+Support matrix:
+
+| Classification | Count |
+|---|---:|
+| `native_supported` | 12 |
+| `native_unsupported` | 6 |
+| `fallback_used` | 0 |
+| `build_failed` | 2 |
+
+Benchmark status:
+
+| Status | Count |
+|---|---:|
+| `ok` | 12 |
+| `skipped` | 8 |
+
+Opportunity counts after applying the generic-diagnostic quality rule:
+
+| Code | Count | Meaning |
+|---|---:|---|
+| `UCO1001` | 6 | Native support gap. |
+| `UCO1003` | 2 | Auto-build classification failed. |
+| `UCO3001` | 12 | Native frontend compile dominates. |
+| `UCO3006` | 2 | Cold speedup is weak. |
+| `UCO4001` | 12 | Bounded launch-evidence candidate after stricter validation. |
+| `UCO4002` | 2 | Strong warm no-op speedup. |
+| `UCO5001` | 4 | Diagnostic is not agent-grade. |
+
+The two `build_failed` rows were `accounts_workshop` and
+`starknetpy_contracts`. Both selected the Cairo 2.14 external helper and failed
+inside a cached `cairo-contracts` dependency with a Cairo diagnostic shaped like
+`error[E0002]: Method span could not be called on type core::array::Span::<core::felt252>`.
+The generated build reports carried structured `UCN2002` diagnostics, but the
+`what_happened` and `why` fields were only `Compilation failed.`. That is too
+generic for an agent to remediate, so the opportunity summarizer now treats
+generic diagnostic text as `UCO5001` even when all required fields are present.
+
+Low-sample same-window speed ratios for native-supported rows:
+
+| Tag | Cold p95 speedup | Warm no-op p95 speedup | Launch-use status |
+|---|---:|---:|---|
+| `braavos_account` | 1.196x | 34.334x | Diagnostic only; cold speedup weak. |
+| `monero_atomic_swap` | 1.211x | 135.222x | Diagnostic only; cold speedup weak. |
+| `agentic_session` | 1.821x | 4.819x | Needs strict rerun. |
+| `agentic_agent` | 2.089x | 4.530x | Needs strict rerun. |
+| `agentic_erc8004` | 1.789x | 8.791x | Needs strict rerun. |
+| `agentic_huginn` | 1.562x | 2.102x | Needs strict rerun. |
+| `book_ownable` | 1.290x | 0.544x | Warm regression target. |
+| `book_vote_contracts` | 1.693x | 6.109x | Needs strict rerun. |
+| `book_ownable_components` | 1.918x | 6.284x | Needs strict rerun. |
+| `token_factory` | 1.287x | 0.977x | Warm parity/regression target. |
+| `zcash_relay` | 1.747x | 1.058x | Needs strict rerun. |
+| `glint_contracts` | 2.132x | 3.123x | Needs strict rerun. |
+
+Next blockers from this sweep:
+
+1. Add or select helper lanes for the remaining unsupported Cairo versions
+   before counting those rows as solved.
+2. Turn generic native compile failures into agent-grade diagnostics with the
+   original Cairo error code, source span, expected/found toolchain, retryability,
+   fallback state, and replay/log path.
+3. Rerun only native-supported cases under strict same-window sample settings
+   before using any speed ratio externally.
+4. Profile `native_frontend_compile_ms` on supported repos first; this was the
+   dominant hotspot across all 12 supported rows.

--- a/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
+++ b/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
@@ -123,9 +123,21 @@ The generated build reports carried structured `UCN2002` diagnostics, but the
 generic for an agent to remediate, so the opportunity summarizer now treats
 generic diagnostic text as `UCO5001` even when all required fields are present.
 
-Low-sample same-window speed ratios for native-supported rows:
+Low-sample same-window observed ratios for native-supported rows:
 
-| Tag | Cold p95 speedup | Warm no-op p95 speedup | Launch-use status |
+- Benchmark lane: `benchmarks/scripts/run_real_repo_benchmarks.sh` real-repo
+  lane, comparing `scarb build` against `uc build --engine uc --daemon-mode off
+  --offline`.
+- Stages: `build.cold` p95 and `build.warm_noop` p95.
+- Sample settings: `--runs 1`, `--cold-runs 1`,
+  `--warm-settle-seconds 0`, `--timeout-secs 180`.
+- Host condition: local ad hoc macOS developer workstation run; no pinned CPU,
+  no strict host-noise preflight, and no recorded hardware claim metadata.
+- Claim-guard status: no deployed-contract `claim_guard` was produced for this
+  real-repo diagnostic sweep. The ratios below are backlog triage signals only,
+  not launch speed claims.
+
+| Tag | Cold p95 observed ratio | Warm no-op p95 observed ratio | Launch-use status |
 |---|---:|---:|---|
 | `braavos_account` | 1.196x | 34.334x | Diagnostic only; cold speedup weak. |
 | `monero_atomic_swap` | 1.211x | 135.222x | Diagnostic only; cold speedup weak. |


### PR DESCRIPTION
## Summary

- keep real-repo corpus sweeps alive when `scarb --offline fetch` fails by recording a per-case `build_failed` row and log path
- flag complete-but-generic diagnostics like `Compilation failed.` as `UCO5001` so agents do not treat them as remediation-ready
- document the local 20-case corpus sweep, support matrix, low-sample speed ratios, and remaining launch blockers

## Validation

- `./benchmarks/scripts/tests/corpus_opportunity_summary_test.sh`
- `./benchmarks/scripts/tests/real_repo_benchmark_test.sh`
- `git diff --check`
- `make agent-validate`
- `TMPDIR="$PWD/.tmp" make local-ci`
- pre-push hook reran `make local-ci` successfully

## Notes

The 20-case numbers are explicitly documented as diagnostic evidence only: `--runs 1`, `--cold-runs 1`, no strict pinned-host stability window. The launch path still requires strict same-window reruns and claim-guarded corpus artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-case fetch logging now captures fetch output and exit codes and yields per-case failure results (no longer aborting full sweeps).

* **Behavior Change**
  * UCO5001 redefined to flag missing or overly generic diagnostic remediation detail; reports “weak remediation detail” with enumerated quality issues.

* **Documentation**
  * Benchmarks and experiment docs updated to describe per-case failure reporting and the refined diagnostic-quality rule.

* **Tests**
  * Added/updated tests for per-case fetch handling and generic-diagnostic detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->