### PR TITLE
[codex] Preserve fallback classification from helper reports

### DIFF
--- a/benchmarks/scripts/run_real_repo_benchmarks.sh
+++ b/benchmarks/scripts/run_real_repo_benchmarks.sh
@@ -484,19 +484,21 @@ classify_support_matrix_case() {
     --arg log_path "$log_path" \
     --arg report_path "$report_path" \
     '
-      def fallback_used:
-        (($build_report.diagnostics // []) | any(.fallback_used == true));
       def compile_backend:
         ($build_report.compile_backend // null);
+      def fallback_used:
+        (compile_backend == "scarb_fallback"
+          or compile_backend == "uc_scarb"
+          or (($build_report.diagnostics // []) | any(.fallback_used == true)));
       def classification:
         if $native_support.supported != true then
           "native_unsupported"
         elif $exit_code != 0 then
           "build_failed"
-        elif compile_backend == "uc_native" or compile_backend == "uc_native_external_helper" then
-          "native_supported"
         elif compile_backend == "scarb_fallback" or compile_backend == "uc_scarb" or fallback_used then
           "fallback_used"
+        elif compile_backend == "uc_native" or compile_backend == "uc_native_external_helper" then
+          "native_supported"
         else
           "build_failed"
         end;

--- a/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
+++ b/benchmarks/scripts/tests/deployed_contract_corpus_test.sh
@@ -132,7 +132,7 @@ if [[ "$1" == "build" ]]; then
   compile_backend="uc_native"
   diagnostics="[]"
   if [[ "$manifest" == *"fallback-used"* ]]; then
-    compile_backend="scarb_fallback"
+    compile_backend="uc_native_external_helper"
     diagnostics='[{"code":"UCN2002","category":"native_fallback_local_native_error","severity":"warn","title":"Native local build downgraded to Scarb","what_happened":"native failed","why":"native failed","how_to_fix":["fix native"],"retryable":true,"fallback_used":true,"toolchain_expected":"2.16.0","toolchain_found":"2.16.0"}]'
   fi
   if [[ -n "$report_path" ]]; then

--- a/benchmarks/scripts/tests/real_repo_benchmark_test.sh
+++ b/benchmarks/scripts/tests/real_repo_benchmark_test.sh
@@ -120,11 +120,14 @@ if [[ "$1" == "build" ]]; then
     compile_backend="uc_native"
     fallback_used="false"
     diagnostics='[]'
-  if [[ "$manifest" == *"fallback-used"* ]]; then
-    compile_backend="scarb_fallback"
-    fallback_used="true"
-    diagnostics='[{"code":"UCN2002","category":"native_fallback_local_native_error","severity":"warn","title":"Native local build downgraded to Scarb","what_happened":"native failed","why":"native failed","how_to_fix":["fix native"],"retryable":true,"fallback_used":true,"toolchain_expected":"2.16.0","toolchain_found":"2.16.0"}]'
-  fi
+    if [[ "$manifest" == *"fallback-used"* ]]; then
+      compile_backend="uc_native_external_helper"
+      fallback_used="true"
+      diagnostics='[{"code":"UCN2002","category":"native_fallback_local_native_error","severity":"warn","title":"Native local build downgraded to Scarb","what_happened":"native failed","why":"native failed","how_to_fix":["fix native"],"retryable":true,"fallback_used":true,"toolchain_expected":"2.16.0","toolchain_found":"2.16.0"}]'
+    fi
+    if [[ "$manifest" == *"fallback-backend-only"* ]]; then
+      compile_backend="scarb_fallback"
+    fi
   cat > "$report_path" <<REPORT
 {
   "generated_at_epoch_ms": 1,
@@ -458,6 +461,7 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   write_mock_scarb_bin "$mock_scarb"
   write_manifest_case "$cases_root" "supported"
   write_manifest_case "$cases_root" "fallback-used"
+  write_manifest_case "$cases_root" "fallback-backend-only"
   write_manifest_case "$cases_root" "unsupported"
 
   local stdout_text
@@ -474,6 +478,7 @@ test_real_repo_benchmark_records_support_matrix_categories() {
       --warm-settle-seconds 0 \
       --case "$cases_root/supported/Scarb.toml" supported \
       --case "$cases_root/fallback-used/Scarb.toml" fallback-used \
+      --case "$cases_root/fallback-backend-only/Scarb.toml" fallback-backend-only \
       --case "$cases_root/unsupported/Scarb.toml" unsupported
   )"
   assert_contains "$stdout_text" "Benchmark JSON:"
@@ -492,13 +497,19 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   unsupported_status="$(jq -r '.cases[] | select(.tag=="unsupported") | .native_support.status' "$json_path")"
   local fallback_classification
   fallback_classification="$(jq -r '.cases[] | select(.tag=="fallback-used") | .support_matrix.classification' "$json_path")"
+  local fallback_used_flag
+  fallback_used_flag="$(jq -r '.cases[] | select(.tag=="fallback-used") | .support_matrix.fallback_used' "$json_path")"
+  local fallback_backend_only_classification
+  fallback_backend_only_classification="$(jq -r '.cases[] | select(.tag=="fallback-backend-only") | .support_matrix.classification' "$json_path")"
+  local fallback_backend_only_flag
+  fallback_backend_only_flag="$(jq -r '.cases[] | select(.tag=="fallback-backend-only") | .support_matrix.fallback_used' "$json_path")"
   local supported_benchmark_status
   supported_benchmark_status="$(jq -r '.cases[] | select(.tag=="supported") | .benchmark_status' "$json_path")"
   local unsupported_classification
   unsupported_classification="$(jq -r '.cases[] | select(.tag=="unsupported") | .support_matrix.classification' "$json_path")"
   local supported_classification
   supported_classification="$(jq -r '.cases[] | select(.tag=="supported") | .support_matrix.classification' "$json_path")"
-  if [[ "$supported_status" != "supported" || "$unsupported_status" != "unsupported" || "$supported_benchmark_status" != "ok" || "$supported_classification" != "native_supported" || "$fallback_classification" != "fallback_used" || "$unsupported_classification" != "native_unsupported" ]]; then
+  if [[ "$supported_status" != "supported" || "$unsupported_status" != "unsupported" || "$supported_benchmark_status" != "ok" || "$supported_classification" != "native_supported" || "$fallback_classification" != "fallback_used" || "$fallback_used_flag" != "true" || "$fallback_backend_only_classification" != "fallback_used" || "$fallback_backend_only_flag" != "true" || "$unsupported_classification" != "native_unsupported" ]]; then
     echo "unexpected support classification in json report" >&2
     cat "$json_path" >&2
     return 1
@@ -512,7 +523,8 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   assert_contains "$markdown_text" "## Fallback-Used Cases"
   assert_contains "$markdown_text" "## Native-Unsupported Cases"
   assert_contains "$markdown_text" "| supported |"
-  assert_contains "$markdown_text" "| fallback-used | fallback_used | scarb_fallback |"
+  assert_contains "$markdown_text" "| fallback-used | fallback_used | uc_native_external_helper |"
+  assert_contains "$markdown_text" "| fallback-backend-only | fallback_used | scarb_fallback |"
   assert_contains "$markdown_text" "| unsupported | native_unsupported | <none> | 2.14.0 |"
 
   local canonical_corelib_dir
@@ -534,6 +546,11 @@ test_real_repo_benchmark_records_support_matrix_categories() {
   fi
   if grep -q "build .*fallback-used.* disallow=1" "$TEST_TMP_DIR/uc.args"; then
     echo "fallback-used case should not run strict native benchmark builds" >&2
+    cat "$TEST_TMP_DIR/uc.args" >&2
+    return 1
+  fi
+  if grep -q "build .*fallback-backend-only.* disallow=1" "$TEST_TMP_DIR/uc.args"; then
+    echo "fallback-backend-only case should not run strict native benchmark builds" >&2
     cat "$TEST_TMP_DIR/uc.args" >&2
     return 1
   fi

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -320,18 +320,33 @@ fn build_report_compile_backend_label(
     used_external_helper: bool,
     diagnostics: &[NativeDiagnostic],
 ) -> &'static str {
+    if matches!(engine, EngineArg::Uc) && diagnostics_used_native_fallback(diagnostics) {
+        return "scarb_fallback";
+    }
     match (engine, compile_backend, used_external_helper) {
         (EngineArg::Scarb, BuildCompileBackend::Scarb, _) => "scarb",
         (EngineArg::Uc, BuildCompileBackend::Native, true) => "uc_native_external_helper",
         (EngineArg::Uc, BuildCompileBackend::Native, false) => "uc_native",
-        (EngineArg::Uc, BuildCompileBackend::Scarb, _) => {
-            if diagnostics_used_native_fallback(diagnostics) {
-                "scarb_fallback"
-            } else {
-                "uc_scarb"
-            }
-        }
+        (EngineArg::Uc, BuildCompileBackend::Scarb, _) => "uc_scarb",
         (EngineArg::Scarb, BuildCompileBackend::Native, _) => "native",
+    }
+}
+
+fn compile_backend_from_build_report_label(
+    label: Option<&str>,
+    diagnostics: &[NativeDiagnostic],
+) -> Option<BuildCompileBackend> {
+    if diagnostics_used_native_fallback(diagnostics) {
+        return Some(BuildCompileBackend::Scarb);
+    }
+    match label.map(str::trim) {
+        Some("scarb") | Some("uc_scarb") | Some("scarb_fallback") => {
+            Some(BuildCompileBackend::Scarb)
+        }
+        Some("native") | Some("uc_native") | Some("uc_native_external_helper") => {
+            Some(BuildCompileBackend::Native)
+        }
+        _ => None,
     }
 }
 
@@ -1147,7 +1162,6 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                 if let Ok(selection) = &toolchain_selection {
                     if let Some(helper_path) = selection.helper_path.as_ref() {
                         used_external_helper = true;
-                        actual_compile_backend = Some(BuildCompileBackend::Native);
                         let helper_display = helper_path.display().to_string();
                         let helper_report_path = if write_report {
                             Some(helper_build_report_temp_path(&workspace_root)?)
@@ -1172,6 +1186,12 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                         if let Some(path) = helper_report_path.as_ref() {
                             if path.exists() {
                                 let helper_report = load_build_report(path)?;
+                                if let Some(backend) = compile_backend_from_build_report_label(
+                                    helper_report.compile_backend.as_deref(),
+                                    &helper_report.diagnostics,
+                                ) {
+                                    actual_compile_backend = Some(backend);
+                                }
                                 daemon_used = helper_report.daemon_used;
                                 session_key = helper_report.session_key;
                                 phase_telemetry = helper_report.phase_telemetry;
@@ -2327,7 +2347,61 @@ mod tests {
             ),
             "scarb_fallback"
         );
+        assert_eq!(
+            build_report_compile_backend_label(
+                EngineArg::Uc,
+                BuildCompileBackend::Native,
+                true,
+                &diagnostics,
+            ),
+            "scarb_fallback"
+        );
         assert!(diagnostics_used_native_fallback(&diagnostics));
+    }
+
+    #[test]
+    fn helper_build_report_backend_prefers_fallback_diagnostics() {
+        let diagnostics = vec![NativeDiagnostic {
+            schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+            code: "UCN2002".to_string(),
+            category: "native_fallback_local_native_error".to_string(),
+            severity: NativeDiagnosticSeverity::Warn,
+            title: "Native local build downgraded to Scarb".to_string(),
+            docs_url: native_diagnostic_docs_url("UCN2002"),
+            what_happened: "native failed, fallback used".to_string(),
+            why: "fallback_used=true".to_string(),
+            how_to_fix: vec!["inspect fallback".to_string()],
+            next_commands: vec![
+                "uc build --engine scarb --daemon-mode off --manifest-path <Scarb.toml>"
+                    .to_string(),
+            ],
+            safe_automated_action: "inspect_native_support_then_retry".to_string(),
+            retryable: true,
+            fallback_used: true,
+            toolchain_expected: Some("2.14.0".to_string()),
+            toolchain_found: Some("2.14.0".to_string()),
+        }];
+
+        assert_eq!(
+            compile_backend_from_build_report_label(
+                Some("uc_native_external_helper"),
+                &diagnostics
+            ),
+            Some(BuildCompileBackend::Scarb)
+        );
+        assert_eq!(
+            compile_backend_from_build_report_label(Some("scarb_fallback"), &[]),
+            Some(BuildCompileBackend::Scarb)
+        );
+        assert_eq!(
+            compile_backend_from_build_report_label(Some("uc_native_external_helper"), &[]),
+            Some(BuildCompileBackend::Native)
+        );
+        assert_eq!(compile_backend_from_build_report_label(None, &[]), None);
+        assert_eq!(
+            compile_backend_from_build_report_label(Some("future_backend"), &[]),
+            None
+        );
     }
 
     #[test]

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -164,6 +164,86 @@ fn write_fake_uc_support_helper(path: &Path, report: &NativeSupportReport) {
     fs::set_permissions(path, perms).expect("chmod fake helper");
 }
 
+#[cfg(all(feature = "native-compile", unix))]
+fn write_fake_uc_build_helper_with_fallback_report(path: &Path, toolchain_version: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "support" ]]; then
+  printf '%s\n' '{"schema_version":1,"manifest_path":"","status":"supported","supported":true,"compiler_version":"__TOOLCHAIN_VERSION__","diagnostics":[]}'
+  exit 0
+fi
+
+if [[ "${1:-}" == "build" ]]; then
+  report_path=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --report-path)
+        report_path="${2:-}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  if [[ -n "$report_path" ]]; then
+    mkdir -p "$(dirname "$report_path")"
+    cat > "$report_path" <<'JSON'
+{
+  "schema_version": 1,
+  "generated_at_epoch_ms": 1,
+  "engine": "uc",
+  "daemon_used": false,
+  "manifest_path": "helper-manifest",
+  "workspace_root": "helper-workspace",
+  "profile": "dev",
+  "session_key": "helper-session",
+  "command": ["uc", "build"],
+  "exit_code": 0,
+  "elapsed_ms": 1.0,
+  "cache_hit": false,
+  "fingerprint": "helper-fingerprint",
+  "artifact_count": 0,
+  "phase_telemetry": null,
+  "compile_backend": "uc_native_external_helper",
+  "diagnostics": [
+    {
+      "schema_version": 1,
+      "code": "UCN2002",
+      "category": "native_fallback_local_native_error",
+      "severity": "warn",
+      "title": "Native local build downgraded to Scarb",
+      "docs_url": "https://example.invalid/docs#ucn2002",
+      "what_happened": "native failed, fallback used",
+      "why": "fake helper emitted fallback diagnostics",
+      "how_to_fix": ["inspect native failure"],
+      "next_commands": ["uc build --engine scarb --daemon-mode off --manifest-path <Scarb.toml>"],
+      "safe_automated_action": "inspect_native_support_then_retry",
+      "retryable": true,
+      "fallback_used": true,
+      "toolchain_expected": "__TOOLCHAIN_VERSION__",
+      "toolchain_found": "__TOOLCHAIN_VERSION__"
+    }
+  ]
+}
+JSON
+  fi
+  exit 0
+fi
+
+echo "unexpected helper invocation: $*" >&2
+exit 64
+"#
+    .replace("__TOOLCHAIN_VERSION__", toolchain_version);
+    fs::write(path, script).expect("write fake helper script");
+    let mut perms = fs::metadata(path).expect("stat fake helper").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod fake helper");
+}
+
 #[cfg(feature = "native-compile")]
 fn native_progress_hook_lock() -> &'static Mutex<()> {
     static LOCK: TestOnceLock<Mutex<()>> = TestOnceLock::new();
@@ -3820,6 +3900,88 @@ cairo-version = "{requested_version}"
         Some(requested_version.as_str())
     );
     assert!(report.diagnostics.is_empty());
+}
+
+#[cfg(all(feature = "native-compile", unix))]
+#[test]
+fn build_report_from_external_helper_preserves_fallback_backend() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let current = parse_cairo_version_major_minor(native_cairo_lang_compiler_version())
+        .expect("compiler version should parse");
+    let current_major_minor = format_cairo_version_major_minor(current);
+    let productized_lanes = productized_native_toolchain_helper_lanes();
+    let requested_major_minor = productized_lanes
+        .iter()
+        .find(|lane| *lane != &current_major_minor)
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a productized native helper lane different from current {current_major_minor}; productized lanes: {productized_lanes:?}"
+            )
+        });
+    let requested_version = format!("{requested_major_minor}.0");
+    let helper_env = native_toolchain_env_var_name_for_major_minor(&requested_major_minor);
+
+    let dir = unique_test_dir("uc-build-helper-fallback-report");
+    let _cleanup = TestDirCleanup::new(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2024_07"
+cairo-version = "{requested_version}"
+"#
+        ),
+    )
+    .expect("write manifest");
+
+    let helper_path = dir.join("uc-helper.sh");
+    write_fake_uc_build_helper_with_fallback_report(&helper_path, &requested_version);
+    let report_path = dir.join("outer-build-report.json");
+    let _helper = ScopedDynamicEnvVar::set_with_lock(&_guard, helper_env, &helper_path);
+    let _mode = ScopedEnvVar::set_with_lock(&_guard, "UC_NATIVE_BUILD_MODE", "auto");
+    let _disallow = ScopedEnvVar::unset_with_lock(&_guard, "UC_NATIVE_DISALLOW_SCARB_FALLBACK");
+
+    run_build(BuildArgs {
+        common: BuildCommonArgs {
+            manifest_path: Some(manifest_path),
+            package: None,
+            workspace: false,
+            features: Vec::new(),
+            offline: false,
+            release: false,
+            profile: None,
+        },
+        engine: EngineArg::Uc,
+        daemon_mode: DaemonModeArg::Off,
+        json: false,
+        report_path: Some(report_path.clone()),
+        record_failure: None,
+    })
+    .expect("helper-backed build should succeed");
+
+    let report: BuildReport =
+        serde_json::from_slice(&fs::read(&report_path).expect("read outer build report"))
+            .expect("outer build report should parse");
+    assert_eq!(report.compile_backend.as_deref(), Some("scarb_fallback"));
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "UCN2002" && diagnostic.fallback_used),
+        "outer report should preserve helper fallback diagnostics: {report:#?}"
+    );
+    assert_eq!(
+        report
+            .native_toolchain
+            .as_ref()
+            .map(|toolchain| &toolchain.source),
+        Some(&NativeToolchainSource::ExternalHelper)
+    );
 }
 
 #[cfg(feature = "native-compile")]


### PR DESCRIPTION
## Summary
- Treat fallback diagnostics as authoritative for build report backend labels, including external helper reports.
- Propagate helper report `compile_backend` and fallback diagnostics into the outer build report.
- Make real-repo and deployed-corpus harnesses classify `fallback_used` before native labels, so old inconsistent reports cannot count as `native_supported`.

## Why
External helper fallback can carry `UCN2002` with `fallback_used=true` while the report still looks like `uc_native_external_helper`. That can inflate `native_supported` counts and weaken launch claim guards.

## Validation
- `cargo test -p uc-cli build_report_compile_backend_labels_scarb_fallbacks -- --nocapture`
- `cargo test -p uc-cli helper_build_report_backend_prefers_fallback_diagnostics -- --nocapture`
- `benchmarks/scripts/tests/real_repo_benchmark_test.sh`
- `benchmarks/scripts/tests/deployed_contract_corpus_test.sh`
- `make agent-validate`
- `make local-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reporting now prioritizes fallback diagnostics when determining the reported compile backend, fixing misleading backend labels and classification ordering so fallback is recognized before native support.

* **Tests**
  * Expanded integration and benchmark tests to cover fallback detection, a new fallback-only case, updated expected results, and validations for reported backend labels and support-matrix outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->