### PR TITLE
[codex] Improve native fallback diagnostics for agents

### DIFF
--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -14,7 +14,11 @@ const DAEMON_LOCAL_PROBE_HINT_MAX_ENTRIES_PER_DIR: usize = 256;
 const DAEMON_LOCAL_PROBE_HINT_MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
 const MAX_AGENT_DIAGNOSTIC_REASON_CHARS: usize = 2_000;
 const MAX_FALLBACK_ERROR_BLOCKS: usize = 3;
+const MIN_FALLBACK_ERROR_SUMMARY_CHARS: usize = 800;
+const FALLBACK_ERROR_SUMMARY_SEPARATOR: &str = " Fallback build failure summary: ";
+const TRUNCATED_DIAGNOSTIC_SUFFIX: &str = "...";
 
+/// Creates the base native-fallback diagnostic shared by native downgrade paths.
 fn native_fallback_diagnostic(
     code: &str,
     category: &str,
@@ -48,6 +52,7 @@ fn native_fallback_diagnostic(
     }
 }
 
+/// Builds a UCN2002 diagnostic from an anyhow error chain without losing generic roots.
 fn native_fallback_diagnostic_from_error(
     code: &str,
     category: &str,
@@ -104,6 +109,7 @@ fn native_fallback_diagnostic_from_error(
     diagnostic
 }
 
+/// Returns the de-duplicated anyhow error chain from outer context to root cause.
 fn native_error_chain(err: &anyhow::Error) -> Vec<String> {
     let mut chain = Vec::new();
     for cause in err.chain() {
@@ -120,6 +126,7 @@ fn native_error_chain(err: &anyhow::Error) -> Vec<String> {
     chain
 }
 
+/// Detects root causes that need surrounding error-chain context to be useful.
 fn is_generic_native_compile_failure(reason: &str) -> bool {
     let normalized = reason.trim().trim_end_matches('.').to_ascii_lowercase();
     matches!(
@@ -128,19 +135,55 @@ fn is_generic_native_compile_failure(reason: &str) -> bool {
     )
 }
 
+/// Truncates agent-facing diagnostic text to the standard reason character budget.
 fn truncate_agent_diagnostic_text(value: &str) -> String {
+    truncate_agent_diagnostic_text_to(value, MAX_AGENT_DIAGNOSTIC_REASON_CHARS)
+}
+
+/// Truncates agent-facing diagnostic text using a character budget, including suffix.
+fn truncate_agent_diagnostic_text_to(value: &str, max_chars: usize) -> String {
     let trimmed = value.trim();
-    if trimmed.len() <= MAX_AGENT_DIAGNOSTIC_REASON_CHARS {
+    if trimmed.chars().count() <= max_chars {
         return trimmed.to_string();
     }
-    let mut truncated = trimmed
-        .chars()
-        .take(MAX_AGENT_DIAGNOSTIC_REASON_CHARS)
-        .collect::<String>();
-    truncated.push_str("...");
+    if max_chars == 0 {
+        return String::new();
+    }
+    let suffix_chars = TRUNCATED_DIAGNOSTIC_SUFFIX.chars().count();
+    let take_chars = max_chars.saturating_sub(suffix_chars);
+    let mut truncated = trimmed.chars().take(take_chars).collect::<String>();
+    if take_chars > 0 {
+        truncated.push_str(TRUNCATED_DIAGNOSTIC_SUFFIX);
+    }
     truncated
 }
 
+/// Combines native and fallback failures while reserving room for fallback output.
+fn native_fallback_reason_with_fallback_summary(
+    native_why: &str,
+    fallback_summary: &str,
+) -> String {
+    let separator_chars = FALLBACK_ERROR_SUMMARY_SEPARATOR.chars().count();
+    let available_chars = MAX_AGENT_DIAGNOSTIC_REASON_CHARS.saturating_sub(separator_chars);
+    if available_chars == 0 {
+        return truncate_agent_diagnostic_text(fallback_summary);
+    }
+
+    let fallback_chars = fallback_summary.trim().chars().count();
+    let fallback_min_budget =
+        fallback_chars.min(MIN_FALLBACK_ERROR_SUMMARY_CHARS.min(available_chars));
+    let native_budget = available_chars.saturating_sub(fallback_min_budget);
+    let native_section = truncate_agent_diagnostic_text_to(native_why, native_budget);
+    let native_chars = native_section.chars().count();
+    let fallback_budget = available_chars.saturating_sub(native_chars);
+    let fallback_section = truncate_agent_diagnostic_text_to(fallback_summary, fallback_budget);
+
+    truncate_agent_diagnostic_text(&format!(
+        "{native_section}{FALLBACK_ERROR_SUMMARY_SEPARATOR}{fallback_section}"
+    ))
+}
+
+/// Adds fallback build failure details to an existing native-fallback diagnostic.
 fn enrich_native_fallback_diagnostic_with_fallback_run(
     diagnostic: &mut NativeDiagnostic,
     fallback_run: &CommandRun,
@@ -163,9 +206,7 @@ fn enrich_native_fallback_diagnostic_with_fallback_run(
         "Native Cairo compilation failed, uc downgraded to Scarb, and the fallback build exited with code {}.",
         fallback_run.exit_code
     );
-    diagnostic.why = truncate_agent_diagnostic_text(&format!(
-        "{native_why} Fallback build failure summary: {fallback_summary}"
-    ));
+    diagnostic.why = native_fallback_reason_with_fallback_summary(&native_why, &fallback_summary);
     diagnostic.how_to_fix.push(
         "Fix the fallback compiler diagnostics before claiming native support for this manifest."
             .to_string(),
@@ -175,6 +216,7 @@ fn enrich_native_fallback_diagnostic_with_fallback_run(
     );
 }
 
+/// Extracts the first actionable compiler diagnostic blocks from fallback output.
 fn extract_fallback_error_summary(stderr: &str, stdout: &str) -> Option<String> {
     let combined = if stdout.trim().is_empty() {
         stderr.to_string()
@@ -190,6 +232,7 @@ fn extract_fallback_error_summary(stderr: &str, stdout: &str) -> Option<String> 
     Some(truncate_agent_diagnostic_text(&blocks.join("\n---\n")))
 }
 
+/// Prefers compiler error blocks and falls back to warning blocks when needed.
 fn extract_agent_error_blocks(output: &str) -> Vec<String> {
     let error_blocks = extract_agent_diagnostic_blocks(output, is_agent_error_lead);
     if !error_blocks.is_empty() {
@@ -198,6 +241,7 @@ fn extract_agent_error_blocks(output: &str) -> Vec<String> {
     extract_agent_diagnostic_blocks(output, is_agent_warning_lead)
 }
 
+/// Extracts bounded diagnostic blocks using the supplied lead-line classifier.
 fn extract_agent_diagnostic_blocks(output: &str, is_lead: impl Fn(&str) -> bool) -> Vec<String> {
     let mut blocks = Vec::new();
     let mut current = Vec::new();
@@ -236,12 +280,14 @@ fn extract_agent_diagnostic_blocks(output: &str, is_lead: impl Fn(&str) -> bool)
     blocks
 }
 
+/// Returns true for compiler output lines that begin an error block.
 fn is_agent_error_lead(line: &str) -> bool {
     let trimmed = line.trim_start();
     let lowered = trimmed.to_ascii_lowercase();
     lowered.starts_with("error:") || lowered.starts_with("error[") || lowered.starts_with("error ")
 }
 
+/// Returns true for compiler output lines that begin a warning block.
 fn is_agent_warning_lead(line: &str) -> bool {
     let trimmed = line.trim_start();
     let lowered = trimmed.to_ascii_lowercase();
@@ -250,6 +296,7 @@ fn is_agent_warning_lead(line: &str) -> bool {
         || trimmed.starts_with("Plugin diagnostic")
 }
 
+/// Returns true for source spans and indented lines that belong to the active block.
 fn is_agent_error_continuation(line: &str) -> bool {
     if line.trim().is_empty() {
         return false;
@@ -2083,6 +2130,130 @@ mod tests {
                 .any(|command| command.contains("--engine scarb")),
             "agents need a command to isolate fallback build failures: {:?}",
             diagnostic.next_commands
+        );
+    }
+
+    #[test]
+    fn native_fallback_diagnostic_reserves_fallback_error_budget() {
+        let err = anyhow::anyhow!("Compilation failed.").context("native cairo compile failed");
+        let mut diagnostic = native_fallback_diagnostic_from_error(
+            "UCN2002",
+            "native_fallback_local_native_error",
+            "Native local build downgraded to Scarb",
+            &err,
+            None,
+        );
+        diagnostic.why = "native chain entry -> ".repeat(300);
+        let fallback_run = CommandRun {
+            command: vec!["scarb".to_string(), "build".to_string()],
+            exit_code: 1,
+            elapsed_ms: 10.0,
+            stdout: String::new(),
+            stderr: "error[E0002]: Method `span` could not be called on type `core::array::Span::<core::felt252>`.\n --> src/account.cairo:254:64\n        calldata.span()\n                 ^^^^\n".to_string(),
+        };
+
+        enrich_native_fallback_diagnostic_with_fallback_run(&mut diagnostic, &fallback_run);
+
+        assert!(
+            diagnostic.why.contains("Fallback build failure summary"),
+            "fallback section should always remain visible: {}",
+            diagnostic.why
+        );
+        assert!(
+            diagnostic.why.contains("error[E0002]"),
+            "fallback compiler errors must survive long native chains: {}",
+            diagnostic.why
+        );
+        assert!(
+            diagnostic.why.chars().count() <= MAX_AGENT_DIAGNOSTIC_REASON_CHARS,
+            "diagnostic reason should respect the char budget: {} chars",
+            diagnostic.why.chars().count()
+        );
+    }
+
+    #[test]
+    fn truncate_agent_diagnostic_text_uses_char_budget() {
+        let input = "é".repeat(MAX_AGENT_DIAGNOSTIC_REASON_CHARS + 20);
+
+        let truncated = truncate_agent_diagnostic_text(&input);
+
+        assert!(
+            truncated.chars().count() <= MAX_AGENT_DIAGNOSTIC_REASON_CHARS,
+            "truncation should enforce a char budget, not mix byte and char units"
+        );
+        assert!(truncated.ends_with(TRUNCATED_DIAGNOSTIC_SUFFIX));
+    }
+
+    #[test]
+    fn build_report_json_preserves_enriched_ucn2002_payload() {
+        let err = anyhow::anyhow!("Compilation failed.")
+            .context("native starknet compile failed")
+            .context("native fallback to scarb is allowed");
+        let mut diagnostic = native_fallback_diagnostic_from_error(
+            "UCN2002",
+            "native_fallback_local_native_error",
+            "Native local build downgraded to Scarb",
+            &err,
+            None,
+        );
+        let fallback_run = CommandRun {
+            command: vec!["scarb".to_string(), "build".to_string()],
+            exit_code: 1,
+            elapsed_ms: 10.0,
+            stdout: String::new(),
+            stderr: "error[E0002]: Method `span` could not be called on type `core::array::Span::<core::felt252>`.\n --> src/account.cairo:254:64\n        calldata.span()\n                 ^^^^\n".to_string(),
+        };
+        enrich_native_fallback_diagnostic_with_fallback_run(&mut diagnostic, &fallback_run);
+        let report = BuildReport {
+            schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+            generated_at_epoch_ms: 1,
+            engine: "uc".to_string(),
+            daemon_used: false,
+            manifest_path: "/tmp/workspace/Scarb.toml".to_string(),
+            workspace_root: "/tmp/workspace".to_string(),
+            profile: "dev".to_string(),
+            session_key: "test-session".to_string(),
+            command: vec!["scarb".to_string(), "build".to_string()],
+            exit_code: 1,
+            elapsed_ms: 10.0,
+            cache_hit: false,
+            fingerprint: "test-fingerprint".to_string(),
+            artifact_count: 0,
+            phase_telemetry: None,
+            compile_backend: Some("scarb_fallback".to_string()),
+            native_toolchain: None,
+            diagnostics: vec![diagnostic],
+        };
+
+        let report_json = serde_json::to_value(&report).expect("build report should serialize");
+        let payload = &report_json["diagnostics"][0];
+        assert_eq!(payload["code"], "UCN2002");
+        assert!(payload["what_happened"]
+            .as_str()
+            .expect("what_happened should be a string")
+            .contains("Native Cairo compilation failed"));
+        assert!(payload["why"]
+            .as_str()
+            .expect("why should be a string")
+            .contains("native starknet compile failed"));
+        assert!(payload["why"]
+            .as_str()
+            .expect("why should be a string")
+            .contains("error[E0002]"));
+        let next_commands = payload["next_commands"]
+            .as_array()
+            .expect("next_commands should be an array");
+        assert!(
+            next_commands.iter().any(|command| command
+                .as_str()
+                .is_some_and(|value| value.contains("--record-failure"))),
+            "report JSON should preserve replay-bundle next command: {next_commands:?}"
+        );
+        assert!(
+            next_commands.iter().any(|command| command
+                .as_str()
+                .is_some_and(|value| value.contains("--engine scarb"))),
+            "report JSON should preserve fallback isolation next command: {next_commands:?}"
         );
     }
 

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -12,6 +12,8 @@ const DEFAULT_UC_NATIVE_FALLBACK_HINT_RETRY_SECS: u64 = 30 * 60;
 // so total footprint can be up to 2x this value across both directories.
 const DAEMON_LOCAL_PROBE_HINT_MAX_ENTRIES_PER_DIR: usize = 256;
 const DAEMON_LOCAL_PROBE_HINT_MAX_AGE_SECS: u64 = 7 * 24 * 60 * 60;
+const MAX_AGENT_DIAGNOSTIC_REASON_CHARS: usize = 2_000;
+const MAX_FALLBACK_ERROR_BLOCKS: usize = 3;
 
 fn native_fallback_diagnostic(
     code: &str,
@@ -44,6 +46,219 @@ fn native_fallback_diagnostic(
             .and_then(|entry| entry.requested_version.clone().or(entry.requested_major_minor.clone())),
         toolchain_found: toolchain.and_then(|entry| entry.compiler_version.clone()),
     }
+}
+
+fn native_fallback_diagnostic_from_error(
+    code: &str,
+    category: &str,
+    title: &str,
+    err: &anyhow::Error,
+    toolchain: Option<&NativeToolchainReport>,
+) -> NativeDiagnostic {
+    let chain = native_error_chain(err);
+    let root_cause = err.root_cause().to_string();
+    let stage = chain
+        .iter()
+        .find(|message| {
+            message.contains("native starknet compile failed")
+                || message.contains("native cairo compile failed")
+                || message.contains("native compile")
+        })
+        .cloned()
+        .unwrap_or_else(|| "native Cairo compilation failed".to_string());
+    let chain_summary = truncate_agent_diagnostic_text(&chain.join(" -> "));
+
+    let mut diagnostic = native_fallback_diagnostic(
+        code,
+        category,
+        title,
+        if is_generic_native_compile_failure(&root_cause) {
+            format!(
+                "Native Cairo compilation failed before native artifacts were produced ({stage})."
+            )
+        } else {
+            format!(
+                "Native Cairo compilation failed before native artifacts were produced: {root_cause}"
+            )
+        },
+        toolchain,
+    );
+    diagnostic.why = if is_generic_native_compile_failure(&root_cause) {
+        format!(
+            "The native compiler returned a generic root cause (`{root_cause}`). Full error chain: {chain_summary}"
+        )
+    } else {
+        format!("Full native error chain: {chain_summary}")
+    };
+    diagnostic.how_to_fix = vec![
+        "Inspect the native error chain and selected toolchain lane before changing source code."
+            .to_string(),
+        "If the fallback build also failed, fix the reported Cairo compiler errors first, then rerun native with fallback disallowed to isolate native-only failures.".to_string(),
+        "If the failure comes from a registry or git dependency, keep it in the support matrix until the dependency/toolchain combination is validated.".to_string(),
+    ];
+    diagnostic.next_commands = vec![
+        "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+        "uc build --engine uc --daemon-mode off --manifest-path <Scarb.toml> --report-path /tmp/uc-build-report.json".to_string(),
+        "UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 uc build --engine uc --daemon-mode off --manifest-path <Scarb.toml> --record-failure /tmp/uc-failure.json".to_string(),
+    ];
+    diagnostic
+}
+
+fn native_error_chain(err: &anyhow::Error) -> Vec<String> {
+    let mut chain = Vec::new();
+    for cause in err.chain() {
+        let message = cause.to_string();
+        let message = message.trim();
+        if message.is_empty() || chain.iter().any(|existing| existing == message) {
+            continue;
+        }
+        chain.push(message.to_string());
+    }
+    if chain.is_empty() {
+        chain.push(err.to_string());
+    }
+    chain
+}
+
+fn is_generic_native_compile_failure(reason: &str) -> bool {
+    let normalized = reason.trim().trim_end_matches('.').to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "compilation failed" | "native failed" | "build failed"
+    )
+}
+
+fn truncate_agent_diagnostic_text(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.len() <= MAX_AGENT_DIAGNOSTIC_REASON_CHARS {
+        return trimmed.to_string();
+    }
+    let mut truncated = trimmed
+        .chars()
+        .take(MAX_AGENT_DIAGNOSTIC_REASON_CHARS)
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn enrich_native_fallback_diagnostic_with_fallback_run(
+    diagnostic: &mut NativeDiagnostic,
+    fallback_run: &CommandRun,
+) {
+    if fallback_run.exit_code == 0 {
+        return;
+    }
+
+    let fallback_summary =
+        extract_fallback_error_summary(&fallback_run.stderr, &fallback_run.stdout).unwrap_or_else(
+            || {
+                format!(
+            "Scarb fallback command exited with code {} without captured compiler diagnostics.",
+            fallback_run.exit_code
+        )
+            },
+        );
+    let native_why = diagnostic.why.clone();
+    diagnostic.what_happened = format!(
+        "Native Cairo compilation failed, uc downgraded to Scarb, and the fallback build exited with code {}.",
+        fallback_run.exit_code
+    );
+    diagnostic.why = truncate_agent_diagnostic_text(&format!(
+        "{native_why} Fallback build failure summary: {fallback_summary}"
+    ));
+    diagnostic.how_to_fix.push(
+        "Fix the fallback compiler diagnostics before claiming native support for this manifest."
+            .to_string(),
+    );
+    diagnostic.next_commands.push(
+        "uc build --engine scarb --daemon-mode off --manifest-path <Scarb.toml> --report-path /tmp/uc-scarb-fallback-report.json".to_string(),
+    );
+}
+
+fn extract_fallback_error_summary(stderr: &str, stdout: &str) -> Option<String> {
+    let combined = if stdout.trim().is_empty() {
+        stderr.to_string()
+    } else if stderr.trim().is_empty() {
+        stdout.to_string()
+    } else {
+        format!("{stderr}\n{stdout}")
+    };
+    let blocks = extract_agent_error_blocks(&combined);
+    if blocks.is_empty() {
+        return None;
+    }
+    Some(truncate_agent_diagnostic_text(&blocks.join("\n---\n")))
+}
+
+fn extract_agent_error_blocks(output: &str) -> Vec<String> {
+    let error_blocks = extract_agent_diagnostic_blocks(output, is_agent_error_lead);
+    if !error_blocks.is_empty() {
+        return error_blocks;
+    }
+    extract_agent_diagnostic_blocks(output, is_agent_warning_lead)
+}
+
+fn extract_agent_diagnostic_blocks(output: &str, is_lead: impl Fn(&str) -> bool) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current = Vec::new();
+
+    for raw_line in output.lines() {
+        let line = raw_line.trim_end();
+        if is_lead(line) {
+            if !current.is_empty() {
+                blocks.push(current.join("\n"));
+                current.clear();
+                if blocks.len() >= MAX_FALLBACK_ERROR_BLOCKS {
+                    break;
+                }
+            }
+            current.push(line.to_string());
+            continue;
+        }
+
+        if !current.is_empty() && is_agent_error_continuation(line) {
+            current.push(line.to_string());
+            continue;
+        }
+
+        if !current.is_empty() {
+            blocks.push(current.join("\n"));
+            current.clear();
+            if blocks.len() >= MAX_FALLBACK_ERROR_BLOCKS {
+                break;
+            }
+        }
+    }
+
+    if !current.is_empty() && blocks.len() < MAX_FALLBACK_ERROR_BLOCKS {
+        blocks.push(current.join("\n"));
+    }
+    blocks
+}
+
+fn is_agent_error_lead(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let lowered = trimmed.to_ascii_lowercase();
+    lowered.starts_with("error:") || lowered.starts_with("error[") || lowered.starts_with("error ")
+}
+
+fn is_agent_warning_lead(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let lowered = trimmed.to_ascii_lowercase();
+    lowered.starts_with("warn:")
+        || lowered.starts_with("warning:")
+        || trimmed.starts_with("Plugin diagnostic")
+}
+
+fn is_agent_error_continuation(line: &str) -> bool {
+    if line.trim().is_empty() {
+        return false;
+    }
+    line.starts_with(' ')
+        || line.starts_with('\t')
+        || line.trim_start().starts_with("-->")
+        || line.trim_start().starts_with('|')
+        || line.trim_start().starts_with('=')
 }
 
 fn diagnostics_used_native_fallback(diagnostics: &[NativeDiagnostic]) -> bool {
@@ -1194,13 +1409,13 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                                     );
                                 }
                                 record_native_fallback(NativeFallbackReason::LocalNativeError);
-                                diagnostics.borrow_mut().push(native_fallback_diagnostic(
+                                let mut diagnostic = native_fallback_diagnostic_from_error(
                                     "UCN2002",
                                     "native_fallback_local_native_error",
                                     "Native local build downgraded to Scarb",
-                                    format!("{}", native_err.root_cause()),
+                                    &native_err,
                                     native_toolchain.as_ref(),
-                                ));
+                                );
                                 eprintln!(
                                     "uc: native compile unavailable ({}), falling back to scarb backend",
                                     native_err.root_cause()
@@ -1213,6 +1428,11 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                                         &compiler_version,
                                         BuildCompileBackend::Scarb,
                                     )?;
+                                enrich_native_fallback_diagnostic_with_fallback_run(
+                                    &mut diagnostic,
+                                    &run,
+                                );
+                                diagnostics.borrow_mut().push(diagnostic);
                                 let _ = persist_daemon_local_probe_hint(
                                     &workspace_root,
                                     &native_session_key,
@@ -1778,6 +1998,92 @@ mod tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+
+    #[test]
+    fn native_fallback_diagnostic_expands_generic_compiler_root_cause() {
+        let err = anyhow::anyhow!("Compilation failed.")
+            .context("native starknet compile failed")
+            .context(
+                "native compile manifest includes non-starknet dependencies (cairo-contracts); retrying with scarb fallback is allowed",
+            );
+
+        let diagnostic = native_fallback_diagnostic_from_error(
+            "UCN2002",
+            "native_fallback_local_native_error",
+            "Native local build downgraded to Scarb",
+            &err,
+            None,
+        );
+
+        assert_ne!(diagnostic.what_happened, "Compilation failed.");
+        assert!(
+            diagnostic
+                .what_happened
+                .contains("Native Cairo compilation failed"),
+            "unexpected what_happened: {}",
+            diagnostic.what_happened
+        );
+        assert!(
+            diagnostic.why.contains("native starknet compile failed"),
+            "generic roots should preserve the actionable chain: {}",
+            diagnostic.why
+        );
+        assert!(
+            diagnostic
+                .next_commands
+                .iter()
+                .any(|command| command.contains("--record-failure")),
+            "agents need a replay-bundle command for native failures: {:?}",
+            diagnostic.next_commands
+        );
+    }
+
+    #[test]
+    fn native_fallback_diagnostic_includes_fallback_build_errors() {
+        let err = anyhow::anyhow!("Compilation failed.").context("native cairo compile failed");
+        let mut diagnostic = native_fallback_diagnostic_from_error(
+            "UCN2002",
+            "native_fallback_local_native_error",
+            "Native local build downgraded to Scarb",
+            &err,
+            None,
+        );
+        let fallback_run = CommandRun {
+            command: vec!["scarb".to_string(), "build".to_string()],
+            exit_code: 1,
+            elapsed_ms: 10.0,
+            stdout: String::new(),
+            stderr: "warn: `edition` field not set in `[package]` section\n   Compiling account v0.1.0\nerror[E0002]: Method `span` could not be called on type `core::array::Span::<core::felt252>`.\n --> src/account.cairo:254:64\n        calldata.span()\n                 ^^^^\nwarning: ignored after the error block\n".to_string(),
+        };
+
+        enrich_native_fallback_diagnostic_with_fallback_run(&mut diagnostic, &fallback_run);
+
+        assert!(
+            diagnostic
+                .what_happened
+                .contains("fallback build exited with code 1"),
+            "unexpected what_happened: {}",
+            diagnostic.what_happened
+        );
+        assert!(
+            diagnostic.why.contains("error[E0002]"),
+            "fallback Cairo diagnostics should be surfaced to agents: {}",
+            diagnostic.why
+        );
+        assert!(
+            !diagnostic.why.contains("edition"),
+            "leading warnings should not hide the first actual error: {}",
+            diagnostic.why
+        );
+        assert!(
+            diagnostic
+                .next_commands
+                .iter()
+                .any(|command| command.contains("--engine scarb")),
+            "agents need a command to isolate fallback build failures: {:?}",
+            diagnostic.next_commands
+        );
     }
 
     #[test]

--- a/docs/agent/AGENT_DIAGNOSTICS.md
+++ b/docs/agent/AGENT_DIAGNOSTICS.md
@@ -151,6 +151,9 @@ Native local build downgraded to Scarb.
 - Category: `native_fallback_local_native_error`
 - Safe action: `inspect_native_support_then_retry`
 - Agent behavior: keep the fallback result, inspect native support and build report diagnostics, then retry native with fallback disallowed only after fixing the native failure.
+- Required payload behavior: if the native compiler only reports a generic root cause such as `Compilation failed.`, preserve the full error chain in `why` so agents can distinguish native Cairo frontend failures, external-dependency compatibility failures, and fallback activation.
+- Required fallback-failure behavior: if the Scarb fallback build also exits nonzero, keep `fallback_used=true` and include the first bounded compiler error blocks in `why`; agents should fix those Cairo diagnostics before claiming native support for that manifest.
+- Replay evidence: `next_commands` must include a `--record-failure` command so agents can preserve a redacted replay bundle for native-only retry failures.
 
 ### UCN2003
 

--- a/docs/agent/AGENT_DIAGNOSTICS.md
+++ b/docs/agent/AGENT_DIAGNOSTICS.md
@@ -151,9 +151,9 @@ Native local build downgraded to Scarb.
 - Category: `native_fallback_local_native_error`
 - Safe action: `inspect_native_support_then_retry`
 - Agent behavior: keep the fallback result, inspect native support and build report diagnostics, then retry native with fallback disallowed only after fixing the native failure.
-- Required payload behavior: if the native compiler only reports a generic root cause such as `Compilation failed.`, preserve the full error chain in `why` so agents can distinguish native Cairo frontend failures, external-dependency compatibility failures, and fallback activation.
+- Required payload behavior: if the native compiler only reports a generic root cause such as `Compilation failed.`, preserve a bounded summary in `why` (truncated to `MAX_AGENT_DIAGNOSTIC_REASON_CHARS`) so agents can distinguish native Cairo frontend failures, external-dependency compatibility failures, and fallback activation.
 - Required fallback-failure behavior: if the Scarb fallback build also exits nonzero, keep `fallback_used=true` and include the first bounded compiler error blocks in `why`; agents should fix those Cairo diagnostics before claiming native support for that manifest.
-- Replay evidence: `next_commands` must include a `--record-failure` command so agents can preserve a redacted replay bundle for native-only retry failures.
+- Replay evidence: `next_commands` must include a `--record-failure` command so agents can preserve a redacted replay bundle for native-only retry failures when complete output is needed.
 
 ### UCN2003
 

--- a/docs/agent/AGENT_FIRST_COMPILER.md
+++ b/docs/agent/AGENT_FIRST_COMPILER.md
@@ -140,6 +140,8 @@ uc replay "$failure_bundle"
 
 Use `uc replay "$failure_bundle" --execute` only when the agent is allowed to rerun the recorded build command. Replay reports still emit structured JSON if the command cannot spawn or exceeds capture limits.
 
+When native fallback activates, agents should inspect `UCN2002` before editing source. If `UCN2002` says the fallback build also failed, treat the embedded compiler error blocks as the immediate blocker and keep the manifest in `build_failed` support state until those errors are fixed or a lane-specific compatibility patch lands.
+
 ## Sources
 
 - AGENTS.md: <https://agents.md/>


### PR DESCRIPTION
## Summary

- Expand `UCN2002` native fallback diagnostics from generic root causes into full native error-chain summaries.
- Include bounded fallback compiler error blocks when native fallback activates and the Scarb fallback build also exits nonzero.
- Document the agent contract for `UCN2002`, including replay-bundle next commands and build-failed support behavior.

## Why

The 20-contract corpus left `accounts_workshop` and `starknetpy_contracts` in `build_failed` state with reports that only said `Compilation failed.`. That is not enough for an agent to distinguish native frontend failure, fallback activation, or fallback compiler errors.

## Validation

- `cargo test -p uc-cli native_fallback_diagnostic -- --nocapture`
- `make agent-validate`
- `make local-ci`
- Live replay: `UC_NATIVE_FALLBACK_HINT_RETRY_SECS=0 UC_NATIVE_TOOLCHAIN_2_14_BIN=$PWD/.uc/toolchain-helper-targets/cairo-2.14/debug/uc target/debug/uc build --engine uc --daemon-mode off --manifest-path /Users/espejelomar/StarkNet/accounts_workshop/Scarb.toml --report-path /tmp/uc-accounts-workshop-agent-diagnostic-report.json --offline`

## Evidence

The live replay now emits `UCN2002` with:

- `what_happened`: native failed, fallback used, fallback build exited with code 1
- `why`: full native error chain plus first bounded fallback Cairo error blocks
- `next_commands`: support probe, build report, replay-bundle command, fallback isolation command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Richer native-build diagnostics with de-duplicated error chains, generic-root-cause summaries, and fallback exit-code context.
  * Enriched diagnostics include truncated causal summaries, expanded guidance, and an added command for isolating fallback failures.

* **Tests**
  * New tests covering root-cause expansion, fallback error extraction, truncation budgeting, and serialized enriched payloads.

* **Documentation**
  * Updated diagnostic contract and agent guidance, including requirement to preserve replay-recording commands for fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->