### PR TITLE
Flag fallback activation in corpus opportunity summaries

### DIFF
--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -121,6 +121,15 @@ def collect_diagnostics(case: dict[str, Any]) -> list[dict[str, Any]]:
     return diagnostics
 
 
+def case_used_fallback(matrix: dict[str, Any], diagnostics: list[dict[str, Any]], classification: str) -> bool:
+    return (
+        classification == "fallback_used"
+        or matrix.get("fallback_used") is True
+        or matrix.get("compile_backend") in {"scarb_fallback", "uc_scarb"}
+        or any(diag.get("fallback_used") is True for diag in diagnostics)
+    )
+
+
 def phase_telemetry(case: dict[str, Any]) -> dict[str, Any]:
     matrix = case.get("support_matrix") if isinstance(case.get("support_matrix"), dict) else {}
     build_report = matrix.get("build_report") if isinstance(matrix.get("build_report"), dict) else {}
@@ -238,6 +247,7 @@ def summarize_case(
     unstable = unstable_by_tag.get(tag, [])
     classification = str(matrix.get("classification") or "unknown")
     benchmark_status = str(case.get("benchmark_status") or "unknown")
+    fallback_used = case_used_fallback(matrix, diagnostics, classification)
     opps: list[dict[str, Any]] = []
 
     if classification == "native_unsupported":
@@ -249,7 +259,7 @@ def summarize_case(
             str(matrix.get("reason") or native_support.get("reason") or "native support probe returned unsupported"),
             "Fix toolchain selection or add the missing native lane before benchmarking this case.",
         )
-    elif classification == "fallback_used":
+    if fallback_used:
         add_opportunity(
             opps,
             "UCO1002",
@@ -258,7 +268,7 @@ def summarize_case(
             str(matrix.get("reason") or "uc auto build fell back to Scarb"),
             "Treat this as unsupported for launch speed claims; capture the fallback diagnostic and fix the native failure class.",
         )
-    elif classification == "build_failed":
+    if classification == "build_failed":
         add_opportunity(
             opps,
             "UCO1003",
@@ -366,7 +376,7 @@ def summarize_case(
         "classification": classification,
         "benchmark_status": benchmark_status,
         "compile_backend": matrix.get("compile_backend"),
-        "fallback_used": bool(matrix.get("fallback_used")),
+        "fallback_used": fallback_used,
         "toolchain": {
             "requested_version": toolchain.get("requested_version"),
             "requested_major_minor": toolchain.get("requested_major_minor"),

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -500,7 +500,7 @@ test_fallback_signal_branches_are_detected() {
       "native_supported": 0,
       "fallback_used": 0,
       "native_unsupported": 0,
-      "build_failed": 2
+      "build_failed": 3
     },
     "unstable_lanes": [],
     "unstable_lane_count": 0
@@ -545,6 +545,26 @@ test_fallback_signal_branches_are_detected() {
       },
       "benchmark_status": "skipped",
       "benchmarks": null
+    },
+    {
+      "tag": "uc-scarb-only",
+      "manifest_path": "/tmp/uc-scarb-only/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_scarb",
+        "fallback_used": false,
+        "reason": "uc_scarb backend label persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
     }
   ]
 }
@@ -564,6 +584,12 @@ JSON
   backend_only_uco="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   backend_only_uco3="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
 
+  local uc_scarb_backend uc_scarb_output uc_scarb_uco uc_scarb_uco3
+  uc_scarb_backend="$(jq -r '.cases[] | select(.tag=="uc-scarb-only") | .compile_backend' "$out_json")"
+  uc_scarb_output="$(jq -r '.cases[] | select(.tag=="uc-scarb-only") | .fallback_used' "$out_json")"
+  uc_scarb_uco="$(jq -r '.cases[] | select(.tag=="uc-scarb-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  uc_scarb_uco3="$(jq -r '.cases[] | select(.tag=="uc-scarb-only") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
+
   assert_json_value "fallback-used-only backend" "$flag_only_backend" "uc_native_external_helper" "$out_json"
   assert_json_value "fallback-used-only fallback_used" "$flag_only_matrix" "true" "$out_json"
   assert_json_value "fallback-used-only UCO1002" "$flag_only_output" "true" "$out_json"
@@ -572,6 +598,10 @@ JSON
   assert_json_value "scarb-fallback-only fallback_used" "$backend_only_output" "true" "$out_json"
   assert_json_value "scarb-fallback-only UCO1002" "$backend_only_uco" "true" "$out_json"
   assert_json_value "scarb-fallback-only UCO1003" "$backend_only_uco3" "true" "$out_json"
+  assert_json_value "uc-scarb-only backend" "$uc_scarb_backend" "uc_scarb" "$out_json"
+  assert_json_value "uc-scarb-only fallback_used" "$uc_scarb_output" "true" "$out_json"
+  assert_json_value "uc-scarb-only UCO1002" "$uc_scarb_uco" "true" "$out_json"
+  assert_json_value "uc-scarb-only UCO1003" "$uc_scarb_uco3" "true" "$out_json"
 }
 
 test_remediation_fields_are_validated_without_overmatching() {

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -290,12 +290,14 @@ JSON
 
   "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
 
-  local generic_gap weak_reason build_blocker
+  local generic_gap weak_reason build_blocker fallback_activation
   generic_gap="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
   weak_reason="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
   build_blocker="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
+  fallback_activation="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   assert_json_value "generic_gap" "$generic_gap" "true" "$out_json"
   assert_json_value "build_blocker" "$build_blocker" "true" "$out_json"
+  assert_json_value "fallback_activation" "$fallback_activation" "true" "$out_json"
   if [[ "$weak_reason" != *"what_happened is generic"* || "$weak_reason" != *"why is generic"* ]]; then
     echo "expected generic diagnostic fields to be named in UCO5001 reason" >&2
     cat "$out_json" >&2
@@ -366,10 +368,12 @@ JSON
 
   "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
 
-  local generic_gap weak_reason
+  local generic_gap weak_reason fallback_activation
   generic_gap="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
   weak_reason="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
+  fallback_activation="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   assert_json_value "generic_gap" "$generic_gap" "true" "$out_json"
+  assert_json_value "fallback_activation" "$fallback_activation" "true" "$out_json"
   if [[ "$weak_reason" != *"what_happened is generic"* || "$weak_reason" != *"why is not a string"* ]]; then
     echo "expected stock and malformed diagnostic fields to be named in UCO5001 reason" >&2
     cat "$out_json" >&2

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -558,10 +558,11 @@ JSON
   flag_only_output="$(jq -r '.cases[] | select(.tag=="fallback-used-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   flag_only_uco="$(jq -r '.cases[] | select(.tag=="fallback-used-only") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
 
-  local backend_only_backend backend_only_output backend_only_uco
+  local backend_only_backend backend_only_output backend_only_uco backend_only_uco3
   backend_only_backend="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .compile_backend' "$out_json")"
   backend_only_output="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .fallback_used' "$out_json")"
   backend_only_uco="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  backend_only_uco3="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
 
   assert_json_value "fallback-used-only backend" "$flag_only_backend" "uc_native_external_helper" "$out_json"
   assert_json_value "fallback-used-only fallback_used" "$flag_only_matrix" "true" "$out_json"
@@ -570,6 +571,7 @@ JSON
   assert_json_value "scarb-fallback-only backend" "$backend_only_backend" "scarb_fallback" "$out_json"
   assert_json_value "scarb-fallback-only fallback_used" "$backend_only_output" "true" "$out_json"
   assert_json_value "scarb-fallback-only UCO1002" "$backend_only_uco" "true" "$out_json"
+  assert_json_value "scarb-fallback-only UCO1003" "$backend_only_uco3" "true" "$out_json"
 }
 
 test_remediation_fields_are_validated_without_overmatching() {

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -283,6 +283,46 @@ test_complete_but_generic_diagnostic_is_not_agent_grade() {
       },
       "benchmark_status": "skipped",
       "benchmarks": null
+    },
+    {
+      "tag": "fallback-used-only-generic",
+      "manifest_path": "/tmp/fallback-used-only-generic/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": true,
+        "reason": "fallback flag persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    },
+    {
+      "tag": "scarb-fallback-only-generic",
+      "manifest_path": "/tmp/scarb-fallback-only-generic/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "scarb_fallback",
+        "fallback_used": false,
+        "reason": "fallback backend label persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
     }
   ]
 }
@@ -291,13 +331,27 @@ JSON
   "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
 
   local generic_gap weak_reason build_blocker fallback_activation
+  local flag_only_backend flag_only_matrix flag_only_output
+  local backend_only_backend backend_only_matrix backend_only_output
   generic_gap="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
   weak_reason="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
   build_blocker="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
   fallback_activation="$(jq -r '.cases[] | select(.tag=="generic-native-failure") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  flag_only_backend="$(jq -r '.cases[] | select(.tag=="fallback-used-only-generic") | .compile_backend' "$out_json")"
+  flag_only_matrix="$(jq -r '.cases[] | select(.tag=="fallback-used-only-generic") | .fallback_used' "$out_json")"
+  flag_only_output="$(jq -r '.cases[] | select(.tag=="fallback-used-only-generic") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  backend_only_backend="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only-generic") | .compile_backend' "$out_json")"
+  backend_only_matrix="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only-generic") | .fallback_used' "$out_json")"
+  backend_only_output="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only-generic") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   assert_json_value "generic_gap" "$generic_gap" "true" "$out_json"
   assert_json_value "build_blocker" "$build_blocker" "true" "$out_json"
   assert_json_value "fallback_activation" "$fallback_activation" "true" "$out_json"
+  assert_json_value "fallback-used-only generic backend" "$flag_only_backend" "uc_native_external_helper" "$out_json"
+  assert_json_value "fallback-used-only generic fallback_used" "$flag_only_matrix" "true" "$out_json"
+  assert_json_value "fallback-used-only generic UCO1002" "$flag_only_output" "true" "$out_json"
+  assert_json_value "scarb-fallback-only generic backend" "$backend_only_backend" "scarb_fallback" "$out_json"
+  assert_json_value "scarb-fallback-only generic fallback_used" "$backend_only_matrix" "true" "$out_json"
+  assert_json_value "scarb-fallback-only generic UCO1002" "$backend_only_output" "true" "$out_json"
   if [[ "$weak_reason" != *"what_happened is generic"* || "$weak_reason" != *"why is generic"* ]]; then
     echo "expected generic diagnostic fields to be named in UCO5001 reason" >&2
     cat "$out_json" >&2
@@ -361,6 +415,46 @@ test_stock_and_malformed_diagnostic_is_not_agent_grade() {
       },
       "benchmark_status": "skipped",
       "benchmarks": null
+    },
+    {
+      "tag": "fallback-used-only-stock",
+      "manifest_path": "/tmp/fallback-used-only-stock/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": true,
+        "reason": "fallback flag persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    },
+    {
+      "tag": "scarb-fallback-only-stock",
+      "manifest_path": "/tmp/scarb-fallback-only-stock/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "scarb_fallback",
+        "fallback_used": false,
+        "reason": "fallback backend label persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
     }
   ]
 }
@@ -369,16 +463,113 @@ JSON
   "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
 
   local generic_gap weak_reason fallback_activation
+  local flag_only_backend flag_only_matrix flag_only_output
+  local backend_only_backend backend_only_matrix backend_only_output
   generic_gap="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunity_codes | index("UCO5001") != null' "$out_json")"
   weak_reason="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunities[] | select(.code=="UCO5001") | .why' "$out_json")"
   fallback_activation="$(jq -r '.cases[] | select(.tag=="stock-malformed-native-failure") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  flag_only_backend="$(jq -r '.cases[] | select(.tag=="fallback-used-only-stock") | .compile_backend' "$out_json")"
+  flag_only_matrix="$(jq -r '.cases[] | select(.tag=="fallback-used-only-stock") | .fallback_used' "$out_json")"
+  flag_only_output="$(jq -r '.cases[] | select(.tag=="fallback-used-only-stock") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  backend_only_backend="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only-stock") | .compile_backend' "$out_json")"
+  backend_only_matrix="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only-stock") | .fallback_used' "$out_json")"
+  backend_only_output="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only-stock") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   assert_json_value "generic_gap" "$generic_gap" "true" "$out_json"
   assert_json_value "fallback_activation" "$fallback_activation" "true" "$out_json"
+  assert_json_value "fallback-used-only stock backend" "$flag_only_backend" "uc_native_external_helper" "$out_json"
+  assert_json_value "fallback-used-only stock fallback_used" "$flag_only_matrix" "true" "$out_json"
+  assert_json_value "fallback-used-only stock UCO1002" "$flag_only_output" "true" "$out_json"
+  assert_json_value "scarb-fallback-only stock backend" "$backend_only_backend" "scarb_fallback" "$out_json"
+  assert_json_value "scarb-fallback-only stock fallback_used" "$backend_only_matrix" "true" "$out_json"
+  assert_json_value "scarb-fallback-only stock UCO1002" "$backend_only_output" "true" "$out_json"
   if [[ "$weak_reason" != *"what_happened is generic"* || "$weak_reason" != *"why is not a string"* ]]; then
     echo "expected stock and malformed diagnostic fields to be named in UCO5001 reason" >&2
     cat "$out_json" >&2
     exit 1
   fi
+}
+
+test_fallback_signal_branches_are_detected() {
+  local fixture="$TEST_TMP_DIR/fallback-signal-branches.json"
+  local out_json="$TEST_TMP_DIR/fallback-signal-branches-opportunities.json"
+  cat > "$fixture" <<'JSON'
+{
+  "generated_at": "2026-04-25T00:00:00Z",
+  "summary": {
+    "support_matrix": {
+      "native_supported": 0,
+      "fallback_used": 0,
+      "native_unsupported": 0,
+      "build_failed": 2
+    },
+    "unstable_lanes": [],
+    "unstable_lane_count": 0
+  },
+  "cases": [
+    {
+      "tag": "fallback-used-only",
+      "manifest_path": "/tmp/fallback-used-only/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": true,
+        "reason": "fallback flag persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    },
+    {
+      "tag": "scarb-fallback-only",
+      "manifest_path": "/tmp/scarb-fallback-only/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "scarb_fallback",
+        "fallback_used": false,
+        "reason": "fallback backend label persisted from helper report",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
+    }
+  ]
+}
+JSON
+
+  "$SUMMARY_SCRIPT" --benchmark-json "$fixture" --out-json "$out_json"
+
+  local flag_only_backend flag_only_matrix flag_only_output flag_only_uco
+  flag_only_backend="$(jq -r '.cases[] | select(.tag=="fallback-used-only") | .compile_backend' "$out_json")"
+  flag_only_matrix="$(jq -r '.cases[] | select(.tag=="fallback-used-only") | .fallback_used' "$out_json")"
+  flag_only_output="$(jq -r '.cases[] | select(.tag=="fallback-used-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  flag_only_uco="$(jq -r '.cases[] | select(.tag=="fallback-used-only") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
+
+  local backend_only_backend backend_only_output backend_only_uco
+  backend_only_backend="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .compile_backend' "$out_json")"
+  backend_only_output="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .fallback_used' "$out_json")"
+  backend_only_uco="$(jq -r '.cases[] | select(.tag=="scarb-fallback-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+
+  assert_json_value "fallback-used-only backend" "$flag_only_backend" "uc_native_external_helper" "$out_json"
+  assert_json_value "fallback-used-only fallback_used" "$flag_only_matrix" "true" "$out_json"
+  assert_json_value "fallback-used-only UCO1002" "$flag_only_output" "true" "$out_json"
+  assert_json_value "fallback-used-only UCO1003" "$flag_only_uco" "true" "$out_json"
+  assert_json_value "scarb-fallback-only backend" "$backend_only_backend" "scarb_fallback" "$out_json"
+  assert_json_value "scarb-fallback-only fallback_used" "$backend_only_output" "true" "$out_json"
+  assert_json_value "scarb-fallback-only UCO1002" "$backend_only_uco" "true" "$out_json"
 }
 
 test_remediation_fields_are_validated_without_overmatching() {
@@ -533,6 +724,7 @@ run_test "real_repo_summary_records_opportunities" test_real_repo_summary_record
 run_test "deployed_wrapper_preserves_corpus_metadata" test_deployed_wrapper_preserves_corpus_metadata
 run_test "complete_but_generic_diagnostic_is_not_agent_grade" test_complete_but_generic_diagnostic_is_not_agent_grade
 run_test "stock_and_malformed_diagnostic_is_not_agent_grade" test_stock_and_malformed_diagnostic_is_not_agent_grade
+run_test "fallback_signal_branches_are_detected" test_fallback_signal_branches_are_detected
 run_test "remediation_fields_are_validated_without_overmatching" test_remediation_fields_are_validated_without_overmatching
 
 echo "All corpus opportunity summary tests passed."

--- a/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
+++ b/benchmarks/scripts/tests/corpus_opportunity_summary_test.sh
@@ -236,7 +236,7 @@ test_complete_but_generic_diagnostic_is_not_agent_grade() {
       "native_supported": 0,
       "fallback_used": 0,
       "native_unsupported": 0,
-      "build_failed": 1
+      "build_failed": 3
     },
     "unstable_lanes": [],
     "unstable_lane_count": 0
@@ -370,7 +370,7 @@ test_stock_and_malformed_diagnostic_is_not_agent_grade() {
       "native_supported": 0,
       "fallback_used": 0,
       "native_unsupported": 0,
-      "build_failed": 1
+      "build_failed": 3
     },
     "unstable_lanes": [],
     "unstable_lane_count": 0
@@ -500,7 +500,7 @@ test_fallback_signal_branches_are_detected() {
       "native_supported": 0,
       "fallback_used": 0,
       "native_unsupported": 0,
-      "build_failed": 3
+      "build_failed": 4
     },
     "unstable_lanes": [],
     "unstable_lane_count": 0
@@ -565,6 +565,26 @@ test_fallback_signal_branches_are_detected() {
       },
       "benchmark_status": "skipped",
       "benchmarks": null
+    },
+    {
+      "tag": "build-failed-no-fallback",
+      "manifest_path": "/tmp/build-failed-no-fallback/Scarb.toml",
+      "native_support": {
+        "supported": true,
+        "package_cairo_version": "2.14.0",
+        "diagnostics": []
+      },
+      "support_matrix": {
+        "classification": "build_failed",
+        "compile_backend": "uc_native_external_helper",
+        "fallback_used": false,
+        "reason": "native compile failed before fallback was attempted",
+        "build_report": {
+          "diagnostics": []
+        }
+      },
+      "benchmark_status": "skipped",
+      "benchmarks": null
     }
   ]
 }
@@ -590,6 +610,12 @@ JSON
   uc_scarb_uco="$(jq -r '.cases[] | select(.tag=="uc-scarb-only") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
   uc_scarb_uco3="$(jq -r '.cases[] | select(.tag=="uc-scarb-only") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
 
+  local no_fallback_backend no_fallback_output no_fallback_uco no_fallback_uco3
+  no_fallback_backend="$(jq -r '.cases[] | select(.tag=="build-failed-no-fallback") | .compile_backend' "$out_json")"
+  no_fallback_output="$(jq -r '.cases[] | select(.tag=="build-failed-no-fallback") | .fallback_used' "$out_json")"
+  no_fallback_uco="$(jq -r '.cases[] | select(.tag=="build-failed-no-fallback") | .opportunity_codes | index("UCO1002") != null' "$out_json")"
+  no_fallback_uco3="$(jq -r '.cases[] | select(.tag=="build-failed-no-fallback") | .opportunity_codes | index("UCO1003") != null' "$out_json")"
+
   assert_json_value "fallback-used-only backend" "$flag_only_backend" "uc_native_external_helper" "$out_json"
   assert_json_value "fallback-used-only fallback_used" "$flag_only_matrix" "true" "$out_json"
   assert_json_value "fallback-used-only UCO1002" "$flag_only_output" "true" "$out_json"
@@ -602,6 +628,10 @@ JSON
   assert_json_value "uc-scarb-only fallback_used" "$uc_scarb_output" "true" "$out_json"
   assert_json_value "uc-scarb-only UCO1002" "$uc_scarb_uco" "true" "$out_json"
   assert_json_value "uc-scarb-only UCO1003" "$uc_scarb_uco3" "true" "$out_json"
+  assert_json_value "build-failed-no-fallback backend" "$no_fallback_backend" "uc_native_external_helper" "$out_json"
+  assert_json_value "build-failed-no-fallback fallback_used" "$no_fallback_output" "false" "$out_json"
+  assert_json_value "build-failed-no-fallback UCO1002" "$no_fallback_uco" "false" "$out_json"
+  assert_json_value "build-failed-no-fallback UCO1003" "$no_fallback_uco3" "true" "$out_json"
 }
 
 test_remediation_fields_are_validated_without_overmatching() {

--- a/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
+++ b/docs/CONTRACT_CORPUS_EXPERIMENT_2026-04-25.md
@@ -73,16 +73,19 @@ The 20-contract corpus is an experiment harness first. It becomes launch evidenc
 
 This sweep is diagnostic evidence, not launch copy. It used `--runs 1`,
 `--cold-runs 1`, and no pinned-host strict stability window. The purpose was to
-expand coverage, surface blockers, and produce an agent-readable backlog.
+expand coverage, surface blockers, and produce an agent-readable backlog. The
+latest artifact below was regenerated after fallback-aware helper-report
+classification landed, so helper reports that activate Scarb fallback are no
+longer counted as native-supported.
 
 Artifacts:
 
 - Evidence root: `<abs/path>/uc-20-contract-experiment-20260425`
 - Cases file: `<evidence-root>/cases.tsv`
-- Benchmark JSON: `<evidence-root>/results/real-repo-bench-20260426-011206.json`
-- Benchmark Markdown: `<evidence-root>/results/real-repo-bench-20260426-011206.md`
-- Opportunity JSON: `<evidence-root>/corpus-opportunities.json`
-- Opportunity Markdown: `<evidence-root>/corpus-opportunities.md`
+- Benchmark JSON: `<evidence-root>/results-refresh-20260426-pr56-classifier/real-repo-bench-20260426-045630.json`
+- Benchmark Markdown: `<evidence-root>/results-refresh-20260426-pr56-classifier/real-repo-bench-20260426-045630.md`
+- Opportunity JSON: `<evidence-root>/corpus-opportunities-refresh-pr56-classifier.json`
+- Opportunity Markdown: `<evidence-root>/corpus-opportunities-refresh-pr56-classifier.md`
 - Cairo 2.14 helper: `${UC_NATIVE_TOOLCHAIN_2_14_BIN}`, produced by
   `./scripts/build_native_toolchain_helper.sh --lane 2.14`
 
@@ -102,26 +105,32 @@ Benchmark status:
 | `ok` | 12 |
 | `skipped` | 8 |
 
-Opportunity counts after applying the generic-diagnostic quality rule:
+Opportunity counts after applying the generic-diagnostic quality rule and the
+fallback-activation rule:
 
 | Code | Count | Meaning |
 |---|---:|---|
 | `UCO1001` | 6 | Native support gap. |
+| `UCO1002` | 2 | Fallback path used. |
 | `UCO1003` | 2 | Auto-build classification failed. |
 | `UCO3001` | 12 | Native frontend compile dominates. |
-| `UCO3006` | 2 | Cold speedup is weak. |
 | `UCO4001` | 12 | Bounded launch-evidence candidate after stricter validation. |
 | `UCO4002` | 2 | Strong warm no-op speedup. |
-| `UCO5001` | 4 | Diagnostic is not agent-grade. |
+| `UCO5001` | 2 | Diagnostic is not agent-grade. |
 
 The two `build_failed` rows were `accounts_workshop` and
-`starknetpy_contracts`. Both selected the Cairo 2.14 external helper and failed
-inside a cached `cairo-contracts` dependency with a Cairo diagnostic shaped like
+`starknetpy_contracts`. Both selected the Cairo 2.14 external helper, activated
+the Scarb fallback path, and failed inside a cached `cairo-contracts` dependency
+with a Cairo diagnostic shaped like
 `error[E0002]: Method span could not be called on type core::array::Span::<core::felt252>`.
-The generated build reports carried structured `UCN2002` diagnostics, but the
-`what_happened` and `why` fields were only `Compilation failed.`. That is too
-generic for an agent to remediate, so the opportunity summarizer now treats
-generic diagnostic text as `UCO5001` even when all required fields are present.
+The refreshed build reports classify their backend as `scarb_fallback` with
+`fallback_used=true`; the opportunity summary now emits `UCO1002` for that
+fallback activation even though the exclusive classification remains
+`build_failed`. The generated build reports carried structured `UCN2002`
+diagnostics, but the `what_happened` and `why` fields were only
+`Compilation failed.`. That is too generic for an agent to remediate, so the
+opportunity summarizer treats generic diagnostic text as `UCO5001` even when all
+required fields are present.
 
 Low-sample same-window observed ratios for native-supported rows:
 
@@ -131,7 +140,7 @@ Low-sample same-window observed ratios for native-supported rows:
 - Stages: `build.cold` observed value and `build.warm_noop` observed value
   from a single-sample diagnostic run.
 - Sample settings: `--runs 1`, `--cold-runs 1`,
-  `--warm-settle-seconds 0`, `--timeout-secs 180`.
+  `--warm-settle-seconds 0`, `--timeout-secs 240`.
 - Host condition: local ad hoc macOS developer workstation run; no pinned CPU,
   no strict host-noise preflight, and no recorded hardware claim metadata.
 - Claim-guard status: no deployed-contract `claim_guard` was produced for this
@@ -140,18 +149,29 @@ Low-sample same-window observed ratios for native-supported rows:
 
 | Tag | Cold observed ratio (single-sample) | Warm no-op observed ratio (single-sample) | Launch-use status |
 |---|---:|---:|---|
-| `braavos_account` | 1.196x | 34.334x | Diagnostic only; cold speedup weak. |
-| `monero_atomic_swap` | 1.211x | 135.222x | Diagnostic only; cold speedup weak. |
-| `agentic_session` | 1.821x | 4.819x | Needs strict rerun. |
-| `agentic_agent` | 2.089x | 4.530x | Needs strict rerun. |
-| `agentic_erc8004` | 1.789x | 8.791x | Needs strict rerun. |
-| `agentic_huginn` | 1.562x | 2.102x | Needs strict rerun. |
-| `book_ownable` | 1.290x | 0.544x | Warm regression target. |
-| `book_vote_contracts` | 1.693x | 6.109x | Needs strict rerun. |
-| `book_ownable_components` | 1.918x | 6.284x | Needs strict rerun. |
-| `token_factory` | 1.287x | 0.977x | Warm parity/regression target. |
-| `zcash_relay` | 1.747x | 1.058x | Needs strict rerun. |
-| `glint_contracts` | 2.132x | 3.123x | Needs strict rerun. |
+| `braavos_account` | 1.372x | 44.157x | Needs strict rerun. |
+| `monero_atomic_swap` | 1.367x | 125.859x | Needs strict rerun. |
+| `agentic_session` | 1.647x | 4.410x | Needs strict rerun. |
+| `agentic_agent` | 1.603x | 5.245x | Needs strict rerun. |
+| `agentic_erc8004` | 1.437x | 3.852x | Needs strict rerun. |
+| `agentic_huginn` | 1.383x | 2.277x | Needs strict rerun. |
+| `book_ownable` | 1.629x | 0.518x | Warm regression target. |
+| `book_vote_contracts` | 2.305x | 6.274x | Needs strict rerun. |
+| `book_ownable_components` | 1.897x | 5.866x | Needs strict rerun. |
+| `token_factory` | 1.653x | 0.657x | Warm regression target. |
+| `zcash_relay` | 1.613x | 0.551x | Warm regression target. |
+| `glint_contracts` | 1.759x | 1.733x | Needs strict rerun. |
+
+Refresh artifact hashes:
+
+```text
+c996fffd4a0f2e063fafe7e4f8e15934e1bccf51343f41ce8aa8b73d46ff382f  cases.tsv
+0c86d3bb226398dd0037594e2ebc0e71cdee0d0603878765c6cc4eb14bcdcd81  results-refresh-20260426-pr56-classifier/real-repo-bench-20260426-045630.json
+b7d3ca2b56f20e62d63b261381b846e0497c3d13615e8780db12ba5f0d25a76d  results-refresh-20260426-pr56-classifier/real-repo-bench-20260426-045630.md
+d83d440c1a6b9abaa82db4b258f7f1d69a63e89260674af6b1739bbbc1929121  corpus-opportunities-refresh-pr56-classifier.json
+1d7c9e44f30721ceebada069a2f327891db3530461483b51c5aaccaaa8df1e0f  corpus-opportunities-refresh-pr56-classifier.md
+34212c3af55637476cc172eb7cafa19de8c3b45616b2724fb5577eb3681fcba0  run-20-refresh-pr56-classifier.log
+```
 
 Next blockers from this sweep:
 


### PR DESCRIPTION
## Summary

- emit `UCO1002` whenever a case actually activated fallback, even if the exclusive support classification is `build_failed`
- derive the summarized `fallback_used` field from classification, backend label, matrix flag, or structured diagnostics
- refresh the 20-case corpus experiment note with the post-classifier-refresh artifact paths, hashes, and opportunity counts

## Local validation

- `benchmarks/scripts/tests/corpus_opportunity_summary_test.sh`
- `python3 -m py_compile benchmarks/scripts/summarize_corpus_opportunities.py`
- `git diff --check`
- `make agent-validate`
- `make local-ci`

## Evidence refresh

- Benchmark JSON: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/results-refresh-20260426-pr56-classifier/real-repo-bench-20260426-045630.json`
- Opportunity JSON: `/Users/espejelomar/StarkNet/uc-20-contract-experiment-20260425/corpus-opportunities-refresh-pr56-classifier.json`
- Refreshed opportunity counts now include `UCO1002=2` for the `accounts_workshop` and `starknetpy_contracts` fallback activations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection and reporting of fallback activation in opportunity summaries; UCO1002 (fallback used) is emitted reliably and can appear alongside UCO1003 when applicable.

* **Tests**
  * Added and expanded tests covering fallback vs non-fallback branches, validating backend labels, fallback flags, and presence/absence of UCO1002/UCO1003.

* **Documentation**
  * Regenerated experiment results and updated counts, sample settings, narratives, and pinned artifact hashes to reflect fallback-aware summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->