### PR TITLE
Support helper-builder salsa package metadata

### DIFF
--- a/docs/NATIVE_TOOLCHAIN_HELPERS.md
+++ b/docs/NATIVE_TOOLCHAIN_HELPERS.md
@@ -35,6 +35,7 @@ The helper rewriter is fail-closed: it rewrites only the current workspace depen
 Lane-specific Cairo patches are applied only after the main-lane patch section is removed:
 
 - the lane metadata can set `patch-dir = "toolchains/cairo-2.14/patches"`
+- the lane metadata can also set `salsa-package = "rust-analyzer-salsa"` when an older Cairo lane still aliases the `salsa` dependency to a different Cargo package name
 - patch files must be named after the patched crate, such as `cairo-lang-compiler.patch`
 - the builder copies the matching exact version from `$UC_HELPER_CARGO_REGISTRY_SRC`, `$CARGO_HOME/registry/src`, or `$HOME/.cargo/registry/src`
 - patched sources live only in the staging tree under `.uc/helper-lane-patches/cairo-2.14/`

--- a/docs/research/CAIRO_210_HELPER_PORT_2026-04-28.md
+++ b/docs/research/CAIRO_210_HELPER_PORT_2026-04-28.md
@@ -1,0 +1,130 @@
+# Cairo 2.10 Helper Port Notes
+
+## Purpose
+
+This note records the first production-grade blockers encountered while trying
+to turn the `argent_contracts` support gap into a real Cairo `2.10` native
+helper lane.
+
+This is not a launch claim and not a productization decision. It is a verified
+boundary note so future work starts from evidence instead of guesswork.
+
+## Corpus Context
+
+The post-PR58 20-case diagnostic sweep produced this support matrix:
+
+- `native_supported=12`
+- `native_unsupported=6`
+- `build_failed=2`
+- `fallback_used=0` (exclusive classification)
+
+The agent-grade diagnostics fix removed `UCO5001` from the two build-failed
+fallback cases, so the highest-value remaining coverage gap in the current
+corpus is Cairo `2.10.1` for `argent_contracts`.
+
+## Finding 1: The helper builder cannot yet rewrite Cairo 2.10 salsa metadata
+
+Scratch reproduction:
+
+```bash
+tmpdir=$(mktemp -d /tmp/uc-cairo210-scratch.XXXXXX)
+rsync -a --exclude '.git' --exclude 'target' --exclude '.uc' --exclude 'benchmarks/results' ./ "$tmpdir/"
+# Add lane metadata and feature alias in the scratch copy, then:
+(cd "$tmpdir" && ./scripts/build_native_toolchain_helper.sh --lane 2.10 --check-only)
+```
+
+Observed failure:
+
+```text
+failed to rewrite salsa in .../Cargo.toml
+```
+
+Why this happens:
+
+- the helper rewriter assumes the workspace dependency is shaped like
+  `salsa = "..."`;
+- Cairo `2.10.1` depends on `rust-analyzer-salsa 0.17.0-pre.6`;
+- older-compatible helper lanes therefore need lane metadata that can rewrite
+  the `salsa` dependency to an aliased Cargo package form.
+
+Primary-source crate metadata inspected locally from crates.io:
+
+- `cairo-lang-compiler 2.10.1` depends on
+  `salsa = { package = "rust-analyzer-salsa", version = "0.17.0-pre.6" }`
+- `cairo-lang-starknet 2.10.1` and
+  `cairo-lang-starknet-classes 2.10.1` are present on crates.io, so this is
+  not the same boundary as Cairo `2.4` or `2.5`
+
+## Finding 2: Solver-generated lockfiles are not safe enough for this lane
+
+Scratch reproduction after manually rewriting the workspace dependency shape:
+
+```bash
+tmpdir=$(mktemp -d /tmp/uc-cairo210-compile.XXXXXX)
+rsync -a --exclude '.git' --exclude 'target' --exclude '.uc' --exclude 'benchmarks/results' ./ "$tmpdir/"
+# Rewrite Cairo deps to =2.10.1, rewrite salsa to rust-analyzer-salsa, add helper-cairo-210 feature alias.
+(cd "$tmpdir" && cargo check -p uc-cli --no-default-features --features native-compile,helper-cairo-210)
+```
+
+Observed failure:
+
+```text
+error[E0570]: "aapcs" is not a supported ABI for the current target
+...
+error: could not compile `size-of` (lib) due to 5 previous errors
+```
+
+What this means:
+
+- a naive lane port that lets Cargo solve a fresh lockfile will pull transitive
+  crates that are not acceptable on the current host/toolchain combination;
+- the helper lane therefore needs a reviewed, lane-specific lockfile for the
+  current `uc` workspace shape, not just upstream Cairo's lockfile and not an
+  unconstrained local solve.
+
+## Finding 3: Upstream Cairo's lockfile is useful input, but not drop-in
+
+Primary source:
+
+- `https://raw.githubusercontent.com/starkware-libs/cairo/v2.10.1/Cargo.lock`
+
+Scratch probe:
+
+```bash
+curl -L https://raw.githubusercontent.com/starkware-libs/cairo/v2.10.1/Cargo.lock -o /tmp/Cargo.lock
+# Place it into a scratch uc copy after rewriting deps, then:
+cargo check -p uc-cli --locked --no-default-features --features native-compile,helper-cairo-210
+```
+
+Observed failure:
+
+```text
+error: the lock file ... needs to be updated but --locked was passed
+```
+
+Why:
+
+- upstream Cairo's lockfile matches Cairo's workspace, not `uc`'s current
+  helper-stage workspace;
+- it is still a useful primary-source reference for expected dependency eras,
+  but it is not a drop-in lane lockfile for `uc`.
+
+## Current Recommendation
+
+Do the Cairo `2.10` lane in this order:
+
+1. Land helper-builder support for aliased `salsa` metadata.
+2. Generate and review a Cairo `2.10` lane lockfile for the actual `uc`
+   helper-stage workspace.
+3. Only after the helper builder and lockfile are stable, attempt full helper
+   compilation and `argent_contracts` validation.
+4. Productize the lane only after `uc support native`, helper build, and the
+   affected corpus cases all pass locally under the normal repo validation
+   discipline.
+
+## What Not To Do
+
+- Do not mark Cairo `2.10` productized based only on metadata changes.
+- Do not reuse the Cairo `2.14` lockfile as if it were valid for `2.10`.
+- Do not claim `argent_contracts` native support until the helper lane builds
+  and the corpus reclassifies it from `native_unsupported`.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -8,6 +8,7 @@ This directory contains:
 - `SUPREMACY_ENGINEERING_PLAYBOOK_2026-03-05.md`: production-oriented performance strategy and source-backed execution plan.
 - `SUPREMACY_NEXT_BEST_OPTIMIZATION_2026-03-06.md`: deep research + highest-ROI next optimization plan based on modern compiler/build practices.
 - `MONERO_NATIVE_FRONTEND_PROFILE_2026-04-25.md`: local Cairo 2.14 monero profile note showing the current native frontend hotspot and rejected inlining experiment.
+- `CAIRO_210_HELPER_PORT_2026-04-28.md`: scratch evidence for the first Cairo 2.10 helper-lane blockers, including the salsa alias rewrite boundary and lockfile requirements.
 - `archive/`: imported original research artifacts captured during exploration.
 
 Note: some archived files use historical naming (`khepri`) from earlier ideation; current project name and direction is `uc`.

--- a/scripts/build_native_toolchain_helper.sh
+++ b/scripts/build_native_toolchain_helper.sh
@@ -158,6 +158,7 @@ PY
 
 CAIRO_VERSION="$(read_metadata_field cairo-version)"
 SALSA_VERSION="$(read_metadata_field salsa-version)"
+SALSA_PACKAGE="$(read_metadata_field_optional salsa-package)"
 LOCKFILE_REL="$(read_metadata_field lockfile)"
 PATCH_DIR_REL="$(read_metadata_field_optional patch-dir)"
 LOCKFILE_PATH="$ROOT/$LOCKFILE_REL"
@@ -212,12 +213,13 @@ prepare_staging_tree() {
 }
 
 rewrite_workspace_manifest() {
-  python3 - "$STAGING_DIR/Cargo.toml" "$CAIRO_VERSION" "$SALSA_VERSION" <<'PY'
+  python3 - "$STAGING_DIR/Cargo.toml" "$CAIRO_VERSION" "$SALSA_VERSION" "$SALSA_PACKAGE" <<'PY'
 import re, sys
 from pathlib import Path
 path = Path(sys.argv[1])
 cairo_version = sys.argv[2]
 salsa_version = sys.argv[3]
+salsa_package = sys.argv[4]
 text = path.read_text()
 for dep in [
     "cairo-lang-compiler",
@@ -233,7 +235,18 @@ for dep in [
     text, count = re.subn(pattern, replacement, text, flags=re.MULTILINE)
     if count != 1:
         raise SystemExit(f"failed to rewrite {dep} in {path}")
-text, count = re.subn(r'^salsa\s*=\s*".*"$', f'salsa = "{salsa_version}"', text, flags=re.MULTILINE)
+if salsa_package:
+    salsa_replacement = (
+        f'salsa = {{ version = "{salsa_version}", package = "{salsa_package}" }}'
+    )
+else:
+    salsa_replacement = f'salsa = "{salsa_version}"'
+text, count = re.subn(
+    r'^salsa\s*=\s*(?:"[^"]*"|\{.*\})$',
+    salsa_replacement,
+    text,
+    flags=re.MULTILINE,
+)
 if count != 1:
     raise SystemExit(f"failed to rewrite salsa in {path}")
 text, count = re.subn(r'\n\[patch\.crates-io\]\n(?:.*\n)*?(?=\n\[|\Z)', '\n', text, flags=re.MULTILINE)

--- a/scripts/tests/build_native_toolchain_helper_test.sh
+++ b/scripts/tests/build_native_toolchain_helper_test.sh
@@ -91,6 +91,51 @@ test_prepare_only_accepts_workspace_manifest_without_patch_section() {
   fi
 }
 
+write_minimal_helper_repo_with_salsa_package() {
+  local repo_root="$1"
+  mkdir -p "$repo_root/scripts" "$repo_root/toolchains/cairo-2.10"
+  cp "$HELPER_SCRIPT" "$repo_root/scripts/build_native_toolchain_helper.sh"
+  cp "$ROOT/toolchains/cairo-2.14/Cargo.lock" "$repo_root/toolchains/cairo-2.10/Cargo.lock"
+  cat > "$repo_root/Cargo.toml" <<'TOML'
+[workspace]
+members = []
+resolver = "2"
+
+[workspace.dependencies]
+cairo-lang-compiler = "2.16.0"
+cairo-lang-defs = "2.16.0"
+cairo-lang-filesystem = "2.16.0"
+cairo-lang-lowering = "2.16.0"
+cairo-lang-semantic = "2.16.0"
+cairo-lang-starknet = "2.16.0"
+cairo-lang-starknet-classes = "2.16.0"
+salsa = "0.26.0"
+
+[workspace.metadata.uc-native-toolchain-helpers."2.10"]
+cairo-version = "2.10.1"
+salsa-version = "0.17.0-pre.6"
+salsa-package = "rust-analyzer-salsa"
+lockfile = "toolchains/cairo-2.10/Cargo.lock"
+TOML
+}
+
+test_prepare_only_rewrites_workspace_manifest_with_salsa_package_override() {
+  local fake_root="$TMP_DIR/salsa-package-root"
+  local stage_dir="$TMP_DIR/salsa-package-stage"
+  local stdout_path="$TMP_DIR/salsa-package.out"
+  write_minimal_helper_repo_with_salsa_package "$fake_root"
+
+  "$fake_root/scripts/build_native_toolchain_helper.sh" \
+    --lane 2.10 \
+    --staging-dir "$stage_dir" \
+    --prepare-only >"$stdout_path"
+
+  grep -qF "Prepared helper staging tree:" "$stdout_path"
+  grep -qF 'cairo-lang-compiler = "=2.10.1"' "$stage_dir/Cargo.toml"
+  grep -qF 'salsa = { version = "0.17.0-pre.6", package = "rust-analyzer-salsa" }' \
+    "$stage_dir/Cargo.toml"
+}
+
 test_prepare_only_excludes_in_repo_staging_dir_from_archive() {
   local stage_dir="$ROOT/.tmp-helper-inrepo-stage-$$"
   local stdout_path="$TMP_DIR/inrepo-stage.out"
@@ -227,6 +272,8 @@ run_test "prepare_only_rewrites_workspace_manifest_for_cairo214" \
   test_prepare_only_rewrites_workspace_manifest_for_cairo214
 run_test "prepare_only_accepts_workspace_manifest_without_patch_section" \
   test_prepare_only_accepts_workspace_manifest_without_patch_section
+run_test "prepare_only_rewrites_workspace_manifest_with_salsa_package_override" \
+  test_prepare_only_rewrites_workspace_manifest_with_salsa_package_override
 run_test "prepare_only_excludes_in_repo_staging_dir_from_archive" \
   test_prepare_only_excludes_in_repo_staging_dir_from_archive
 run_test "prepare_only_applies_helper_lane_patches_from_registry_source" \


### PR DESCRIPTION
## Summary
- add optional helper-lane `salsa-package` metadata for staging manifest rewrites
- cover aliased salsa rewrites in helper-builder script tests
- document the metadata needed by older-compatible helper lanes

## Why
Cairo 2.10.1 uses `rust-analyzer-salsa` behind the `salsa` dependency alias. The current helper builder could only rewrite `salsa = "..."` string lines, which blocks any honest 2.10 lane port before compile even starts.

## Validation
- scripts/tests/build_native_toolchain_helper_test.sh
- make agent-validate
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified native toolchain helper behavior and added research notes on Cairo 2.10 helper lane considerations.
* **Chores**
  * Added support for lane-level package overrides to handle legacy Cairo dependency layouts.
* **Tests**
  * Expanded staging tests to verify helper rewrites and override behavior during prepare-only staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->