### PR TITLE
uc-cli: harden native support agent decisions

### DIFF
--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -555,6 +555,16 @@ enum NativeSupportStatus {
     Unavailable,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+enum NativeSupportDecisionStatus {
+    NativeSupported,
+    NativeUnsupported,
+    FallbackLikely,
+    #[default]
+    BuildBlocked,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum NativeToolchainRequestSource {
@@ -636,6 +646,8 @@ struct NativeSupportReport {
     schema_version: u32,
     manifest_path: String,
     status: NativeSupportStatus,
+    #[serde(default)]
+    decision_status: NativeSupportDecisionStatus,
     supported: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
@@ -781,9 +793,19 @@ struct ProjectToolchainSummary {
     requested_version: Option<String>,
     requested_major_minor: Option<String>,
     request_source: Option<NativeToolchainRequestSource>,
-    native_status: NativeSupportStatus,
+    native_status: ProjectNativeSupportStatus,
     native_supported: bool,
     fallback_used: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ProjectNativeSupportStatus {
+    NativeSupported,
+    NativeUnsupported,
+    FallbackLikely,
+    BuildBlocked,
+    Unavailable,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3405,8 +3427,8 @@ fn project_toolchain_summary(
     native_support: Option<&NativeSupportReport>,
 ) -> ProjectToolchainSummary {
     let native_status = native_support
-        .map(|support| support.status.clone())
-        .unwrap_or(NativeSupportStatus::Unavailable);
+        .map(|support| project_native_support_status_from_report(Some(support)))
+        .unwrap_or(ProjectNativeSupportStatus::Unavailable);
     let native_supported = native_support
         .map(|support| support.supported)
         .unwrap_or(false);
@@ -3634,6 +3656,83 @@ fn project_agent_diagnostic(
         toolchain_expected,
         toolchain_found,
     }
+}
+
+fn native_support_issue_kind_is_fallback_likely(issue_kind: &str) -> bool {
+    matches!(
+        issue_kind,
+        "unparseable_compiler_version"
+            | "compiler_version_mismatch"
+            | "missing_toolchain_helper"
+            | "invalid_toolchain_helper"
+    )
+}
+
+fn native_support_diagnostic_code_is_fallback_likely(code: &str) -> bool {
+    matches!(code, "UCN1001" | "UCN1003" | "UCN1004" | "UCN1005")
+}
+
+fn native_support_decision_status_from_report(
+    supported: bool,
+    status: &NativeSupportStatus,
+    issue_kind: Option<&str>,
+    diagnostics: &[NativeDiagnostic],
+) -> NativeSupportDecisionStatus {
+    if supported || matches!(status, NativeSupportStatus::Supported) {
+        return NativeSupportDecisionStatus::NativeSupported;
+    }
+    if matches!(status, NativeSupportStatus::Unavailable) {
+        return NativeSupportDecisionStatus::BuildBlocked;
+    }
+    if issue_kind.is_some_and(native_support_issue_kind_is_fallback_likely)
+        || diagnostics
+            .iter()
+            .any(|diagnostic| native_support_diagnostic_code_is_fallback_likely(&diagnostic.code))
+    {
+        return NativeSupportDecisionStatus::FallbackLikely;
+    }
+    NativeSupportDecisionStatus::NativeUnsupported
+}
+
+fn refresh_native_support_report_decision_status(report: &mut NativeSupportReport) {
+    report.decision_status = native_support_decision_status_from_report(
+        report.supported,
+        &report.status,
+        report.issue_kind.as_deref(),
+        &report.diagnostics,
+    );
+}
+
+fn project_native_support_status_from_report(
+    support: Option<&NativeSupportReport>,
+) -> ProjectNativeSupportStatus {
+    match support.map(|report| report.decision_status) {
+        Some(NativeSupportDecisionStatus::NativeSupported) => {
+            ProjectNativeSupportStatus::NativeSupported
+        }
+        Some(NativeSupportDecisionStatus::NativeUnsupported) => {
+            ProjectNativeSupportStatus::NativeUnsupported
+        }
+        Some(NativeSupportDecisionStatus::FallbackLikely) => {
+            ProjectNativeSupportStatus::FallbackLikely
+        }
+        Some(NativeSupportDecisionStatus::BuildBlocked) => ProjectNativeSupportStatus::BuildBlocked,
+        None => ProjectNativeSupportStatus::Unavailable,
+    }
+}
+
+fn best_effort_manifest_path_display(manifest_path: &Option<PathBuf>) -> String {
+    let requested = manifest_path
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("Scarb.toml"));
+    if requested.is_absolute() {
+        return requested.display().to_string();
+    }
+    std::env::current_dir()
+        .ok()
+        .map(|cwd| cwd.join(&requested).display().to_string())
+        .unwrap_or_else(|| requested.display().to_string())
 }
 
 fn run_agent_eval(args: AgentEvalArgs) -> Result<()> {
@@ -4366,9 +4465,18 @@ fn run_support(args: SupportArgs) -> Result<()> {
     }
 }
 
+fn native_support_report_from_args(args: &NativeSupportArgs) -> Result<NativeSupportReport> {
+    match resolve_manifest_path(&args.manifest_path) {
+        Ok(manifest_path) => native_support_report_from_manifest_path(&manifest_path),
+        Err(err) => Ok(native_support_manifest_path_resolution_blocked_report(
+            &args.manifest_path,
+            &err,
+        )),
+    }
+}
+
 fn run_native_support(args: NativeSupportArgs) -> Result<()> {
-    let manifest_path = resolve_manifest_path(&args.manifest_path)?;
-    let report = native_support_report_from_manifest_path(&manifest_path)?;
+    let report = native_support_report_from_args(&args)?;
     let format = if args.json {
         SupportFormatArg::Json
     } else {
@@ -4376,13 +4484,18 @@ fn run_native_support(args: NativeSupportArgs) -> Result<()> {
     };
     match format {
         SupportFormatArg::Text => {
-            if report.supported {
-                println!("supported");
-            } else {
-                println!(
-                    "unsupported: {}",
-                    report.reason.as_deref().unwrap_or("unknown reason")
-                );
+            let reason = report.reason.as_deref().unwrap_or("unknown reason");
+            match report.decision_status {
+                NativeSupportDecisionStatus::NativeSupported => println!("native_supported"),
+                NativeSupportDecisionStatus::NativeUnsupported => {
+                    println!("native_unsupported: {reason}");
+                }
+                NativeSupportDecisionStatus::FallbackLikely => {
+                    println!("fallback_likely: {reason}");
+                }
+                NativeSupportDecisionStatus::BuildBlocked => {
+                    println!("build_blocked: {reason}");
+                }
             }
         }
         SupportFormatArg::Json => {
@@ -5279,6 +5392,13 @@ impl NativeCompileSupportIssue {
             } => (Some(requested.clone()), Some(path.clone())),
         };
         let code = self.code();
+        let retryable = matches!(
+            self,
+            Self::UnparseableCompilerVersion { .. }
+                | Self::CompilerVersionMismatch { .. }
+                | Self::MissingToolchainHelper { .. }
+                | Self::InvalidToolchainHelper { .. }
+        );
         NativeDiagnostic {
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             code: code.to_string(),
@@ -5291,7 +5411,7 @@ impl NativeCompileSupportIssue {
             how_to_fix: self.how_to_fix(),
             next_commands: self.next_commands(),
             safe_automated_action: self.safe_automated_action().to_string(),
-            retryable: false,
+            retryable,
             fallback_used: false,
             toolchain_expected,
             toolchain_found,
@@ -5495,6 +5615,17 @@ fn select_native_toolchain_from_manifest_path(
         manifest_path,
         "failed to parse manifest for native support probe",
     )?;
+    select_native_toolchain_from_manifest_value(manifest_path, &manifest)
+}
+
+#[cfg(feature = "native-compile")]
+fn select_native_toolchain_from_manifest_value(
+    manifest_path: &Path,
+    manifest: &TomlValue,
+) -> Result<(
+    NativeToolchainRequirement,
+    std::result::Result<NativeToolchainSelection, NativeCompileSupportIssue>,
+)> {
     let requirement = resolve_native_toolchain_requirement(manifest_path, &manifest)?;
     let selection = select_native_toolchain_from_requirement(&requirement)?;
     Ok((requirement, selection))
@@ -5508,30 +5639,63 @@ fn native_compile_support_reason(manifest_path: &Path) -> Result<Option<String>>
 
 #[cfg(feature = "native-compile")]
 fn native_support_report_from_manifest_path(manifest_path: &Path) -> Result<NativeSupportReport> {
-    let manifest_text = read_text_file_with_limit(manifest_path, MAX_MANIFEST_BYTES, "manifest")?;
-    let manifest = parse_manifest_toml(
+    let compiler_version = Some(native_cairo_lang_compiler_version().to_string());
+    let manifest_text =
+        match read_text_file_with_limit(manifest_path, MAX_MANIFEST_BYTES, "manifest") {
+            Ok(text) => text,
+            Err(err) => {
+                return Ok(native_support_manifest_read_blocked_report(
+                    manifest_path,
+                    compiler_version,
+                    &err,
+                ))
+            }
+        };
+    let manifest = match parse_manifest_toml(
         &manifest_text,
         manifest_path,
         "failed to parse manifest for native support probe",
-    )?;
+    ) {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            return Ok(native_support_manifest_parse_blocked_report(
+                manifest_path,
+                compiler_version,
+                &err,
+            ))
+        }
+    };
     let package_cairo_version = manifest_package_cairo_version(&manifest);
-    let (requirement, selection) = select_native_toolchain_from_manifest_path(manifest_path)?;
+    let (requirement, selection) =
+        select_native_toolchain_from_manifest_value(manifest_path, &manifest)?;
     match selection {
         Ok(selection) => {
             if let Some(helper_path) = selection.helper_path.as_ref() {
                 let mut report =
-                    load_native_support_report_from_helper(helper_path, manifest_path)?;
+                    match load_native_support_report_from_helper(helper_path, manifest_path) {
+                        Ok(report) => report,
+                        Err(err) => {
+                            return Ok(native_support_external_helper_probe_blocked_report(
+                                manifest_path,
+                                selection.toolchain.clone(),
+                                helper_path,
+                                &err,
+                            ))
+                        }
+                    };
                 report.manifest_path = manifest_path.display().to_string();
                 report.package_cairo_version = package_cairo_version;
                 let mut toolchain = selection.toolchain;
                 toolchain.compiler_version = report.compiler_version.clone();
                 report.toolchain = Some(toolchain);
+                refresh_native_support_report_decision_status(&mut report);
                 return Ok(report);
             }
-            Ok(NativeSupportReport {
+            let mut report = NativeSupportReport {
                 schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
                 manifest_path: manifest_path.display().to_string(),
                 status: NativeSupportStatus::Supported,
+                decision_status: NativeSupportDecisionStatus::NativeSupported,
                 supported: true,
                 reason: None,
                 compiler_version: Some(native_cairo_lang_compiler_version().to_string()),
@@ -5539,29 +5703,37 @@ fn native_support_report_from_manifest_path(manifest_path: &Path) -> Result<Nati
                 issue_kind: None,
                 toolchain: Some(selection.toolchain),
                 diagnostics: Vec::new(),
-            })
+            };
+            refresh_native_support_report_decision_status(&mut report);
+            Ok(report)
         }
-        Err(issue) => Ok(NativeSupportReport {
-            schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
-            manifest_path: manifest_path.display().to_string(),
-            status: NativeSupportStatus::Unsupported,
-            supported: false,
-            reason: Some(issue.reason()),
-            compiler_version: Some(native_cairo_lang_compiler_version().to_string()),
-            package_cairo_version,
-            issue_kind: Some(issue.kind().to_string()),
-            toolchain: Some(native_toolchain_report_for_issue(&requirement, &issue)),
-            diagnostics: vec![issue.diagnostic()],
-        }),
+        Err(issue) => {
+            let mut report = NativeSupportReport {
+                schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+                manifest_path: manifest_path.display().to_string(),
+                status: NativeSupportStatus::Unsupported,
+                decision_status: NativeSupportDecisionStatus::NativeUnsupported,
+                supported: false,
+                reason: Some(issue.reason()),
+                compiler_version: Some(native_cairo_lang_compiler_version().to_string()),
+                package_cairo_version,
+                issue_kind: Some(issue.kind().to_string()),
+                toolchain: Some(native_toolchain_report_for_issue(&requirement, &issue)),
+                diagnostics: vec![issue.diagnostic()],
+            };
+            refresh_native_support_report_decision_status(&mut report);
+            Ok(report)
+        }
     }
 }
 
 #[cfg(not(feature = "native-compile"))]
 fn native_support_report_from_manifest_path(manifest_path: &Path) -> Result<NativeSupportReport> {
-    Ok(NativeSupportReport {
+    let mut report = NativeSupportReport {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         manifest_path: manifest_path.display().to_string(),
         status: NativeSupportStatus::Unavailable,
+        decision_status: NativeSupportDecisionStatus::BuildBlocked,
         supported: false,
         reason: Some(
             "native compile support probing is unavailable because this uc binary was built without native-compile".to_string(),
@@ -5594,7 +5766,9 @@ fn native_support_report_from_manifest_path(manifest_path: &Path) -> Result<Nati
             toolchain_expected: None,
             toolchain_found: None,
         }],
-    })
+    };
+    refresh_native_support_report_decision_status(&mut report);
+    Ok(report)
 }
 
 #[cfg(all(feature = "native-compile", test))]
@@ -14860,6 +15034,192 @@ fn build_uc_support_native_json_command(
     (command, command_vec)
 }
 
+fn native_support_blocked_report(
+    manifest_path: String,
+    issue_kind: &str,
+    compiler_version: Option<String>,
+    toolchain: Option<NativeToolchainReport>,
+    diagnostic: NativeDiagnostic,
+) -> NativeSupportReport {
+    let reason = Some(diagnostic.why.clone());
+    let mut report = NativeSupportReport {
+        schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+        manifest_path,
+        status: NativeSupportStatus::Unavailable,
+        decision_status: NativeSupportDecisionStatus::BuildBlocked,
+        supported: false,
+        reason,
+        compiler_version,
+        package_cairo_version: None,
+        issue_kind: Some(issue_kind.to_string()),
+        toolchain,
+        diagnostics: vec![diagnostic],
+    };
+    refresh_native_support_report_decision_status(&mut report);
+    report
+}
+
+fn native_support_manifest_path_resolution_blocked_report(
+    manifest_path: &Option<PathBuf>,
+    err: &anyhow::Error,
+) -> NativeSupportReport {
+    let manifest_display = best_effort_manifest_path_display(manifest_path);
+    let what_happened = format!("uc could not resolve the manifest path for `{manifest_display}`.");
+    let why = format!("{err:#}");
+    let next_commands = vec![
+        "pwd".to_string(),
+        format!("ls {}", shell_escape_command_arg(&manifest_display)),
+    ];
+    native_support_blocked_report(
+        manifest_display,
+        "manifest_path_resolution_failed",
+        None,
+        None,
+        project_agent_diagnostic(
+            "UCN1100",
+            "manifest_path",
+            NativeDiagnosticSeverity::Error,
+            "Manifest path could not be resolved",
+            what_happened,
+            why,
+            vec![
+                "Pass an existing Scarb.toml path with --manifest-path.".to_string(),
+                "If you intended to use the default manifest, run the command from the project root.".to_string(),
+            ],
+            next_commands,
+            "manual_manifest_fix_required",
+            true,
+            false,
+            None,
+            None,
+        ),
+    )
+}
+
+fn native_support_manifest_read_blocked_report(
+    manifest_path: &Path,
+    compiler_version: Option<String>,
+    err: &anyhow::Error,
+) -> NativeSupportReport {
+    native_support_blocked_report(
+        manifest_path.display().to_string(),
+        "manifest_read_failed",
+        compiler_version,
+        None,
+        project_agent_diagnostic(
+            "UCN1101",
+            "manifest_read",
+            NativeDiagnosticSeverity::Error,
+            "Project manifest could not be read",
+            format!(
+                "uc could not read the manifest at `{}` during native support probing.",
+                manifest_path.display()
+            ),
+            format!("{err:#}"),
+            vec!["Ensure the manifest exists, is readable, and is valid UTF-8.".to_string()],
+            vec![format!(
+                "uc support native --manifest-path {} --json",
+                shell_escape_command_arg(&manifest_path.display().to_string())
+            )],
+            "manual_manifest_fix_required",
+            true,
+            false,
+            None,
+            None,
+        ),
+    )
+}
+
+fn native_support_manifest_parse_blocked_report(
+    manifest_path: &Path,
+    compiler_version: Option<String>,
+    err: &anyhow::Error,
+) -> NativeSupportReport {
+    native_support_blocked_report(
+        manifest_path.display().to_string(),
+        "manifest_parse_failed",
+        compiler_version,
+        None,
+        project_agent_diagnostic(
+            "UCN1102",
+            "manifest_parse",
+            NativeDiagnosticSeverity::Error,
+            "Project manifest TOML could not be parsed",
+            format!(
+                "uc read `{}` but could not parse it as a Scarb manifest during native support probing.",
+                manifest_path.display()
+            ),
+            format!("{err:#}"),
+            vec![
+                "Fix the TOML syntax or manifest structure, then rerun native support probing."
+                    .to_string(),
+            ],
+            vec![
+                format!(
+                    "uc support native --manifest-path {} --json",
+                    shell_escape_command_arg(&manifest_path.display().to_string())
+                ),
+            ],
+            "manual_manifest_fix_required",
+            true,
+            false,
+            None,
+            None,
+        ),
+    )
+}
+
+#[cfg(feature = "native-compile")]
+fn native_support_external_helper_probe_blocked_report(
+    manifest_path: &Path,
+    toolchain: NativeToolchainReport,
+    helper_path: &Path,
+    err: &anyhow::Error,
+) -> NativeSupportReport {
+    let expected = toolchain
+        .requested_major_minor
+        .clone()
+        .or_else(|| toolchain.requested_version.clone());
+    let found = Some(helper_path.display().to_string());
+    let lane = expected.clone().unwrap_or_else(|| "<lane>".to_string());
+    native_support_blocked_report(
+        manifest_path.display().to_string(),
+        "external_helper_probe_failed",
+        Some(native_cairo_lang_compiler_version().to_string()),
+        Some(toolchain),
+        project_agent_diagnostic(
+            "UCN1103",
+            "toolchain_helper_probe",
+            NativeDiagnosticSeverity::Error,
+            "External helper native support probe failed",
+            format!(
+                "uc selected the external helper `{}` for native support probing, but that helper did not return a usable support report.",
+                helper_path.display()
+            ),
+            format!("{err:#}"),
+            vec![
+                format!(
+                    "Rebuild the helper lane for Cairo {lane} if the helper is stale or incompatible."
+                ),
+                "If the helper is intentionally custom, run it directly and inspect its JSON output."
+                    .to_string(),
+            ],
+            vec![
+                format!("./scripts/build_native_toolchain_helper.sh --lane {lane}"),
+                format!(
+                    "uc support native --manifest-path {} --json",
+                    shell_escape_command_arg(&manifest_path.display().to_string())
+                ),
+            ],
+            "rebuild_helper_lane",
+            true,
+            false,
+            expected,
+            found,
+        ),
+    )
+}
+
 #[cfg(feature = "native-compile")]
 fn load_native_support_report_from_helper(
     helper_path: &Path,
@@ -14877,12 +15237,15 @@ fn load_native_support_report_from_helper(
             run.stderr.trim()
         );
     }
-    serde_json::from_str::<NativeSupportReport>(run.stdout.trim()).with_context(|| {
-        format!(
-            "failed to decode native support report from helper {}",
-            helper_path.display()
-        )
-    })
+    let mut report =
+        serde_json::from_str::<NativeSupportReport>(run.stdout.trim()).with_context(|| {
+            format!(
+                "failed to decode native support report from helper {}",
+                helper_path.display()
+            )
+        })?;
+    refresh_native_support_report_decision_status(&mut report);
+    Ok(report)
 }
 
 fn build_uc_build_command(

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -1470,6 +1470,7 @@ fn agent_eval_decision_runs_safe_action_for_helper_lane_failure() {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         manifest_path: "/tmp/workspace/Scarb.toml".to_string(),
         status: NativeSupportStatus::Unsupported,
+        decision_status: NativeSupportDecisionStatus::FallbackLikely,
         supported: false,
         reason: Some("helper missing".to_string()),
         compiler_version: Some("2.16.0".to_string()),
@@ -1521,6 +1522,7 @@ fn agent_eval_decision_shell_escapes_next_command_paths() {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         manifest_path: "/tmp/My Project/Scarb.toml".to_string(),
         status: NativeSupportStatus::Supported,
+        decision_status: NativeSupportDecisionStatus::NativeSupported,
         supported: true,
         reason: None,
         compiler_version: Some("2.16.0".to_string()),
@@ -1546,6 +1548,7 @@ fn agent_eval_decision_uses_manifest_path_for_manifest_safe_actions() {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         manifest_path: "/tmp/My Project/Scarb.toml".to_string(),
         status: NativeSupportStatus::Unsupported,
+        decision_status: NativeSupportDecisionStatus::FallbackLikely,
         supported: false,
         reason: Some("cache refresh needed".to_string()),
         compiler_version: Some("2.16.0".to_string()),
@@ -1594,6 +1597,7 @@ fn agent_eval_decision_selects_first_runnable_safe_action() {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         manifest_path: "/tmp/workspace/Scarb.toml".to_string(),
         status: NativeSupportStatus::Unsupported,
+        decision_status: NativeSupportDecisionStatus::FallbackLikely,
         supported: false,
         reason: Some("helper missing".to_string()),
         compiler_version: Some("2.16.0".to_string()),
@@ -2214,6 +2218,7 @@ starknet = "={requested_version}"
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             manifest_path: manifest_path.display().to_string(),
             status: NativeSupportStatus::Supported,
+            decision_status: NativeSupportDecisionStatus::NativeSupported,
             supported: true,
             reason: None,
             compiler_version: Some(requested_version.to_string()),
@@ -3884,6 +3889,10 @@ edition = "2023_01"
     let report = native_support_report_from_manifest_path(&manifest_path)
         .expect("legacy manifest should still produce a report");
     assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::NativeUnsupported
+    );
     assert!(!report.supported);
     assert_eq!(
         report.issue_kind.as_deref(),
@@ -3921,6 +3930,10 @@ starknet = "=2.5.x"
     let report = native_support_report_from_manifest_path(&manifest_path)
         .expect("invalid pinned dependency should still produce a report");
     assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::NativeUnsupported
+    );
     assert!(!report.supported);
     assert_eq!(
         report.issue_kind.as_deref(),
@@ -3942,6 +3955,72 @@ starknet = "=2.5.x"
             .contains("unsupported constraint `=2.5.x`"),
         "report should classify malformed pinned dependency versions as unsupported constraints"
     );
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn native_support_report_from_args_marks_missing_manifest_build_blocked() {
+    let dir = unique_test_dir("uc-native-support-missing-manifest");
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let missing_manifest_path = dir.join("Scarb.toml");
+    let report = native_support_report_from_args(&NativeSupportArgs {
+        manifest_path: Some(missing_manifest_path.clone()),
+        format: SupportFormatArg::Json,
+        json: false,
+    })
+    .expect("missing manifest should still produce a blocked support report");
+
+    assert_eq!(report.status, NativeSupportStatus::Unavailable);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::BuildBlocked
+    );
+    assert_eq!(
+        report.issue_kind.as_deref(),
+        Some("manifest_path_resolution_failed")
+    );
+    let diagnostic = report
+        .diagnostics
+        .first()
+        .expect("blocked support report should include a diagnostic");
+    assert_eq!(diagnostic.code, "UCN1100");
+    assert!(diagnostic.retryable);
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn native_support_report_from_manifest_path_marks_parse_error_build_blocked() {
+    let dir = unique_test_dir("uc-native-support-parse-blocked");
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    fs::write(
+        &manifest_path,
+        r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2024_07"
+cairo-version = "2.14.0
+"#,
+    )
+    .expect("write invalid manifest");
+
+    let report = native_support_report_from_manifest_path(&manifest_path)
+        .expect("manifest parse failure should still produce a blocked support report");
+    assert_eq!(report.status, NativeSupportStatus::Unavailable);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::BuildBlocked
+    );
+    assert_eq!(report.issue_kind.as_deref(), Some("manifest_parse_failed"));
+    let diagnostic = report
+        .diagnostics
+        .first()
+        .expect("blocked support report should include a diagnostic");
+    assert_eq!(diagnostic.code, "UCN1102");
+    assert!(diagnostic.retryable);
 
     fs::remove_dir_all(&dir).ok();
 }
@@ -3972,6 +4051,10 @@ cairo-version = "{compiler_major}.{compiler_minor}.0"
     let supported_report = native_support_report_from_manifest_path(&manifest_path)
         .expect("supported manifest should probe successfully");
     assert_eq!(supported_report.status, NativeSupportStatus::Supported);
+    assert_eq!(
+        supported_report.decision_status,
+        NativeSupportDecisionStatus::NativeSupported
+    );
     assert!(supported_report.supported);
     assert!(supported_report.reason.is_none());
 
@@ -4004,6 +4087,10 @@ cairo-version = "{requested_major_minor}.0"
     let unsupported_report = native_support_report_from_manifest_path(&manifest_path)
         .expect("unsupported manifest should still produce a report");
     assert_eq!(unsupported_report.status, NativeSupportStatus::Unsupported);
+    assert_eq!(
+        unsupported_report.decision_status,
+        NativeSupportDecisionStatus::FallbackLikely
+    );
     assert!(!unsupported_report.supported);
     assert_eq!(
         unsupported_report.issue_kind.as_deref(),
@@ -4096,6 +4183,7 @@ version = "{requested_version}"
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             manifest_path: manifest_path.display().to_string(),
             status: NativeSupportStatus::Supported,
+            decision_status: NativeSupportDecisionStatus::NativeSupported,
             supported: true,
             reason: None,
             compiler_version: Some(requested_version.clone()),
@@ -4162,6 +4250,7 @@ cairo-version = "{requested_version}"
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             manifest_path: manifest_path.display().to_string(),
             status: NativeSupportStatus::Supported,
+            decision_status: NativeSupportDecisionStatus::NativeSupported,
             supported: true,
             reason: None,
             compiler_version: Some(requested_version.clone()),
@@ -4184,6 +4273,10 @@ cairo-version = "{requested_version}"
     let report = native_support_report_from_manifest_path(&manifest_path)
         .expect("helper-backed report should be returned");
     assert_eq!(report.status, NativeSupportStatus::Supported);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::NativeSupported
+    );
     assert!(report.supported);
     let toolchain = report.toolchain.expect("toolchain should be populated");
     assert_eq!(toolchain.source, NativeToolchainSource::ExternalHelper);
@@ -4313,6 +4406,10 @@ cairo-version = "{requested_version}"
     assert_eq!(report.schema_version, UC_AGENT_JSON_SCHEMA_VERSION);
     assert_eq!(report.status, NativeSupportStatus::Unsupported);
     assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::FallbackLikely
+    );
+    assert_eq!(
         report.issue_kind.as_deref(),
         Some("missing_toolchain_helper")
     );
@@ -4396,6 +4493,7 @@ cairo-version = "{requested_version}"
     let json = serde_json::to_value(&report).expect("support report should serialize");
     assert_eq!(json["schema_version"], UC_AGENT_JSON_SCHEMA_VERSION);
     assert_eq!(json["status"], "unsupported");
+    assert_eq!(json["decision_status"], "fallback_likely");
     assert_eq!(json["supported"], false);
     assert_eq!(json["issue_kind"], "missing_toolchain_helper");
     assert_eq!(json["diagnostics"][0]["code"], "UCN1004");
@@ -4407,7 +4505,7 @@ cairo-version = "{requested_version}"
         json["diagnostics"][0]["category"],
         "toolchain_lane_unavailable"
     );
-    assert_eq!(json["diagnostics"][0]["retryable"], false);
+    assert_eq!(json["diagnostics"][0]["retryable"], true);
     assert_eq!(json["diagnostics"][0]["fallback_used"], false);
     assert_eq!(
         json["diagnostics"][0]["safe_automated_action"],
@@ -4523,6 +4621,10 @@ starknet = "={requested_version}"
     let report = native_support_report_from_manifest_path(&manifest_path)
         .expect("unproductized helper lane should still return support JSON");
     assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::NativeUnsupported
+    );
     assert!(!report.supported);
     assert_eq!(
         report.issue_kind.as_deref(),
@@ -4623,6 +4725,10 @@ cairo-version = "{requested_version}"
     let report = native_support_report_from_manifest_path(&manifest_path)
         .expect("invalid unproductized helper should still return support JSON");
     assert_eq!(report.status, NativeSupportStatus::Unsupported);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::NativeUnsupported
+    );
     assert_eq!(
         report.issue_kind.as_deref(),
         Some("unsupported_toolchain_helper_lane")
@@ -4787,6 +4893,7 @@ starknet = "={requested_version}"
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             manifest_path: manifest_path.display().to_string(),
             status: NativeSupportStatus::Supported,
+            decision_status: NativeSupportDecisionStatus::NativeSupported,
             supported: true,
             reason: None,
             compiler_version: Some(requested_version.to_string()),
@@ -4801,6 +4908,10 @@ starknet = "={requested_version}"
     let report = native_support_report_from_manifest_path(&manifest_path)
         .expect("reviewed external helper should be allowed even for unproductized lanes");
     assert_eq!(report.status, NativeSupportStatus::Supported);
+    assert_eq!(
+        report.decision_status,
+        NativeSupportDecisionStatus::NativeSupported
+    );
     assert!(report.supported);
     let toolchain = report.toolchain.expect("toolchain should be populated");
     assert_eq!(toolchain.source, NativeToolchainSource::ExternalHelper);

--- a/docs/COMMAND_SURFACE.md
+++ b/docs/COMMAND_SURFACE.md
@@ -44,12 +44,18 @@
 7. `uc support native`
 - Probes whether a manifest is eligible for native compile in the current `uc` binary.
 - Supports: `--manifest-path`, `--format text|json`, `--json`.
-- Returns a structured reason for ineligible manifests so scripts and local benchmark harnesses can classify cases before measuring them.
+- Returns a structured pre-build decision report so scripts and local benchmark harnesses can classify cases before measuring them.
 - Native support JSON includes selected toolchain lane and stable diagnostics for:
   - exact `cairo-version` mismatches
   - unsupported manifest constraints
   - missing or invalid external helper lanes
   - unparseable compiler versions
+  - manifest-path, manifest-read, manifest-parse, and helper-probe blocked states
+- `status` remains the low-level probe status (`supported`, `unsupported`, `unavailable`) for compatibility, while `decision_status` is the agent-facing state:
+  - `native_supported`
+  - `native_unsupported`
+  - `fallback_likely`
+  - `build_blocked`
 
 8. `uc migrate`
 - Analyzes `Scarb.toml` and emits a migration readiness report.
@@ -91,7 +97,7 @@ The intended primary surface for agents is:
 - `uc support native`
   - Status: implemented
   - Pre-build native support classification.
-  - Must report native-supported, native-unsupported, fallback-likely, or build-blocked with reason codes.
+  - Reports agent-facing `decision_status` values `native_supported`, `native_unsupported`, `fallback_likely`, or `build_blocked`, with reason codes and remediation diagnostics.
 
 - `uc resolve`
   - Status: planned (not yet implemented)

--- a/docs/agent/AGENT_DIAGNOSTICS.md
+++ b/docs/agent/AGENT_DIAGNOSTICS.md
@@ -22,6 +22,13 @@ Every agent-facing diagnostic emitted by `uc project inspect --format json`, `uc
 - `toolchain_expected`: expected Cairo/toolchain lane when relevant.
 - `toolchain_found`: found compiler/helper/path when relevant.
 
+For `uc support native --format json`, agents should key their pre-build routing on `decision_status`:
+
+- `native_supported`: native path is ready now.
+- `native_unsupported`: keep the workload outside native claims until compatibility work lands.
+- `fallback_likely`: native is not ready now, but Scarb compatibility fallback is likely to work.
+- `build_blocked`: the support probe itself could not complete; fix the blocking input or helper issue before routing further.
+
 ## Codes
 
 ### UCN0001
@@ -87,6 +94,38 @@ Native toolchain helper lane is not productized.
 - Category: `toolchain_lane_unsupported`
 - Safe action: `manual_legacy_adapter_required`
 - Agent behavior: do not run the helper builder for this lane. Keep the workload in the support matrix as `native_unsupported` unless a reviewed compatible helper binary is explicitly supplied or a dedicated compatibility adapter lands.
+
+### UCN1100
+
+Manifest path could not be resolved.
+
+- Category: `manifest_path`
+- Safe action: `manual_manifest_fix_required`
+- Agent behavior: stop before build; fix the requested path or rerun from the intended project root.
+
+### UCN1101
+
+Project manifest could not be read.
+
+- Category: `manifest_read`
+- Safe action: `manual_manifest_fix_required`
+- Agent behavior: stop before build; ensure `Scarb.toml` exists, is readable, and is valid UTF-8.
+
+### UCN1102
+
+Project manifest TOML could not be parsed.
+
+- Category: `manifest_parse`
+- Safe action: `manual_manifest_fix_required`
+- Agent behavior: stop before build; fix the TOML syntax or manifest structure, then rerun support probing.
+
+### UCN1103
+
+External helper native support probe failed.
+
+- Category: `toolchain_helper_probe`
+- Safe action: `rebuild_helper_lane`
+- Agent behavior: rebuild the helper lane or inspect the helper directly before trusting the lane.
 
 ### UCP1000
 

--- a/docs/agent/AGENT_FIRST_COMPILER.md
+++ b/docs/agent/AGENT_FIRST_COMPILER.md
@@ -37,7 +37,7 @@ Already in this PR or required before launch:
 - `uc mcp serve` emits the read-only command/resource catalog for MCP adapters.
 - `uc project inspect --manifest-path <Scarb.toml> --format json` emits read-only package, workspace, target, dependency, lockfile, and toolchain state.
 - Native support details are included only when exact lane data is available; if read-only inspect skips native probing, use `UCP1005` as the signal to run `uc support native` for full probing.
-- Native support reports include toolchain selection metadata.
+- Native support reports include toolchain selection metadata plus agent-facing `decision_status` values `native_supported`, `native_unsupported`, `fallback_likely`, and `build_blocked`.
 - Diagnostics include schema version, docs URL, next commands, safe automated action, retryability, fallback status, expected toolchain, and found toolchain.
 - Real-repo benchmarks include native support classification and fallback status.
 - `scripts/doctor.sh --uc-bin <path> --manifest-path <Scarb.toml>` probes support before measurement.

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -35,6 +35,7 @@ uc support native --manifest-path /abs/path/to/Scarb.toml --format json
 Read:
 
 - `.supported`
+- `.decision_status`
 - `.status`
 - `.issue_kind`
 - `.toolchain.requested_version`

--- a/docs/agent/schemas/native-support-report.schema.json
+++ b/docs/agent/schemas/native-support-report.schema.json
@@ -8,6 +8,7 @@
     "schema_version",
     "manifest_path",
     "status",
+    "decision_status",
     "supported",
     "diagnostics"
   ],
@@ -15,6 +16,14 @@
     "schema_version": { "const": 1 },
     "manifest_path": { "type": "string", "minLength": 1 },
     "status": { "enum": ["supported", "unsupported", "unavailable"] },
+    "decision_status": {
+      "enum": [
+        "native_supported",
+        "native_unsupported",
+        "fallback_likely",
+        "build_blocked"
+      ]
+    },
     "supported": { "type": "boolean" },
     "reason": { "type": "string" },
     "compiler_version": { "type": "string" },

--- a/docs/agent/schemas/project-inspect-report.schema.json
+++ b/docs/agent/schemas/project-inspect-report.schema.json
@@ -138,7 +138,15 @@
         "requested_version": { "type": ["string", "null"] },
         "requested_major_minor": { "type": ["string", "null"] },
         "request_source": { "type": ["string", "null"] },
-        "native_status": { "enum": ["supported", "unsupported", "unavailable"] },
+        "native_status": {
+          "enum": [
+            "native_supported",
+            "native_unsupported",
+            "fallback_likely",
+            "build_blocked",
+            "unavailable"
+          ]
+        },
         "native_supported": { "type": "boolean" },
         "fallback_used": { "const": false }
       }


### PR DESCRIPTION
## Summary
- add explicit agent-facing `decision_status` to `uc support native` while keeping low-level probe `status` compatibility
- serialize `build_blocked` JSON reports for manifest-path, manifest-read, manifest-parse, and helper-probe failures instead of raw CLI exits
- update project-inspect/native-support schemas, diagnostics docs, and regression coverage for the new support decision contract

## Validation
- `cargo fmt --all`
- `cargo test -p uc-cli native_support_report_from_ -- --nocapture`
- `cargo test -p uc-cli agent_eval_decision_ -- --nocapture`
- `cargo test -p uc-cli project_inspect_ -- --nocapture`
- `make agent-validate`
- `git diff --check`
- `make local-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native support now reports four distinct decision categories: `native_supported`, `native_unsupported`, `fallback_likely`, and `build_blocked`.
  * Enhanced error handling for manifest resolution and parsing failures with new diagnostic codes (UCN1100–UCN1103).
  * Added retryable metadata to diagnostics for improved error recovery guidance.

* **Documentation**
  * Updated JSON schemas and command documentation to reflect new `decision_status` field and diagnostic specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->