### PR TITLE
uc-cli: extend project inspect schema v1

### DIFF
--- a/benchmarks/scripts/summarize_corpus_opportunities.py
+++ b/benchmarks/scripts/summarize_corpus_opportunities.py
@@ -1,6 +1,6 @@
 #!/bin/sh
 """:"
-for candidate in python3.13 python3.12 python3.11 python3 python; do
+for candidate in python3 python3.13 python3.12 python3.11 python; do
   if ! command -v "$candidate" >/dev/null 2>&1; then
     continue
   fi

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -40,7 +40,7 @@ fn native_fallback_diagnostic(
             "If native is required, rerun with UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 after fixing the mismatch.".to_string(),
         ],
         next_commands: vec![
-            "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+            "uc support native --manifest-path <Scarb.toml> --json".to_string(),
             "UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 uc build --engine uc --daemon-mode off --manifest-path <Scarb.toml>".to_string(),
         ],
         safe_automated_action: "inspect_native_support_then_retry".to_string(),
@@ -102,7 +102,7 @@ fn native_fallback_diagnostic_from_error(
         "If the failure comes from a registry or git dependency, keep it in the support matrix until the dependency/toolchain combination is validated.".to_string(),
     ];
     diagnostic.next_commands = vec![
-        "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+        "uc support native --manifest-path <Scarb.toml> --json".to_string(),
         "uc build --engine uc --daemon-mode off --manifest-path <Scarb.toml> --report-path /tmp/uc-build-report.json".to_string(),
         "UC_NATIVE_DISALLOW_SCARB_FALLBACK=1 uc build --engine uc --daemon-mode off --manifest-path <Scarb.toml> --record-failure /tmp/uc-failure.json".to_string(),
     ];
@@ -2559,9 +2559,7 @@ mod tests {
             what_happened: "native failed".to_string(),
             why: "native failed".to_string(),
             how_to_fix: vec!["fix native".to_string()],
-            next_commands: vec![
-                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
-            ],
+            next_commands: vec!["uc support native --manifest-path <Scarb.toml> --json".to_string()],
             safe_automated_action: "inspect_native_support_then_retry".to_string(),
             retryable: true,
             fallback_used: true,

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -662,10 +662,14 @@ struct ProjectInspectReport {
     mutation_status: String,
     manifest: ProjectManifestSummary,
     package: ProjectPackageSummary,
+    packages: Vec<ProjectInspectPackageSummary>,
     workspace: ProjectWorkspaceSummary,
+    profiles: ProjectProfilesSummary,
     targets: Vec<ProjectTargetSummary>,
     dependencies: Vec<ProjectDependencySummary>,
+    source_origins: Vec<ProjectSourceOriginSummary>,
     lockfile: ProjectLockfileSummary,
+    offline_readiness: ProjectOfflineReadinessSummary,
     toolchain: ProjectToolchainSummary,
     #[serde(skip_serializing_if = "Option::is_none")]
     native_support: Option<NativeSupportReport>,
@@ -685,6 +689,29 @@ struct ProjectPackageSummary {
     version: Option<String>,
     edition: Option<String>,
     cairo_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ProjectInspectPackageSummary {
+    manifest_path: String,
+    package_root: String,
+    role: ProjectInspectPackageRole,
+    name: Option<String>,
+    version: Option<String>,
+    edition: Option<String>,
+    cairo_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ProjectInspectPackageRole {
+    InspectedManifest,
+    WorkspaceRootManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+struct ProjectProfilesSummary {
+    declared: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -718,6 +745,16 @@ struct ProjectDependencySummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ProjectSourceOriginSummary {
+    dependency: String,
+    section: String,
+    kind: String,
+    locator: String,
+    workspace_inherited: bool,
+    locked: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ProjectLockfileSummary {
     present: bool,
     path: Option<String>,
@@ -746,6 +783,28 @@ struct ProjectToolchainSummary {
     native_status: NativeSupportStatus,
     native_supported: bool,
     fallback_used: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ProjectOfflineReadinessSummary {
+    status: ProjectOfflineReadinessStatus,
+    readonly_native_source: bool,
+    lockfile_present: bool,
+    lockfile_valid: bool,
+    remote_dependency_count: usize,
+    path_dependency_count: usize,
+    workspace_dependency_count: usize,
+    cache_state_known: bool,
+    reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ProjectOfflineReadinessStatus {
+    Ready,
+    NeedsLockfile,
+    NeedsExactToolchainSource,
+    Blocked,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2291,6 +2350,14 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
         inspected_manifest_for_workspace,
         workspace_manifest_for_report,
     );
+    let packages = project_packages_for_report(
+        manifest.as_ref(),
+        manifest_path,
+        workspace_manifest_for_report,
+        &workspace_manifest_path,
+    );
+    let profiles =
+        project_profiles_summary_for_report(manifest.as_ref(), workspace_manifest_for_report);
     let targets = manifest
         .as_ref()
         .map(project_targets_from_manifest)
@@ -2303,6 +2370,13 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
         .map(project_workspace_dependencies_from_manifest)
         .unwrap_or_default();
     let lockfile = project_lockfile_summary(&workspace_root, &mut diagnostics)?;
+    let source_origins = project_source_origins_for_report(
+        &dependencies,
+        &workspace_dependencies,
+        &lockfile,
+        manifest_path,
+        &workspace_root,
+    );
     let readonly_native_source = project_has_readonly_native_toolchain_source(
         &package,
         &dependencies,
@@ -2392,6 +2466,13 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
         &lockfile,
         native_support.as_ref(),
     );
+    let offline_readiness = project_offline_readiness_summary(
+        manifest.is_some(),
+        readonly_native_source,
+        &dependencies,
+        &workspace_dependencies,
+        &lockfile,
+    );
 
     Ok(ProjectInspectReport {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
@@ -2406,10 +2487,14 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
             hash: manifest_hash,
         },
         package,
+        packages,
         workspace,
+        profiles,
         targets,
         dependencies,
+        source_origins,
         lockfile,
+        offline_readiness,
         toolchain,
         native_support,
         diagnostics,
@@ -2539,6 +2624,87 @@ fn project_workspace_summary_for_report(
     manifest
         .map(project_workspace_summary_from_manifest)
         .unwrap_or_else(empty_project_workspace_summary)
+}
+
+fn project_packages_for_report(
+    manifest: Option<&TomlValue>,
+    manifest_path: &Path,
+    workspace_manifest: Option<&TomlValue>,
+    workspace_manifest_path: &Path,
+) -> Vec<ProjectInspectPackageSummary> {
+    let mut packages = Vec::new();
+    project_push_package_for_report(
+        &mut packages,
+        manifest,
+        manifest_path,
+        ProjectInspectPackageRole::InspectedManifest,
+    );
+    if workspace_manifest_path != manifest_path {
+        project_push_package_for_report(
+            &mut packages,
+            workspace_manifest,
+            workspace_manifest_path,
+            ProjectInspectPackageRole::WorkspaceRootManifest,
+        );
+    }
+    packages.sort_by(|left, right| {
+        left.manifest_path
+            .cmp(&right.manifest_path)
+            .then_with(|| left.package_root.cmp(&right.package_root))
+    });
+    packages
+}
+
+fn project_push_package_for_report(
+    packages: &mut Vec<ProjectInspectPackageSummary>,
+    manifest: Option<&TomlValue>,
+    manifest_path: &Path,
+    role: ProjectInspectPackageRole,
+) {
+    let Some(manifest) = manifest else {
+        return;
+    };
+    let package = project_package_summary_from_manifest(manifest);
+    if package.name.is_none()
+        && package.version.is_none()
+        && package.edition.is_none()
+        && package.cairo_version.is_none()
+    {
+        return;
+    }
+    packages.push(ProjectInspectPackageSummary {
+        manifest_path: manifest_path.display().to_string(),
+        package_root: manifest_path
+            .parent()
+            .unwrap_or(manifest_path)
+            .display()
+            .to_string(),
+        role,
+        name: package.name,
+        version: package.version,
+        edition: package.edition,
+        cairo_version: package.cairo_version,
+    });
+}
+
+fn project_profiles_summary_for_report(
+    manifest: Option<&TomlValue>,
+    workspace_manifest: Option<&TomlValue>,
+) -> ProjectProfilesSummary {
+    let mut declared = BTreeSet::new();
+    for current in [workspace_manifest, manifest] {
+        let Some(current) = current else {
+            continue;
+        };
+        if let Some(table) = current.get("profile").and_then(TomlValue::as_table) {
+            for name in table.keys() {
+                declared.insert(name.to_string());
+            }
+        }
+    }
+    ProjectProfilesSummary {
+        declared: declared.into_iter().collect(),
+    }
 }
 
 fn project_targets_from_manifest(manifest: &TomlValue) -> Vec<ProjectTargetSummary> {
@@ -2688,6 +2854,101 @@ fn project_workspace_dependencies_from_manifest(
         .collect::<Vec<_>>();
     dependencies.sort_by(|left, right| left.name.cmp(&right.name));
     dependencies
+}
+
+fn project_source_origins_for_report(
+    dependencies: &[ProjectDependencySummary],
+    workspace_dependencies: &[ProjectDependencySummary],
+    lockfile: &ProjectLockfileSummary,
+    manifest_path: &Path,
+    workspace_root: &Path,
+) -> Vec<ProjectSourceOriginSummary> {
+    let mut origins = dependencies
+        .iter()
+        .map(|dependency| {
+            project_source_origin_summary(
+                dependency,
+                workspace_dependencies,
+                lockfile,
+                manifest_path,
+                workspace_root,
+            )
+        })
+        .collect::<Vec<_>>();
+    origins.sort_by(|left, right| {
+        left.section
+            .cmp(&right.section)
+            .then_with(|| left.dependency.cmp(&right.dependency))
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.locator.cmp(&right.locator))
+    });
+    origins
+}
+
+fn project_source_origin_summary(
+    dependency: &ProjectDependencySummary,
+    workspace_dependencies: &[ProjectDependencySummary],
+    lockfile: &ProjectLockfileSummary,
+    manifest_path: &Path,
+    workspace_root: &Path,
+) -> ProjectSourceOriginSummary {
+    let inherited = dependency.workspace;
+    let source_dependency = if dependency.workspace {
+        workspace_dependencies
+            .iter()
+            .find(|workspace_dependency| workspace_dependency.name == dependency.name)
+            .unwrap_or(dependency)
+    } else {
+        dependency
+    };
+    let locator = project_dependency_locator(source_dependency, manifest_path, workspace_root);
+    let locked = lockfile
+        .packages
+        .iter()
+        .any(|package| package.name == dependency.name);
+    ProjectSourceOriginSummary {
+        dependency: dependency.name.clone(),
+        section: dependency.section.clone(),
+        kind: source_dependency.kind.clone(),
+        locator,
+        workspace_inherited: inherited,
+        locked,
+    }
+}
+
+fn project_dependency_locator(
+    dependency: &ProjectDependencySummary,
+    manifest_path: &Path,
+    workspace_root: &Path,
+) -> String {
+    if let Some(path) = dependency.path.as_deref() {
+        let base = if dependency.section == "workspace.dependencies" {
+            workspace_root
+        } else {
+            manifest_path.parent().unwrap_or(workspace_root)
+        };
+        return base.join(path).display().to_string();
+    }
+    if let Some(git) = dependency.git.as_deref() {
+        let mut locator = git.to_string();
+        if let Some(branch) = dependency.branch.as_deref() {
+            locator.push_str(&format!("#branch={branch}"));
+        }
+        if let Some(tag) = dependency.tag.as_deref() {
+            locator.push_str(&format!("#tag={tag}"));
+        }
+        if let Some(rev) = dependency.rev.as_deref() {
+            locator.push_str(&format!("#rev={rev}"));
+        }
+        return locator;
+    }
+    if let Some(version) = dependency.version.as_deref() {
+        return version.to_string();
+    }
+    if dependency.workspace {
+        return format!("workspace.dependencies.{}", dependency.name);
+    }
+    "unknown".to_string()
 }
 
 fn project_dependency_resolved_version(
@@ -2912,6 +3173,84 @@ fn project_toolchain_summary(
         native_status,
         native_supported,
         fallback_used: false,
+    }
+}
+
+fn project_offline_readiness_summary(
+    manifest_valid: bool,
+    readonly_native_source: bool,
+    dependencies: &[ProjectDependencySummary],
+    workspace_dependencies: &[ProjectDependencySummary],
+    lockfile: &ProjectLockfileSummary,
+) -> ProjectOfflineReadinessSummary {
+    let path_dependency_count = dependencies
+        .iter()
+        .filter(|dependency| {
+            project_dependency_resolved_origin_kind(dependency, workspace_dependencies) == "path"
+        })
+        .count();
+    let workspace_dependency_count = dependencies
+        .iter()
+        .filter(|dependency| dependency.workspace)
+        .count();
+    let remote_dependency_count = dependencies
+        .iter()
+        .filter(|dependency| {
+            matches!(
+                project_dependency_resolved_origin_kind(dependency, workspace_dependencies)
+                    .as_str(),
+                "git" | "version" | "table" | "unknown"
+            )
+        })
+        .count();
+
+    let mut reasons = Vec::new();
+    let status = if !manifest_valid {
+        reasons.push("manifest_invalid".to_string());
+        ProjectOfflineReadinessStatus::Blocked
+    } else if remote_dependency_count > 0 && (!lockfile.present || !lockfile.valid) {
+        if !lockfile.present {
+            reasons.push("lockfile_missing_for_remote_dependencies".to_string());
+        } else {
+            reasons.push("lockfile_invalid_for_remote_dependencies".to_string());
+        }
+        if !readonly_native_source {
+            reasons.push("native_support_requires_exact_local_source".to_string());
+        }
+        ProjectOfflineReadinessStatus::NeedsLockfile
+    } else if !readonly_native_source {
+        reasons.push("native_support_requires_exact_local_source".to_string());
+        ProjectOfflineReadinessStatus::NeedsExactToolchainSource
+    } else {
+        reasons.push("cache_state_unknown".to_string());
+        ProjectOfflineReadinessStatus::Ready
+    };
+
+    ProjectOfflineReadinessSummary {
+        status,
+        readonly_native_source,
+        lockfile_present: lockfile.present,
+        lockfile_valid: lockfile.valid,
+        remote_dependency_count,
+        path_dependency_count,
+        workspace_dependency_count,
+        cache_state_known: false,
+        reasons,
+    }
+}
+
+fn project_dependency_resolved_origin_kind(
+    dependency: &ProjectDependencySummary,
+    workspace_dependencies: &[ProjectDependencySummary],
+) -> String {
+    if dependency.workspace {
+        workspace_dependencies
+            .iter()
+            .find(|workspace_dependency| workspace_dependency.name == dependency.name)
+            .map(|workspace_dependency| workspace_dependency.kind.clone())
+            .unwrap_or_else(|| "workspace".to_string())
+    } else {
+        dependency.kind.clone()
     }
 }
 

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -707,6 +707,7 @@ struct ProjectInspectPackageSummary {
 enum ProjectInspectPackageRole {
     InspectedManifest,
     WorkspaceRootManifest,
+    WorkspaceMemberManifest,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -802,6 +803,7 @@ struct ProjectOfflineReadinessSummary {
 #[serde(rename_all = "snake_case")]
 enum ProjectOfflineReadinessStatus {
     Ready,
+    Unverified,
     NeedsLockfile,
     NeedsExactToolchainSource,
     Blocked,
@@ -2274,9 +2276,7 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
                         "Verify the file is UTF-8 and below the manifest size limit.".to_string(),
                         "Rerun project inspection after fixing the manifest file.".to_string(),
                     ],
-                    vec![
-                        "uc project inspect --manifest-path <Scarb.toml> --format json".to_string(),
-                    ],
+                    vec!["uc project inspect --manifest-path <Scarb.toml> --json".to_string()],
                     "manual_manifest_fix_required",
                     false,
                     false,
@@ -2314,9 +2314,7 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
                         "Keep the manifest in Scarb-compatible TOML before rerunning inspection."
                             .to_string(),
                     ],
-                    vec![
-                        "uc project inspect --manifest-path <Scarb.toml> --format json".to_string(),
-                    ],
+                    vec!["uc project inspect --manifest-path <Scarb.toml> --json".to_string()],
                     "manual_manifest_fix_required",
                     false,
                     false,
@@ -2414,9 +2412,7 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
                         "Run native support probing directly to isolate the toolchain issue."
                             .to_string(),
                     ],
-                    vec![
-                        "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
-                    ],
+                    vec!["uc support native --manifest-path <Scarb.toml> --json".to_string()],
                     "inspect_native_support_then_retry",
                     true,
                     false,
@@ -2444,7 +2440,7 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
                 "Add an exact [package].cairo-version or commit a lockfile with an exact starknet version when you need read-only toolchain selection.".to_string(),
             ],
             vec![
-                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+                "uc support native --manifest-path <Scarb.toml> --json".to_string(),
             ],
             "inspect_native_support_then_retry",
             true,
@@ -2647,12 +2643,57 @@ fn project_packages_for_report(
             ProjectInspectPackageRole::WorkspaceRootManifest,
         );
     }
+    if let Some(workspace_manifest) = workspace_manifest {
+        for member_manifest_path in
+            project_workspace_member_manifest_paths(workspace_manifest, workspace_manifest_path)
+        {
+            if member_manifest_path == manifest_path
+                || member_manifest_path == workspace_manifest_path
+            {
+                continue;
+            }
+            if let Ok(member_manifest) =
+                read_text_file_with_limit(&member_manifest_path, MAX_MANIFEST_BYTES, "manifest")
+                    .and_then(|text| {
+                        parse_manifest_toml(
+                            &text,
+                            &member_manifest_path,
+                            "failed to parse workspace member manifest for project inspect",
+                        )
+                    })
+            {
+                project_push_package_for_report(
+                    &mut packages,
+                    Some(&member_manifest),
+                    &member_manifest_path,
+                    ProjectInspectPackageRole::WorkspaceMemberManifest,
+                );
+            }
+        }
+    }
     packages.sort_by(|left, right| {
         left.manifest_path
             .cmp(&right.manifest_path)
             .then_with(|| left.package_root.cmp(&right.package_root))
+            .then_with(|| {
+                project_inspect_package_role_rank(&left.role)
+                    .cmp(&project_inspect_package_role_rank(&right.role))
+            })
+    });
+    packages.dedup_by(|left, right| {
+        left.manifest_path == right.manifest_path
+            && left.package_root == right.package_root
+            && left.role == right.role
     });
     packages
+}
+
+fn project_inspect_package_role_rank(role: &ProjectInspectPackageRole) -> u8 {
+    match role {
+        ProjectInspectPackageRole::InspectedManifest => 0,
+        ProjectInspectPackageRole::WorkspaceRootManifest => 1,
+        ProjectInspectPackageRole::WorkspaceMemberManifest => 2,
+    }
 }
 
 fn project_push_package_for_report(
@@ -2685,6 +2726,181 @@ fn project_push_package_for_report(
         edition: package.edition,
         cairo_version: package.cairo_version,
     });
+}
+
+fn project_workspace_member_manifest_paths(
+    workspace_manifest: &TomlValue,
+    workspace_manifest_path: &Path,
+) -> Vec<PathBuf> {
+    let Some(members) = workspace_manifest
+        .get("workspace")
+        .and_then(TomlValue::as_table)
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(TomlValue::as_array)
+    else {
+        return Vec::new();
+    };
+
+    let workspace_root = workspace_manifest_path
+        .parent()
+        .unwrap_or(workspace_manifest_path);
+    let canonical_workspace_root = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf());
+    let mut manifests = BTreeSet::new();
+
+    for member in members {
+        let Some(member_pattern) = member
+            .as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        if project_workspace_member_pattern_is_literal(member_pattern) {
+            let member_path = Path::new(member_pattern);
+            if project_workspace_member_pattern_is_unsafe(member_path) {
+                continue;
+            }
+            let candidate_manifest = workspace_root.join(member_path).join("Scarb.toml");
+            let canonical_candidate_manifest = match candidate_manifest.canonicalize() {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
+            if ensure_path_within_root(
+                &canonical_workspace_root,
+                &canonical_candidate_manifest,
+                "project inspect workspace member manifest",
+            )
+            .is_ok()
+                && canonical_candidate_manifest.is_file()
+            {
+                manifests.insert(canonical_candidate_manifest);
+            }
+            continue;
+        }
+
+        for entry in WalkDir::new(workspace_root)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            if !entry.file_type().is_file() || entry.file_name() != "Scarb.toml" {
+                continue;
+            }
+            let entry_path = entry.path();
+            let relative_parent = match entry_path
+                .parent()
+                .and_then(|parent| parent.strip_prefix(workspace_root).ok())
+            {
+                Some(path) => path,
+                None => continue,
+            };
+            let relative_parent = normalize_fingerprint_path(relative_parent)
+                .trim_start_matches("./")
+                .to_string();
+            if !project_workspace_member_pattern_matches(member_pattern, &relative_parent) {
+                continue;
+            }
+            let canonical_candidate_manifest = match entry_path.canonicalize() {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
+            if ensure_path_within_root(
+                &canonical_workspace_root,
+                &canonical_candidate_manifest,
+                "project inspect workspace member manifest",
+            )
+            .is_ok()
+            {
+                manifests.insert(canonical_candidate_manifest);
+            }
+        }
+    }
+
+    manifests.into_iter().collect()
+}
+
+fn project_workspace_member_pattern_is_literal(pattern: &str) -> bool {
+    !pattern.contains('*') && !pattern.contains('?')
+}
+
+fn project_workspace_member_pattern_is_unsafe(path: &Path) -> bool {
+    path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    })
+}
+
+fn project_workspace_member_pattern_matches(pattern: &str, relative_parent: &str) -> bool {
+    let pattern_segments = pattern
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    let path_segments = relative_parent
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    project_workspace_member_pattern_segments_match(&pattern_segments, &path_segments)
+}
+
+fn project_workspace_member_pattern_segments_match(
+    pattern_segments: &[&str],
+    path_segments: &[&str],
+) -> bool {
+    match pattern_segments.split_first() {
+        None => path_segments.is_empty(),
+        Some((&"**", rest)) => {
+            project_workspace_member_pattern_segments_match(rest, path_segments)
+                || (!path_segments.is_empty()
+                    && project_workspace_member_pattern_segments_match(
+                        pattern_segments,
+                        &path_segments[1..],
+                    ))
+        }
+        Some((pattern_segment, rest)) => {
+            let Some((path_segment, remaining_path_segments)) = path_segments.split_first() else {
+                return false;
+            };
+            project_workspace_member_component_matches(pattern_segment, path_segment)
+                && project_workspace_member_pattern_segments_match(rest, remaining_path_segments)
+        }
+    }
+}
+
+fn project_workspace_member_component_matches(pattern: &str, value: &str) -> bool {
+    let pattern_bytes = pattern.as_bytes();
+    let value_bytes = value.as_bytes();
+    let (mut pattern_index, mut value_index) = (0usize, 0usize);
+    let mut star_index = None;
+    let mut match_index = 0usize;
+
+    while value_index < value_bytes.len() {
+        if pattern_index < pattern_bytes.len()
+            && (pattern_bytes[pattern_index] == value_bytes[value_index]
+                || pattern_bytes[pattern_index] == b'?')
+        {
+            pattern_index += 1;
+            value_index += 1;
+        } else if pattern_index < pattern_bytes.len() && pattern_bytes[pattern_index] == b'*' {
+            star_index = Some(pattern_index);
+            pattern_index += 1;
+            match_index = value_index;
+        } else if let Some(star) = star_index {
+            pattern_index = star + 1;
+            match_index += 1;
+            value_index = match_index;
+        } else {
+            return false;
+        }
+    }
+
+    while pattern_index < pattern_bytes.len() && pattern_bytes[pattern_index] == b'*' {
+        pattern_index += 1;
+    }
+    pattern_index == pattern_bytes.len()
 }
 
 fn project_profiles_summary_for_report(
@@ -2893,15 +3109,24 @@ fn project_source_origin_summary(
     workspace_root: &Path,
 ) -> ProjectSourceOriginSummary {
     let inherited = dependency.workspace;
-    let source_dependency = if dependency.workspace {
+    let resolved_workspace_dependency = if dependency.workspace {
         workspace_dependencies
             .iter()
             .find(|workspace_dependency| workspace_dependency.name == dependency.name)
-            .unwrap_or(dependency)
     } else {
-        dependency
+        None
     };
-    let locator = project_dependency_locator(source_dependency, manifest_path, workspace_root);
+    let source_dependency = resolved_workspace_dependency.unwrap_or(dependency);
+    let kind = if dependency.workspace && resolved_workspace_dependency.is_none() {
+        "unknown".to_string()
+    } else {
+        source_dependency.kind.clone()
+    };
+    let locator = if dependency.workspace && resolved_workspace_dependency.is_none() {
+        "unknown".to_string()
+    } else {
+        project_dependency_locator(source_dependency, manifest_path, workspace_root)
+    };
     let locked = lockfile
         .packages
         .iter()
@@ -2909,7 +3134,7 @@ fn project_source_origin_summary(
     ProjectSourceOriginSummary {
         dependency: dependency.name.clone(),
         section: dependency.section.clone(),
-        kind: source_dependency.kind.clone(),
+        kind,
         locator,
         workspace_inherited: inherited,
         locked,
@@ -3006,7 +3231,7 @@ fn project_lockfile_summary(
             format!("{} exists but is not a regular file.", lock_path.display()),
             "Project inspection cannot trust lockfile metadata from a non-file path.".to_string(),
             vec!["Replace the path with a regular Scarb.lock file or remove it.".to_string()],
-            vec!["uc project inspect --manifest-path <Scarb.toml> --format json".to_string()],
+            vec!["uc project inspect --manifest-path <Scarb.toml> --json".to_string()],
             "manual_lockfile_fix_required",
             false,
             false,
@@ -3083,7 +3308,7 @@ fn project_lockfile_summary(
                         .to_string(),
                 ],
                 vec![
-                    "uc project inspect --manifest-path <Scarb.toml> --format json"
+                    "uc project inspect --manifest-path <Scarb.toml> --json"
                         .to_string(),
                     "scarb metadata --manifest-path <Scarb.toml>".to_string(),
                 ],
@@ -3223,7 +3448,7 @@ fn project_offline_readiness_summary(
         ProjectOfflineReadinessStatus::NeedsExactToolchainSource
     } else {
         reasons.push("cache_state_unknown".to_string());
-        ProjectOfflineReadinessStatus::Ready
+        ProjectOfflineReadinessStatus::Unverified
     };
 
     ProjectOfflineReadinessSummary {
@@ -3248,7 +3473,7 @@ fn project_dependency_resolved_origin_kind(
             .iter()
             .find(|workspace_dependency| workspace_dependency.name == dependency.name)
             .map(|workspace_dependency| workspace_dependency.kind.clone())
-            .unwrap_or_else(|| "workspace".to_string())
+            .unwrap_or_else(|| "unknown".to_string())
     } else {
         dependency.kind.clone()
     }
@@ -3377,7 +3602,7 @@ fn agent_eval_decision(
     let mut next_commands = Vec::new();
     let manifest_path = shell_escape_command_arg(&support.manifest_path);
     next_commands.push(format!(
-        "uc support native --manifest-path {} --format json",
+        "uc support native --manifest-path {} --json",
         manifest_path
     ));
     if support.supported {
@@ -4907,21 +5132,21 @@ impl NativeCompileSupportIssue {
     fn next_commands(&self) -> Vec<String> {
         match self {
             Self::LegacyEditionRequiresPinnedCairoVersion { .. } => vec![
-                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+                "uc support native --manifest-path <Scarb.toml> --json".to_string(),
                 "scarb metadata --manifest-path <Scarb.toml>".to_string(),
             ],
             Self::UnsupportedManifestConstraint { .. } => {
-                vec!["uc support native --manifest-path <Scarb.toml> --format json".to_string()]
+                vec!["uc support native --manifest-path <Scarb.toml> --json".to_string()]
             }
             Self::UnparseableCompilerVersion { .. } => vec![
-                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+                "uc support native --manifest-path <Scarb.toml> --json".to_string(),
                 "scarb --version".to_string(),
             ],
             Self::CompilerVersionMismatch { requested, .. } => {
                 let lane = requested.split('.').take(2).collect::<Vec<_>>().join(".");
                 vec![
                     format!("./scripts/build_native_toolchain_helper.sh --lane {lane}"),
-                    "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+                    "uc support native --manifest-path <Scarb.toml> --json".to_string(),
                 ]
             }
             Self::MissingToolchainHelper {
@@ -4931,7 +5156,7 @@ impl NativeCompileSupportIssue {
                 let lane = requested.split('.').take(2).collect::<Vec<_>>().join(".");
                 vec![
                     format!("./scripts/build_native_toolchain_helper.sh --lane {lane}"),
-                    format!("{helper_env}=<helper-uc-path> uc support native --manifest-path <Scarb.toml> --format json"),
+                    format!("{helper_env}=<helper-uc-path> uc support native --manifest-path <Scarb.toml> --json"),
                 ]
             }
             Self::UnsupportedToolchainHelperLane {
@@ -4939,8 +5164,8 @@ impl NativeCompileSupportIssue {
                 requested,
                 ..
             } => vec![
-                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
-                format!("{helper_env}=<reviewed-cairo-{requested}-helper-uc-path> uc support native --manifest-path <Scarb.toml> --format json"),
+                "uc support native --manifest-path <Scarb.toml> --json".to_string(),
+                format!("{helper_env}=<reviewed-cairo-{requested}-helper-uc-path> uc support native --manifest-path <Scarb.toml> --json"),
             ],
             Self::InvalidToolchainHelper {
                 requested,
@@ -4950,7 +5175,7 @@ impl NativeCompileSupportIssue {
                 let lane = requested.split('.').take(2).collect::<Vec<_>>().join(".");
                 vec![
                     format!("./scripts/build_native_toolchain_helper.sh --lane {lane}"),
-                    format!("{helper_env}=<helper-uc-path> uc support native --manifest-path <Scarb.toml> --format json"),
+                    format!("{helper_env}=<helper-uc-path> uc support native --manifest-path <Scarb.toml> --json"),
                 ]
             }
         }
@@ -5301,7 +5526,7 @@ fn native_support_report_from_manifest_path(manifest_path: &Path) -> Result<Nati
             ],
             next_commands: vec![
                 "cargo build -p uc-cli --features native-compile".to_string(),
-                "uc support native --manifest-path <Scarb.toml> --format json".to_string(),
+                "uc support native --manifest-path <Scarb.toml> --json".to_string(),
             ],
             safe_automated_action: "use_native_enabled_binary".to_string(),
             retryable: false,

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -2353,6 +2353,7 @@ fn project_inspect_report_from_manifest_path(manifest_path: &Path) -> Result<Pro
         manifest_path,
         workspace_manifest_for_report,
         &workspace_manifest_path,
+        &mut diagnostics,
     );
     let profiles =
         project_profiles_summary_for_report(manifest.as_ref(), workspace_manifest_for_report);
@@ -2627,6 +2628,7 @@ fn project_packages_for_report(
     manifest_path: &Path,
     workspace_manifest: Option<&TomlValue>,
     workspace_manifest_path: &Path,
+    diagnostics: &mut Vec<NativeDiagnostic>,
 ) -> Vec<ProjectInspectPackageSummary> {
     let mut packages = Vec::new();
     project_push_package_for_report(
@@ -2652,22 +2654,49 @@ fn project_packages_for_report(
             {
                 continue;
             }
-            if let Ok(member_manifest) =
-                read_text_file_with_limit(&member_manifest_path, MAX_MANIFEST_BYTES, "manifest")
-                    .and_then(|text| {
-                        parse_manifest_toml(
-                            &text,
-                            &member_manifest_path,
-                            "failed to parse workspace member manifest for project inspect",
-                        )
-                    })
-            {
-                project_push_package_for_report(
-                    &mut packages,
-                    Some(&member_manifest),
-                    &member_manifest_path,
-                    ProjectInspectPackageRole::WorkspaceMemberManifest,
-                );
+            match read_text_file_with_limit(&member_manifest_path, MAX_MANIFEST_BYTES, "manifest")
+                .and_then(|text| {
+                    parse_manifest_toml(
+                        &text,
+                        &member_manifest_path,
+                        "failed to parse workspace member manifest for project inspect",
+                    )
+                }) {
+                Ok(member_manifest) => {
+                    project_push_package_for_report(
+                        &mut packages,
+                        Some(&member_manifest),
+                        &member_manifest_path,
+                        ProjectInspectPackageRole::WorkspaceMemberManifest,
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        workspace_member_manifest = %member_manifest_path.display(),
+                        error = %err,
+                        "project inspect could not read workspace member manifest"
+                    );
+                    diagnostics.push(project_agent_diagnostic(
+                        "UCP1006",
+                        "workspace_member_manifest",
+                        NativeDiagnosticSeverity::Warn,
+                        "Workspace member manifest could not be inspected",
+                        format!(
+                            "uc could not inspect workspace member manifest {}.",
+                            member_manifest_path.display()
+                        ),
+                        format!("{err:#}"),
+                        vec![
+                            "Fix the workspace member manifest or remove it from [workspace].members before rerunning project inspection.".to_string(),
+                        ],
+                        vec!["uc project inspect --manifest-path <Scarb.toml> --json".to_string()],
+                        "manual_workspace_member_manifest_fix_required",
+                        false,
+                        false,
+                        None,
+                        Some(member_manifest_path.display().to_string()),
+                    ));
+                }
             }
         }
     }
@@ -2732,14 +2761,28 @@ fn project_workspace_member_manifest_paths(
     workspace_manifest: &TomlValue,
     workspace_manifest_path: &Path,
 ) -> Vec<PathBuf> {
-    let Some(members) = workspace_manifest
+    let Some(workspace_table) = workspace_manifest
         .get("workspace")
         .and_then(TomlValue::as_table)
-        .and_then(|workspace| workspace.get("members"))
-        .and_then(TomlValue::as_array)
     else {
         return Vec::new();
     };
+    let Some(members) = workspace_table.get("members").and_then(TomlValue::as_array) else {
+        return Vec::new();
+    };
+    let excludes = workspace_table
+        .get("exclude")
+        .and_then(TomlValue::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(TomlValue::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
 
     let workspace_root = workspace_manifest_path
         .parent()
@@ -2760,6 +2803,10 @@ fn project_workspace_member_manifest_paths(
         if project_workspace_member_pattern_is_literal(member_pattern) {
             let member_path = Path::new(member_pattern);
             if project_workspace_member_pattern_is_unsafe(member_path) {
+                continue;
+            }
+            let relative_member = normalize_fingerprint_path(member_path);
+            if project_workspace_member_is_excluded(&relative_member, &excludes) {
                 continue;
             }
             let candidate_manifest = workspace_root.join(member_path).join("Scarb.toml");
@@ -2802,6 +2849,9 @@ fn project_workspace_member_manifest_paths(
             if !project_workspace_member_pattern_matches(member_pattern, &relative_parent) {
                 continue;
             }
+            if project_workspace_member_is_excluded(&relative_parent, &excludes) {
+                continue;
+            }
             let canonical_candidate_manifest = match entry_path.canonicalize() {
                 Ok(path) => path,
                 Err(_) => continue,
@@ -2819,6 +2869,16 @@ fn project_workspace_member_manifest_paths(
     }
 
     manifests.into_iter().collect()
+}
+
+fn project_workspace_member_is_excluded(relative_member: &str, excludes: &[String]) -> bool {
+    excludes.iter().any(|exclude| {
+        if project_workspace_member_pattern_is_literal(exclude) {
+            relative_member == exclude.trim_start_matches("./")
+        } else {
+            project_workspace_member_pattern_matches(exclude, relative_member)
+        }
+    })
 }
 
 fn project_workspace_member_pattern_is_literal(pattern: &str) -> bool {

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -766,12 +766,18 @@ dependencies = ["core"]
             && origin.kind == "version"
             && origin.locator == "2.14.0"
             && origin.locked));
+    let expected_path_dep = normalize_fingerprint_path(
+        &manifest_path
+            .parent()
+            .expect("manifest should have a parent")
+            .join("../path_dep"),
+    );
     assert!(report
         .source_origins
         .iter()
         .any(|origin| origin.dependency == "path_dep"
             && origin.kind == "path"
-            && origin.locator.ends_with("/path_dep")));
+            && origin.locator == expected_path_dep));
     assert!(report
         .source_origins
         .iter()
@@ -927,25 +933,70 @@ edition = "2024_07"
 
     assert_eq!(report.package.name, None);
     assert_eq!(report.packages.len(), 2);
-    assert_eq!(
-        report
-            .packages
-            .iter()
-            .map(|package| (package.name.clone(), package.role.clone()))
-            .collect::<Vec<_>>(),
-        vec![
-            (
-                Some("alpha".to_string()),
-                ProjectInspectPackageRole::WorkspaceMemberManifest,
-            ),
-            (
-                Some("beta".to_string()),
-                ProjectInspectPackageRole::WorkspaceMemberManifest,
-            ),
-        ]
-    );
+    assert!(report.packages.iter().any(|package| {
+        package.name.as_deref() == Some("alpha")
+            && package.role == ProjectInspectPackageRole::WorkspaceMemberManifest
+    }));
+    assert!(report.packages.iter().any(|package| {
+        package.name.as_deref() == Some("beta")
+            && package.role == ProjectInspectPackageRole::WorkspaceMemberManifest
+    }));
     assert!(report.workspace.has_workspace_table);
     assert_eq!(report.workspace.members, vec!["packages/*".to_string()]);
+    assert_project_inspect_left_no_artifacts(&dir);
+}
+
+#[test]
+fn project_inspect_workspace_member_excludes_are_honored() {
+    let dir = unique_test_dir("uc-project-inspect-workspace-member-exclude");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let alpha_dir = dir.join("crates/alpha");
+    let template_dir = dir.join("crates/template");
+    fs::create_dir_all(&alpha_dir).expect("create alpha dir");
+    fs::create_dir_all(&template_dir).expect("create template dir");
+    fs::write(
+        dir.join("Scarb.toml"),
+        r#"[workspace]
+members = ["crates/*"]
+exclude = ["crates/template"]
+"#,
+    )
+    .expect("write workspace manifest");
+    fs::write(
+        alpha_dir.join("Scarb.toml"),
+        r#"[package]
+name = "alpha"
+version = "0.1.0"
+edition = "2024_07"
+"#,
+    )
+    .expect("write alpha manifest");
+    fs::write(
+        template_dir.join("Scarb.toml"),
+        r#"[package]
+name = "template"
+version = "0.1.0"
+edition = "2024_07"
+"#,
+    )
+    .expect("write template manifest");
+
+    let report = project_inspect_report_from_manifest_path(&dir.join("Scarb.toml"))
+        .expect("inspect should succeed");
+
+    assert_eq!(report.packages.len(), 1);
+    assert!(report
+        .packages
+        .iter()
+        .any(|package| package.name.as_deref() == Some("alpha")));
+    assert!(!report
+        .packages
+        .iter()
+        .any(|package| package.name.as_deref() == Some("template")));
+    assert_eq!(
+        report.workspace.exclude,
+        vec!["crates/template".to_string()]
+    );
     assert_project_inspect_left_no_artifacts(&dir);
 }
 
@@ -1241,6 +1292,57 @@ shared-dep = { workspace = true }
     assert_eq!(report.offline_readiness.remote_dependency_count, 1);
     assert_project_inspect_left_no_artifacts(&workspace);
     assert_project_inspect_left_no_artifacts(&member);
+}
+
+#[test]
+fn project_inspect_reports_workspace_member_manifest_diagnostics() {
+    let dir = unique_test_dir("uc-project-inspect-broken-workspace-member");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let alpha_dir = dir.join("packages/alpha");
+    let broken_dir = dir.join("packages/broken");
+    fs::create_dir_all(&alpha_dir).expect("create alpha dir");
+    fs::create_dir_all(&broken_dir).expect("create broken dir");
+    fs::write(
+        dir.join("Scarb.toml"),
+        r#"[workspace]
+members = ["packages/*"]
+"#,
+    )
+    .expect("write workspace manifest");
+    fs::write(
+        alpha_dir.join("Scarb.toml"),
+        r#"[package]
+name = "alpha"
+version = "0.1.0"
+edition = "2024_07"
+"#,
+    )
+    .expect("write alpha manifest");
+    fs::write(
+        broken_dir.join("Scarb.toml"),
+        "[package\nname = \"broken\"\n",
+    )
+    .expect("write broken manifest");
+
+    let report = project_inspect_report_from_manifest_path(&dir.join("Scarb.toml"))
+        .expect("inspect should succeed");
+
+    assert!(report
+        .packages
+        .iter()
+        .any(|package| package.name.as_deref() == Some("alpha")));
+    assert!(report
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "UCP1006"
+            && diagnostic.category == "workspace_member_manifest"
+            && diagnostic.safe_automated_action
+                == "manual_workspace_member_manifest_fix_required"
+            && diagnostic
+                .toolchain_found
+                .as_deref()
+                .is_some_and(|path| path.ends_with("/packages/broken/Scarb.toml"))));
+    assert_project_inspect_left_no_artifacts(&dir);
 }
 
 #[test]

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -691,6 +691,9 @@ cairo-version = "2.14.0"
 members = ["crates/*"]
 exclude = ["target"]
 
+[profile.ci]
+inherits = "release"
+
 [dependencies]
 starknet = "2.14.0"
 path_dep = { path = "../path_dep" }
@@ -733,8 +736,15 @@ dependencies = ["core"]
     assert_eq!(report.package.name.as_deref(), Some("demo"));
     assert_eq!(report.package.edition.as_deref(), Some("2024_07"));
     assert_eq!(report.package.cairo_version.as_deref(), Some("2.14.0"));
+    assert_eq!(report.packages.len(), 1);
+    assert_eq!(
+        report.packages[0].role,
+        ProjectInspectPackageRole::InspectedManifest
+    );
+    assert_eq!(report.packages[0].name.as_deref(), Some("demo"));
     assert_eq!(report.workspace.members, vec!["crates/*".to_string()]);
     assert_eq!(report.workspace.exclude, vec!["target".to_string()]);
+    assert_eq!(report.profiles.declared, vec!["ci".to_string()]);
     assert!(report
         .targets
         .iter()
@@ -749,6 +759,25 @@ dependencies = ["core"]
         .dependencies
         .iter()
         .any(|dep| dep.name == "git_dep" && dep.kind == "git"));
+    assert!(report
+        .source_origins
+        .iter()
+        .any(|origin| origin.dependency == "starknet"
+            && origin.kind == "version"
+            && origin.locator == "2.14.0"
+            && origin.locked));
+    assert!(report
+        .source_origins
+        .iter()
+        .any(|origin| origin.dependency == "path_dep"
+            && origin.kind == "path"
+            && origin.locator.ends_with("/path_dep")));
+    assert!(report
+        .source_origins
+        .iter()
+        .any(|origin| origin.dependency == "git_dep"
+            && origin.kind == "git"
+            && origin.locator == "https://example.com/repo.git#rev=abc123"));
     assert!(report.lockfile.present);
     assert!(report.lockfile.valid);
     assert_eq!(report.lockfile.version.as_deref(), Some("1"));
@@ -770,6 +799,21 @@ dependencies = ["core"]
     assert_eq!(
         report.toolchain.requested_major_minor.as_deref(),
         Some("2.14")
+    );
+    assert_eq!(
+        report.offline_readiness.status,
+        ProjectOfflineReadinessStatus::Ready
+    );
+    assert!(report.offline_readiness.readonly_native_source);
+    assert!(report.offline_readiness.lockfile_present);
+    assert!(report.offline_readiness.lockfile_valid);
+    assert_eq!(report.offline_readiness.remote_dependency_count, 3);
+    assert_eq!(report.offline_readiness.path_dependency_count, 1);
+    assert_eq!(report.offline_readiness.workspace_dependency_count, 0);
+    assert!(!report.offline_readiness.cache_state_known);
+    assert_eq!(
+        report.offline_readiness.reasons,
+        vec!["cache_state_unknown".to_string()]
     );
     assert!(report.native_support.is_some());
     assert_eq!(
@@ -795,6 +839,15 @@ fn project_inspect_report_returns_structured_diagnostic_for_invalid_manifest() {
 
     assert!(!report.manifest.valid);
     assert!(report.native_support.is_none());
+    assert!(report.packages.is_empty());
+    assert_eq!(
+        report.offline_readiness.status,
+        ProjectOfflineReadinessStatus::Blocked
+    );
+    assert!(report
+        .offline_readiness
+        .reasons
+        .contains(&"manifest_invalid".to_string()));
     assert!(report
         .diagnostics
         .iter()
@@ -826,8 +879,10 @@ members = ["crates/*"]
     assert_eq!(report.package.version, None);
     assert_eq!(report.package.edition, None);
     assert_eq!(report.package.cairo_version, None);
+    assert!(report.packages.is_empty());
     assert!(report.workspace.has_workspace_table);
     assert_eq!(report.workspace.members, vec!["crates/*".to_string()]);
+    assert!(report.profiles.declared.is_empty());
     assert!(report.readonly);
     assert_eq!(report.mutation_status, "none");
     assert_project_inspect_left_no_artifacts(&dir);
@@ -863,6 +918,19 @@ starknet = ">=2.14.0"
         .any(|diagnostic| diagnostic.code == "UCP1005"
             && diagnostic.category == "native_support_probe"
             && diagnostic.safe_automated_action == "inspect_native_support_then_retry"));
+    assert_eq!(
+        report.offline_readiness.status,
+        ProjectOfflineReadinessStatus::NeedsLockfile
+    );
+    assert!(!report.offline_readiness.readonly_native_source);
+    assert!(report
+        .offline_readiness
+        .reasons
+        .contains(&"lockfile_missing_for_remote_dependencies".to_string()));
+    assert!(report
+        .offline_readiness
+        .reasons
+        .contains(&"native_support_requires_exact_local_source".to_string()));
     assert_project_inspect_left_no_artifacts(&dir);
 }
 
@@ -1045,6 +1113,25 @@ starknet = { workspace = true }
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.code == "UCP1005"));
+    assert!(report
+        .source_origins
+        .iter()
+        .any(|origin| origin.dependency == "starknet"
+            && origin.kind == "version"
+            && origin.workspace_inherited
+            && origin.locator == "2.14.0"));
+    assert_eq!(
+        report.offline_readiness.status,
+        ProjectOfflineReadinessStatus::NeedsLockfile
+    );
+    assert!(report.offline_readiness.readonly_native_source);
+    assert!(!report.offline_readiness.lockfile_present);
+    assert_eq!(report.offline_readiness.remote_dependency_count, 1);
+    assert_eq!(report.offline_readiness.workspace_dependency_count, 1);
+    assert!(report
+        .offline_readiness
+        .reasons
+        .contains(&"lockfile_missing_for_remote_dependencies".to_string()));
     assert_project_inspect_left_no_artifacts(&workspace);
     assert_project_inspect_left_no_artifacts(&member);
 }

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -802,7 +802,7 @@ dependencies = ["core"]
     );
     assert_eq!(
         report.offline_readiness.status,
-        ProjectOfflineReadinessStatus::Ready
+        ProjectOfflineReadinessStatus::Unverified
     );
     assert!(report.offline_readiness.readonly_native_source);
     assert!(report.offline_readiness.lockfile_present);
@@ -885,6 +885,67 @@ members = ["crates/*"]
     assert!(report.profiles.declared.is_empty());
     assert!(report.readonly);
     assert_eq!(report.mutation_status, "none");
+    assert_project_inspect_left_no_artifacts(&dir);
+}
+
+#[test]
+fn project_inspect_workspace_only_manifest_reports_workspace_member_packages() {
+    let dir = unique_test_dir("uc-project-inspect-workspace-member-packages");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let alpha_dir = dir.join("packages/alpha");
+    let beta_dir = dir.join("packages/beta");
+    fs::create_dir_all(&alpha_dir).expect("create alpha dir");
+    fs::create_dir_all(&beta_dir).expect("create beta dir");
+    fs::write(
+        dir.join("Scarb.toml"),
+        r#"[workspace]
+members = ["packages/*"]
+"#,
+    )
+    .expect("write workspace manifest");
+    fs::write(
+        alpha_dir.join("Scarb.toml"),
+        r#"[package]
+name = "alpha"
+version = "0.1.0"
+edition = "2024_07"
+"#,
+    )
+    .expect("write alpha manifest");
+    fs::write(
+        beta_dir.join("Scarb.toml"),
+        r#"[package]
+name = "beta"
+version = "0.2.0"
+edition = "2024_07"
+"#,
+    )
+    .expect("write beta manifest");
+
+    let report = project_inspect_report_from_manifest_path(&dir.join("Scarb.toml"))
+        .expect("inspect should succeed");
+
+    assert_eq!(report.package.name, None);
+    assert_eq!(report.packages.len(), 2);
+    assert_eq!(
+        report
+            .packages
+            .iter()
+            .map(|package| (package.name.clone(), package.role.clone()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                Some("alpha".to_string()),
+                ProjectInspectPackageRole::WorkspaceMemberManifest,
+            ),
+            (
+                Some("beta".to_string()),
+                ProjectInspectPackageRole::WorkspaceMemberManifest,
+            ),
+        ]
+    );
+    assert!(report.workspace.has_workspace_table);
+    assert_eq!(report.workspace.members, vec!["packages/*".to_string()]);
     assert_project_inspect_left_no_artifacts(&dir);
 }
 
@@ -1132,6 +1193,52 @@ starknet = { workspace = true }
         .offline_readiness
         .reasons
         .contains(&"lockfile_missing_for_remote_dependencies".to_string()));
+    assert_project_inspect_left_no_artifacts(&workspace);
+    assert_project_inspect_left_no_artifacts(&member);
+}
+
+#[test]
+fn project_inspect_marks_unresolved_workspace_dependency_origin_unknown() {
+    let workspace = unique_test_dir("uc-project-inspect-unresolved-workspace-dependency");
+    let _cleanup = TestDirCleanup::new(&workspace);
+    let member = workspace.join("member");
+    fs::create_dir_all(&member).expect("create member dir");
+    fs::write(
+        workspace.join("Scarb.toml"),
+        r#"[workspace]
+members = ["member"]
+"#,
+    )
+    .expect("write workspace manifest");
+    let member_manifest = member.join("Scarb.toml");
+    fs::write(
+        &member_manifest,
+        r#"[package]
+name = "member"
+version = "0.1.0"
+edition = "2024_07"
+
+[dependencies]
+shared-dep = { workspace = true }
+"#,
+    )
+    .expect("write member manifest");
+
+    let report = project_inspect_report_from_manifest_path(&member_manifest)
+        .expect("inspect should succeed");
+
+    assert!(report
+        .source_origins
+        .iter()
+        .any(|origin| origin.dependency == "shared-dep"
+            && origin.workspace_inherited
+            && origin.kind == "unknown"
+            && origin.locator == "unknown"));
+    assert_eq!(
+        report.offline_readiness.status,
+        ProjectOfflineReadinessStatus::NeedsLockfile
+    );
+    assert_eq!(report.offline_readiness.remote_dependency_count, 1);
     assert_project_inspect_left_no_artifacts(&workspace);
     assert_project_inspect_left_no_artifacts(&member);
 }
@@ -4252,7 +4359,7 @@ cairo-version = "{requested_version}"
     assert!(
         commands
             .iter()
-            .any(|cmd| cmd.as_str().unwrap_or_default().contains("--format json")),
+            .any(|cmd| cmd.as_str().unwrap_or_default().contains("--json")),
         "agent diagnostics should keep a JSON retry/probe command"
     );
     assert!(

--- a/docs/COMMAND_SURFACE.md
+++ b/docs/COMMAND_SURFACE.md
@@ -37,7 +37,7 @@
 6. `uc project inspect`
 - Reads a `Scarb.toml` and optional sibling `Scarb.lock` without mutating files.
 - Supports: `--manifest-path`, `--format json`, `--json`, `--report-path`.
-- Emits package, workspace, target, dependency, lockfile, requested toolchain, read-only native support when determinable, and stable diagnostics in one JSON report.
+- Emits package entries, workspace summary, declared profiles, target summary, dependency/source origins, lockfile state, conservative offline-readiness status, requested toolchain, read-only native support when determinable, and stable diagnostics in one JSON report.
 - The report includes `readonly=true` and `mutation_status=none`; use this as the agent pre-build project-state surface.
 - The raw report is local evidence and can include absolute paths plus manifest/lockfile hashes; redact or avoid forwarding it when sharing outside the host.
 

--- a/docs/agent/schemas/project-inspect-report.schema.json
+++ b/docs/agent/schemas/project-inspect-report.schema.json
@@ -13,10 +13,14 @@
     "mutation_status",
     "manifest",
     "package",
+    "packages",
     "workspace",
+    "profiles",
     "targets",
     "dependencies",
+    "source_origins",
     "lockfile",
+    "offline_readiness",
     "toolchain",
     "diagnostics"
   ],
@@ -37,6 +41,22 @@
       }
     },
     "package": { "type": "object" },
+    "packages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["manifest_path", "package_root", "role"],
+        "properties": {
+          "manifest_path": { "type": "string", "minLength": 1 },
+          "package_root": { "type": "string", "minLength": 1 },
+          "role": { "enum": ["inspected_manifest", "workspace_root_manifest"] },
+          "name": { "type": ["string", "null"] },
+          "version": { "type": ["string", "null"] },
+          "edition": { "type": ["string", "null"] },
+          "cairo_version": { "type": ["string", "null"] }
+        }
+      }
+    },
     "workspace": {
       "type": "object",
       "required": ["has_workspace_table", "members", "exclude"],
@@ -46,8 +66,30 @@
         "exclude": { "type": "array", "items": { "type": "string" } }
       }
     },
+    "profiles": {
+      "type": "object",
+      "required": ["declared"],
+      "properties": {
+        "declared": { "type": "array", "items": { "type": "string" } }
+      }
+    },
     "targets": { "type": "array", "items": { "type": "object" } },
     "dependencies": { "type": "array", "items": { "type": "object" } },
+    "source_origins": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["dependency", "section", "kind", "locator", "workspace_inherited", "locked"],
+        "properties": {
+          "dependency": { "type": "string", "minLength": 1 },
+          "section": { "type": "string", "minLength": 1 },
+          "kind": { "type": "string", "minLength": 1 },
+          "locator": { "type": "string", "minLength": 1 },
+          "workspace_inherited": { "type": "boolean" },
+          "locked": { "type": "boolean" }
+        }
+      }
+    },
     "lockfile": {
       "type": "object",
       "required": ["present", "valid", "packages"],
@@ -60,6 +102,33 @@
         "modified_unix_ms": { "type": ["integer", "null"], "minimum": 0 },
         "hash": { "type": ["string", "null"] },
         "packages": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "offline_readiness": {
+      "type": "object",
+      "required": [
+        "status",
+        "readonly_native_source",
+        "lockfile_present",
+        "lockfile_valid",
+        "remote_dependency_count",
+        "path_dependency_count",
+        "workspace_dependency_count",
+        "cache_state_known",
+        "reasons"
+      ],
+      "properties": {
+        "status": {
+          "enum": ["ready", "needs_lockfile", "needs_exact_toolchain_source", "blocked"]
+        },
+        "readonly_native_source": { "type": "boolean" },
+        "lockfile_present": { "type": "boolean" },
+        "lockfile_valid": { "type": "boolean" },
+        "remote_dependency_count": { "type": "integer", "minimum": 0 },
+        "path_dependency_count": { "type": "integer", "minimum": 0 },
+        "workspace_dependency_count": { "type": "integer", "minimum": 0 },
+        "cache_state_known": { "type": "boolean" },
+        "reasons": { "type": "array", "items": { "type": "string" } }
       }
     },
     "toolchain": {

--- a/docs/agent/schemas/project-inspect-report.schema.json
+++ b/docs/agent/schemas/project-inspect-report.schema.json
@@ -49,7 +49,7 @@
         "properties": {
           "manifest_path": { "type": "string", "minLength": 1 },
           "package_root": { "type": "string", "minLength": 1 },
-          "role": { "enum": ["inspected_manifest", "workspace_root_manifest"] },
+          "role": { "enum": ["inspected_manifest", "workspace_root_manifest", "workspace_member_manifest"] },
           "name": { "type": ["string", "null"] },
           "version": { "type": ["string", "null"] },
           "edition": { "type": ["string", "null"] },
@@ -119,7 +119,7 @@
       ],
       "properties": {
         "status": {
-          "enum": ["ready", "needs_lockfile", "needs_exact_toolchain_source", "blocked"]
+          "enum": ["ready", "unverified", "needs_lockfile", "needs_exact_toolchain_source", "blocked"]
         },
         "readonly_native_source": { "type": "boolean" },
         "lockfile_present": { "type": "boolean" },

--- a/scripts/tests/doctor_test.sh
+++ b/scripts/tests/doctor_test.sh
@@ -128,6 +128,15 @@ PYTHON
 
 link_required_host_tools() {
   local fake_bin_dir="$1"
+  link_required_non_python_host_tools "$fake_bin_dir"
+
+  local py_resolved=""
+  py_resolved="$(find_python311_plus_for_test)" || return 1
+  write_exec_wrapper "$fake_bin_dir/python3" "$py_resolved"
+}
+
+link_required_non_python_host_tools() {
+  local fake_bin_dir="$1"
   for cmd in bash dirname env head sort; do
     local resolved
     resolved="$(command -v "$cmd" || true)"
@@ -137,7 +146,9 @@ link_required_host_tools() {
     fi
     ln -s "$resolved" "$fake_bin_dir/$cmd"
   done
+}
 
+find_python311_plus_for_test() {
   local py_resolved=""
   local py_cmd
   for py_cmd in python3 python3.13 python3.12 python3.11 python; do
@@ -148,11 +159,11 @@ if sys.version_info < (3, 11):
     raise SystemExit(1)
 PY
     then
-      write_exec_wrapper "$fake_bin_dir/python3" "$py_resolved"
+      printf '%s\n' "$py_resolved"
       return 0
     fi
   done
-  echo "link_required_host_tools could not find python3/python3.13/python3.12/python3.11/python for $fake_bin_dir" >&2
+  echo "find_python311_plus_for_test could not find python3/python3.13/python3.12/python3.11/python" >&2
   return 1
 }
 
@@ -247,25 +258,13 @@ test_doctor_accepts_python_fallback_when_python3_commands_are_missing() {
   local fake_bin_dir="$TMP_DIR/python-fallback-bin"
   local stdout_path="$TMP_DIR/python-fallback.out"
   mkdir -p "$fake_bin_dir"
-  for cmd in bash dirname env head sort; do
-    local resolved
-    resolved="$(command -v "$cmd" || true)"
-    if [[ -z "$resolved" ]]; then
-      echo "required host command not found for test sandbox: $cmd" >&2
-      return 1
-    fi
-    ln -s "$resolved" "$fake_bin_dir/$cmd"
-  done
+  link_required_non_python_host_tools "$fake_bin_dir"
   write_required_tool_stubs "$fake_bin_dir"
   write_version_stub "$fake_bin_dir/jq" "jq-1.7"
   write_git_hooks_stub "$fake_bin_dir/git"
 
   local python_resolved=""
-  python_resolved="$(command -v python || true)"
-  if [[ -z "$python_resolved" ]]; then
-    echo "required python fallback command not found for test sandbox" >&2
-    return 1
-  fi
+  python_resolved="$(find_python311_plus_for_test)" || return 1
   write_exec_wrapper "$fake_bin_dir/python" "$python_resolved"
 
   if ! PATH="$fake_bin_dir" "$DOCTOR_SCRIPT" >"$stdout_path" 2>&1; then
@@ -336,16 +335,15 @@ exit 1
 PYTHON3
   chmod +x "$fake_bin_dir/python3"
   rm -f "$fake_bin_dir/python3.12"
-  cat > "$fake_bin_dir/python3.12" <<'PYTHON312'
+  local python_real=""
+  python_real="$(find_python311_plus_for_test)" || return 1
+  cat > "$fake_bin_dir/python3.12" <<PYTHON312
 #!/usr/bin/env bash
 if [[ "${1-}" == "--version" ]]; then
   printf 'Python 3.12.9\n'
   exit 0
 fi
-while IFS= read -r _; do
-  :
-done
-exit 0
+exec "$python_real" "\$@"
 PYTHON312
   chmod +x "$fake_bin_dir/python3.12"
 


### PR DESCRIPTION
## Summary
- extend `uc project inspect --format json` with first-party package, profile, source-origin, and offline-readiness summaries
- document the richer inspect contract and ship the matching JSON schema update
- carry the shared agent-first validation hardening so local CI stays green on benchmark and helper-lane gates

## Validation
- `cargo test -p uc-cli project_inspect_ -- --nocapture`
- `make agent-validate`
- `git diff --check`
- `make local-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced project inspection with richer JSON reports including package summaries, declared profiles, dependency source-origins, and offline-readiness status.

* **Documentation**
  * Updated command docs and JSON schema to reflect the expanded inspection output structure.

* **Improvements**
  * Standardized CLI flags: `--json` now used consistently in project inspection and support commands.

* **Tests**
  * Expanded test coverage to validate the new report fields and offline-readiness semantics.

* **Chores**
  * Adjusted Python discovery/wrappers used in scripts and test harnesses for tomllib-capable interpreters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->