### PR TITLE
uc-cli: add build --plan-only agent report

### DIFF
--- a/crates/uc-cli/src/commands.rs
+++ b/crates/uc-cli/src/commands.rs
@@ -5,6 +5,8 @@ mod compare;
 mod metadata;
 mod migrate;
 
+#[cfg(test)]
+pub(crate) use build::build_plan_report_from_args;
 pub(crate) use build::run_build;
 pub(crate) use compare::run_compare_build;
 pub(crate) use metadata::run_metadata;

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -425,6 +425,429 @@ fn load_build_report(path: &Path) -> Result<BuildReport> {
         .with_context(|| format!("failed to parse build report {}", path.display()))
 }
 
+fn build_plan_side_effect(kind: &str, description: impl Into<String>) -> BuildPlanSideEffect {
+    BuildPlanSideEffect {
+        kind: kind.to_string(),
+        description: description.into(),
+    }
+}
+
+fn build_plan_network_intent(offline: bool) -> BuildPlanNetworkIntent {
+    if offline {
+        BuildPlanNetworkIntent::Forbidden
+    } else {
+        BuildPlanNetworkIntent::Allowed
+    }
+}
+
+fn build_plan_command(args: &BuildArgs, manifest_path: &Path) -> Vec<String> {
+    let mut command = vec!["uc".to_string(), "build".to_string()];
+    command.push("--manifest-path".to_string());
+    command.push(manifest_path.display().to_string());
+    command.push("--engine".to_string());
+    command.push(args.engine.as_str().to_string());
+    command.push("--daemon-mode".to_string());
+    command.push(args.daemon_mode.as_str().to_string());
+    if args.common.offline {
+        command.push("--offline".to_string());
+    }
+    if args.common.release {
+        command.push("--release".to_string());
+    }
+    if let Some(profile) = &args.common.profile {
+        command.push("--profile".to_string());
+        command.push(profile.clone());
+    }
+    if let Some(package) = &args.common.package {
+        command.push("--package".to_string());
+        command.push(package.clone());
+    }
+    if args.common.workspace {
+        command.push("--workspace".to_string());
+    }
+    if !args.common.features.is_empty() {
+        command.push("--features".to_string());
+        command.push(args.common.features.join(","));
+    }
+    command
+}
+
+fn emit_build_plan_report(args: &BuildArgs, report: &BuildPlanReport) -> Result<()> {
+    if let Some(path) = args.report_path.as_ref() {
+        write_json_report(path, report)?;
+    }
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string(report).context("failed to serialize build plan report")?
+        );
+    } else if args.report_path.is_none() {
+        println!(
+            "status: {}",
+            match report.status {
+                BuildPlanStatus::Ready => "ready",
+                BuildPlanStatus::BuildBlocked => "build_blocked",
+            }
+        );
+        if let Some(backend) = report.planned_compile_backend.as_deref() {
+            println!("planned_compile_backend: {backend}");
+        }
+        if let Some(driver) = report.execution_driver.as_ref() {
+            println!(
+                "execution_driver: {}",
+                serde_json::to_string(driver)
+                    .context("failed to render build plan execution driver")?
+                    .trim_matches('"')
+            );
+        }
+        println!(
+            "network_intent: {}",
+            serde_json::to_string(&report.network_intent)
+                .context("failed to render build plan network intent")?
+                .trim_matches('"')
+        );
+        println!("fallback_allowed: {}", report.fallback_allowed);
+        if let Some(session_key) = report.session_key.as_deref() {
+            println!("session_key: {session_key}");
+        }
+        if let Some(reason) = report.blocked_reason.as_deref() {
+            println!("blocked_reason: {reason}");
+        }
+    }
+    Ok(())
+}
+
+fn build_plan_blocked_report(
+    args: &BuildArgs,
+    manifest_path: String,
+    workspace_root: Option<String>,
+    profile: Option<String>,
+    native_toolchain: Option<NativeToolchainReport>,
+    native_support: Option<NativeSupportReport>,
+    diagnostics: Vec<NativeDiagnostic>,
+    blocked_reason: String,
+) -> Result<BuildPlanReport> {
+    Ok(BuildPlanReport {
+        schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+        generated_at_epoch_ms: epoch_ms_u64()?,
+        status: BuildPlanStatus::BuildBlocked,
+        manifest_path: manifest_path.clone(),
+        workspace_root,
+        profile,
+        engine: args.engine.as_str().to_string(),
+        daemon_mode: args.daemon_mode.as_str().to_string(),
+        offline: args.common.offline,
+        network_intent: build_plan_network_intent(args.common.offline),
+        command: if manifest_path.is_empty() {
+            vec!["uc".to_string(), "build".to_string()]
+        } else {
+            build_plan_command(args, Path::new(&manifest_path))
+        },
+        subprocess_command: None,
+        planned_compile_backend: None,
+        execution_driver: None,
+        daemon_planned: false,
+        daemon_autostart_allowed: false,
+        fallback_allowed: false,
+        session_key: None,
+        strict_invalidation_key: None,
+        native_toolchain,
+        native_support,
+        diagnostics,
+        side_effects: Vec::new(),
+        blocked_reason: Some(blocked_reason),
+    })
+}
+
+pub(crate) fn build_plan_report_from_args(args: &BuildArgs) -> Result<BuildPlanReport> {
+    let manifest_path = match resolve_manifest_path(&args.common.manifest_path) {
+        Ok(path) => path,
+        Err(err) => {
+            let support = native_support_manifest_path_resolution_blocked_report(
+                &args.common.manifest_path,
+                &err,
+            );
+            return build_plan_blocked_report(
+                args,
+                support.manifest_path.clone(),
+                None,
+                None,
+                support.toolchain.clone(),
+                Some(support.clone()),
+                support.diagnostics.clone(),
+                support.reason.clone().unwrap_or_else(|| format!("{err:#}")),
+            );
+        }
+    };
+    let workspace_root = metadata_cache_workspace_root(&manifest_path)?;
+    let profile = effective_profile(&args.common);
+    let command = build_plan_command(args, &manifest_path);
+    let manifest_display = manifest_path.display().to_string();
+    let workspace_display = workspace_root.display().to_string();
+
+    match args.engine {
+        EngineArg::Scarb => {
+            let compiler_version = compiler_version_for_backend(BuildCompileBackend::Scarb)?;
+            let (plan, _) = prepare_daemon_build_plan_with_compiler_version(
+                &args.common,
+                &manifest_path,
+                BuildCompileBackend::Scarb,
+                &compiler_version,
+            )?;
+            let (_scarb_command, subprocess_command) =
+                scarb_build_command(&args.common, &manifest_path);
+            Ok(BuildPlanReport {
+                schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+                generated_at_epoch_ms: epoch_ms_u64()?,
+                status: BuildPlanStatus::Ready,
+                manifest_path: manifest_display,
+                workspace_root: Some(workspace_display),
+                profile: Some(profile.clone()),
+                engine: args.engine.as_str().to_string(),
+                daemon_mode: args.daemon_mode.as_str().to_string(),
+                offline: args.common.offline,
+                network_intent: build_plan_network_intent(args.common.offline),
+                command,
+                subprocess_command: Some(subprocess_command),
+                planned_compile_backend: Some("scarb".to_string()),
+                execution_driver: Some(BuildPlanExecutionDriver::ScarbDirect),
+                daemon_planned: false,
+                daemon_autostart_allowed: false,
+                fallback_allowed: false,
+                session_key: Some(plan.session_key),
+                strict_invalidation_key: Some(plan.strict_invalidation_key),
+                native_toolchain: None,
+                native_support: None,
+                diagnostics: Vec::new(),
+                side_effects: vec![
+                    build_plan_side_effect(
+                        "artifact_write",
+                        format!("Would write Scarb build artifacts under target/{profile}."),
+                    ),
+                    build_plan_side_effect(
+                        "subprocess_spawn",
+                        "Would spawn a direct `scarb build` subprocess.".to_string(),
+                    ),
+                ],
+                blocked_reason: None,
+            })
+        }
+        EngineArg::Uc => {
+            let support = native_support_report_from_manifest_path(&manifest_path)?;
+            let support_reason = support.reason.clone();
+            let diagnostics = support.diagnostics.clone();
+            let native_toolchain = support.toolchain.clone();
+            if matches!(
+                support.decision_status,
+                NativeSupportDecisionStatus::BuildBlocked
+            ) {
+                return build_plan_blocked_report(
+                    args,
+                    manifest_display,
+                    Some(workspace_display),
+                    Some(profile.clone()),
+                    native_toolchain,
+                    Some(support.clone()),
+                    diagnostics,
+                    support_reason.unwrap_or_else(|| {
+                        "build planning stopped because native support probing was blocked"
+                            .to_string()
+                    }),
+                );
+            }
+
+            let configured_native_mode = native_build_mode();
+            let disallow_native_fallback = native_disallow_scarb_fallback();
+            if matches!(configured_native_mode, NativeBuildMode::Require)
+                && !matches!(
+                    support.decision_status,
+                    NativeSupportDecisionStatus::NativeSupported
+                )
+            {
+                return build_plan_blocked_report(
+                    args,
+                    manifest_display,
+                    Some(workspace_display),
+                    Some(profile.clone()),
+                    native_toolchain,
+                    Some(support.clone()),
+                    diagnostics,
+                    support_reason.unwrap_or_else(|| {
+                        "native compile mode is require, but the manifest is not native-supported"
+                            .to_string()
+                    }),
+                );
+            }
+
+            let fallback_allowed = matches!(configured_native_mode, NativeBuildMode::Auto)
+                && !disallow_native_fallback;
+            let use_external_helper = configured_native_mode != NativeBuildMode::Off
+                && matches!(
+                    support.decision_status,
+                    NativeSupportDecisionStatus::NativeSupported
+                )
+                && native_toolchain.as_ref().is_some_and(|toolchain| {
+                    matches!(toolchain.source, NativeToolchainSource::ExternalHelper)
+                });
+            let compile_backend = if matches!(configured_native_mode, NativeBuildMode::Off)
+                || !matches!(
+                    support.decision_status,
+                    NativeSupportDecisionStatus::NativeSupported
+                ) {
+                BuildCompileBackend::Scarb
+            } else {
+                BuildCompileBackend::Native
+            };
+            let execution_driver = if use_external_helper {
+                BuildPlanExecutionDriver::ExternalHelper
+            } else if compile_backend == BuildCompileBackend::Native
+                && !matches!(args.daemon_mode, DaemonModeArg::Off)
+            {
+                BuildPlanExecutionDriver::UcDaemon
+            } else {
+                BuildPlanExecutionDriver::UcLocal
+            };
+            let daemon_planned = matches!(execution_driver, BuildPlanExecutionDriver::UcDaemon);
+            let effective_native_mode = if compile_backend == BuildCompileBackend::Native {
+                configured_native_mode
+            } else {
+                NativeBuildMode::Off
+            };
+            let daemon_autostart_allowed = daemon_planned
+                && daemon_autostart_policy(
+                    args.daemon_mode,
+                    effective_native_mode,
+                    daemon_socket_override_present_for_client(),
+                );
+            let planned_compile_backend = build_report_compile_backend_label(
+                args.engine,
+                compile_backend,
+                use_external_helper,
+                &diagnostics,
+            )
+            .to_string();
+
+            let subprocess_command =
+                if matches!(execution_driver, BuildPlanExecutionDriver::ExternalHelper) {
+                    native_toolchain
+                        .as_ref()
+                        .and_then(|toolchain| toolchain.binary_path.as_deref())
+                        .map(PathBuf::from)
+                        .map(|helper_path| {
+                            let helper_display = helper_path.display().to_string();
+                            let (_command, command_vec) = build_uc_build_command(
+                                &helper_path,
+                                &args.common,
+                                &manifest_path,
+                                EngineArg::Uc,
+                                args.daemon_mode,
+                                None,
+                                Some(&helper_display),
+                            );
+                            command_vec
+                        })
+                } else {
+                    None
+                };
+
+            let (session_key, strict_invalidation_key) =
+                if matches!(execution_driver, BuildPlanExecutionDriver::ExternalHelper) {
+                    (None, None)
+                } else {
+                    let compiler_version = compiler_version_for_backend(compile_backend)?;
+                    let (plan, _) = prepare_daemon_build_plan_with_compiler_version(
+                        &args.common,
+                        &manifest_path,
+                        compile_backend,
+                        &compiler_version,
+                    )?;
+                    (Some(plan.session_key), Some(plan.strict_invalidation_key))
+                };
+
+            let mut side_effects = vec![build_plan_side_effect(
+                "artifact_write",
+                format!("Would write build artifacts under target/{profile}."),
+            )];
+            match execution_driver {
+                BuildPlanExecutionDriver::UcLocal => {
+                    side_effects.push(build_plan_side_effect(
+                        "local_cache_write",
+                        "Would update the local uc build cache.".to_string(),
+                    ));
+                    if compile_backend == BuildCompileBackend::Scarb {
+                        side_effects.push(build_plan_side_effect(
+                            "subprocess_spawn",
+                            "Would spawn Scarb through uc's local build path.".to_string(),
+                        ));
+                    } else {
+                        side_effects.push(build_plan_side_effect(
+                            "native_session_write",
+                            "Would persist native compile session state for reuse.".to_string(),
+                        ));
+                    }
+                }
+                BuildPlanExecutionDriver::UcDaemon => {
+                    side_effects.push(build_plan_side_effect(
+                        "daemon_request",
+                        "Would send the build through the uc daemon path.".to_string(),
+                    ));
+                    side_effects.push(build_plan_side_effect(
+                        "daemon_shared_cache_write",
+                        "Would update the daemon shared cache entry for this build session."
+                            .to_string(),
+                    ));
+                    if daemon_autostart_allowed {
+                        side_effects.push(build_plan_side_effect(
+                            "daemon_autostart_attempt",
+                            "Would auto-start the daemon if the default socket is absent."
+                                .to_string(),
+                        ));
+                    }
+                }
+                BuildPlanExecutionDriver::ExternalHelper => {
+                    side_effects.push(build_plan_side_effect(
+                        "subprocess_spawn",
+                        "Would spawn the selected external helper binary.".to_string(),
+                    ));
+                }
+                BuildPlanExecutionDriver::ScarbDirect => {}
+            }
+
+            Ok(BuildPlanReport {
+                schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
+                generated_at_epoch_ms: epoch_ms_u64()?,
+                status: BuildPlanStatus::Ready,
+                manifest_path: manifest_display,
+                workspace_root: Some(workspace_display),
+                profile: Some(profile.clone()),
+                engine: args.engine.as_str().to_string(),
+                daemon_mode: args.daemon_mode.as_str().to_string(),
+                offline: args.common.offline,
+                network_intent: build_plan_network_intent(args.common.offline),
+                command,
+                subprocess_command,
+                planned_compile_backend: Some(planned_compile_backend),
+                execution_driver: Some(execution_driver),
+                daemon_planned,
+                daemon_autostart_allowed,
+                fallback_allowed,
+                session_key,
+                strict_invalidation_key,
+                native_toolchain,
+                native_support: Some(support),
+                diagnostics,
+                side_effects,
+                blocked_reason: None,
+            })
+        }
+    }
+}
+
+fn run_build_plan(args: BuildArgs) -> Result<()> {
+    let report = build_plan_report_from_args(&args)?;
+    emit_build_plan_report(&args, &report)
+}
+
 fn daemon_probe_hint_root_dir(workspace_root: &Path) -> Result<PathBuf> {
     let hint_dir = workspace_root.join(".uc/cache/probe-hints");
     ensure_path_within_root(
@@ -1176,6 +1599,9 @@ fn maybe_autostart_daemon_for_build(
 }
 
 pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
+    if args.plan_only {
+        return run_build_plan(args);
+    }
     let common = args.common;
     let emit_json = args.json;
     let report_path = args.report_path;

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -510,6 +510,16 @@ enum DaemonModeArg {
     Require,
 }
 
+impl DaemonModeArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Auto => "auto",
+            Self::Require => "require",
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum BuildCompileBackend {
     Scarb,
@@ -1056,6 +1066,9 @@ struct BuildArgs {
     #[arg(long)]
     json: bool,
 
+    #[arg(long, conflicts_with = "record_failure")]
+    plan_only: bool,
+
     #[arg(long)]
     report_path: Option<PathBuf>,
 
@@ -1360,6 +1373,66 @@ struct BuildReport {
     native_toolchain: Option<NativeToolchainReport>,
     #[serde(default)]
     diagnostics: Vec<NativeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum BuildPlanStatus {
+    Ready,
+    BuildBlocked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum BuildPlanNetworkIntent {
+    Allowed,
+    Forbidden,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum BuildPlanExecutionDriver {
+    ScarbDirect,
+    UcLocal,
+    UcDaemon,
+    ExternalHelper,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct BuildPlanSideEffect {
+    kind: String,
+    description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BuildPlanReport {
+    #[serde(default = "uc_agent_json_schema_version")]
+    schema_version: u32,
+    generated_at_epoch_ms: u64,
+    status: BuildPlanStatus,
+    manifest_path: String,
+    workspace_root: Option<String>,
+    profile: Option<String>,
+    engine: String,
+    daemon_mode: String,
+    offline: bool,
+    network_intent: BuildPlanNetworkIntent,
+    command: Vec<String>,
+    subprocess_command: Option<Vec<String>>,
+    planned_compile_backend: Option<String>,
+    execution_driver: Option<BuildPlanExecutionDriver>,
+    daemon_planned: bool,
+    daemon_autostart_allowed: bool,
+    fallback_allowed: bool,
+    session_key: Option<String>,
+    strict_invalidation_key: Option<String>,
+    native_toolchain: Option<NativeToolchainReport>,
+    native_support: Option<NativeSupportReport>,
+    #[serde(default)]
+    diagnostics: Vec<NativeDiagnostic>,
+    #[serde(default)]
+    side_effects: Vec<BuildPlanSideEffect>,
+    blocked_reason: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -411,6 +411,15 @@ fn build_cli_accepts_json_flag() {
 }
 
 #[test]
+fn build_cli_accepts_plan_only_flag() {
+    let cli = Cli::try_parse_from(["uc", "build", "--plan-only"]).expect("build args should parse");
+    let Commands::Build(args) = cli.command else {
+        panic!("expected build command");
+    };
+    assert!(args.plan_only);
+}
+
+#[test]
 fn build_cli_accepts_record_failure_path() {
     let cli = Cli::try_parse_from(["uc", "build", "--record-failure", "/tmp/uc-failure.json"])
         .expect("build args should parse");
@@ -420,6 +429,23 @@ fn build_cli_accepts_record_failure_path() {
     assert_eq!(
         args.record_failure,
         Some(PathBuf::from("/tmp/uc-failure.json"))
+    );
+}
+
+#[test]
+fn build_cli_rejects_plan_only_with_record_failure() {
+    let err = Cli::try_parse_from([
+        "uc",
+        "build",
+        "--plan-only",
+        "--record-failure",
+        "/tmp/uc-failure.json",
+    ])
+    .expect_err("conflicting plan-only and record-failure flags should fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("--plan-only") && message.contains("--record-failure"),
+        "unexpected clap error: {message}"
     );
 }
 
@@ -607,6 +633,10 @@ fn report_schemas_match_nullable_option_output() {
         "../../../docs/agent/schemas/replay-report.schema.json"
     ))
     .expect("replay report schema should parse");
+    let build_plan_schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../docs/agent/schemas/build-plan-report.schema.json"
+    ))
+    .expect("build plan report schema should parse");
     assert_eq!(
         replay_schema["properties"]["manifest_path"]["type"],
         serde_json::json!(["string", "null"])
@@ -672,6 +702,22 @@ fn report_schemas_match_nullable_option_output() {
             "{optional_field} should stay optional in safe-action schema"
         );
     }
+    assert_eq!(
+        build_plan_schema["properties"]["workspace_root"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        build_plan_schema["properties"]["planned_compile_backend"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        build_plan_schema["properties"]["session_key"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        build_plan_schema["properties"]["blocked_reason"]["type"],
+        serde_json::json!(["string", "null"])
+    );
 }
 
 #[test]
@@ -1755,6 +1801,7 @@ fn write_failure_bundle_preserves_missing_manifest_cli_path() {
         engine: EngineArg::Uc,
         daemon_mode: DaemonModeArg::Off,
         json: false,
+        plan_only: false,
         report_path: None,
         record_failure: Some(bundle_path.clone()),
     };
@@ -4106,6 +4153,177 @@ cairo-version = "{requested_major_minor}.0"
     );
 }
 
+#[test]
+fn build_plan_report_from_args_marks_missing_manifest_build_blocked() {
+    let dir = unique_test_dir("uc-build-plan-missing-manifest");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let missing_manifest = dir.join("missing").join("Scarb.toml");
+    let report = commands::build_plan_report_from_args(&BuildArgs {
+        common: BuildCommonArgs {
+            manifest_path: Some(missing_manifest.clone()),
+            package: None,
+            workspace: false,
+            features: Vec::new(),
+            offline: false,
+            release: false,
+            profile: None,
+        },
+        engine: EngineArg::Uc,
+        daemon_mode: DaemonModeArg::Off,
+        json: true,
+        plan_only: true,
+        report_path: None,
+        record_failure: None,
+    })
+    .expect("missing manifest should still produce a structured build plan report");
+    assert_eq!(report.status, BuildPlanStatus::BuildBlocked);
+    assert_eq!(report.manifest_path, missing_manifest.display().to_string());
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "UCN1100"),
+        "build plan should surface manifest resolution diagnostics: {report:#?}"
+    );
+    assert!(report.blocked_reason.is_some());
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn build_plan_report_from_args_marks_builtin_native_ready_plan() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let dir = unique_test_dir("uc-build-plan-native-ready");
+    let _cleanup = TestDirCleanup::new(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    let (compiler_major, compiler_minor) =
+        parse_cairo_version_major_minor(native_cairo_lang_compiler_version())
+            .expect("compiler version should parse");
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2024_07"
+cairo-version = "{compiler_major}.{compiler_minor}.0"
+"#
+        ),
+    )
+    .expect("write manifest");
+
+    let report = commands::build_plan_report_from_args(&BuildArgs {
+        common: BuildCommonArgs {
+            manifest_path: Some(manifest_path.clone()),
+            package: None,
+            workspace: false,
+            features: Vec::new(),
+            offline: true,
+            release: false,
+            profile: None,
+        },
+        engine: EngineArg::Uc,
+        daemon_mode: DaemonModeArg::Off,
+        json: true,
+        plan_only: true,
+        report_path: None,
+        record_failure: None,
+    })
+    .expect("supported manifest should produce a build plan");
+    assert_eq!(report.status, BuildPlanStatus::Ready);
+    assert_eq!(report.planned_compile_backend.as_deref(), Some("uc_native"));
+    assert_eq!(
+        report.execution_driver,
+        Some(BuildPlanExecutionDriver::UcLocal)
+    );
+    assert_eq!(report.network_intent, BuildPlanNetworkIntent::Forbidden);
+    assert!(report.fallback_allowed);
+    assert!(report.session_key.is_some());
+    assert!(report.strict_invalidation_key.is_some());
+    assert_eq!(
+        report
+            .native_support
+            .as_ref()
+            .map(|support| support.decision_status),
+        Some(NativeSupportDecisionStatus::NativeSupported)
+    );
+}
+
+#[cfg(feature = "native-compile")]
+#[test]
+fn build_plan_report_from_args_marks_missing_helper_as_uc_scarb_plan() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let dir = unique_test_dir("uc-build-plan-missing-helper");
+    let _cleanup = TestDirCleanup::new(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let manifest_path = dir.join("Scarb.toml");
+    let current = parse_cairo_version_major_minor(native_cairo_lang_compiler_version())
+        .expect("compiler version should parse");
+    let requested_major_minor = productized_native_toolchain_helper_lanes()
+        .into_iter()
+        .find(|lane| {
+            parse_cairo_version_major_minor(lane)
+                .is_some_and(|lane_version| lane_version != current)
+        })
+        .expect("expected a productized helper lane different from the builtin compiler");
+    let helper_env = native_toolchain_env_var_name_for_major_minor(&requested_major_minor);
+    let _helper = ScopedDynamicEnvVar::unset_with_lock(&_guard, helper_env);
+    fs::write(
+        &manifest_path,
+        format!(
+            r#"[package]
+name = "demo"
+version = "0.1.0"
+edition = "2024_07"
+cairo-version = "{requested_major_minor}.0"
+"#
+        ),
+    )
+    .expect("write manifest");
+
+    let _mode = ScopedEnvVar::set_with_lock(&_guard, "UC_NATIVE_BUILD_MODE", "auto");
+    let _disallow = ScopedEnvVar::unset_with_lock(&_guard, "UC_NATIVE_DISALLOW_SCARB_FALLBACK");
+    let report = commands::build_plan_report_from_args(&BuildArgs {
+        common: BuildCommonArgs {
+            manifest_path: Some(manifest_path),
+            package: None,
+            workspace: false,
+            features: Vec::new(),
+            offline: false,
+            release: false,
+            profile: None,
+        },
+        engine: EngineArg::Uc,
+        daemon_mode: DaemonModeArg::Off,
+        json: true,
+        plan_only: true,
+        report_path: None,
+        record_failure: None,
+    })
+    .expect("missing helper should still produce a plan");
+    assert_eq!(report.status, BuildPlanStatus::Ready);
+    assert_eq!(report.planned_compile_backend.as_deref(), Some("uc_scarb"));
+    assert_eq!(
+        report.execution_driver,
+        Some(BuildPlanExecutionDriver::UcLocal)
+    );
+    assert!(report.fallback_allowed);
+    assert_eq!(
+        report
+            .native_support
+            .as_ref()
+            .map(|support| support.decision_status),
+        Some(NativeSupportDecisionStatus::FallbackLikely)
+    );
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "UCN1004"),
+        "plan should surface the missing-helper diagnostic: {report:#?}"
+    );
+}
+
 #[cfg(feature = "native-compile")]
 #[test]
 fn productized_native_toolchain_helper_lanes_match_workspace_metadata() {
@@ -4348,6 +4566,7 @@ cairo-version = "{requested_version}"
         engine: EngineArg::Uc,
         daemon_mode: DaemonModeArg::Off,
         json: false,
+        plan_only: false,
         report_path: Some(report_path.clone()),
         record_failure: None,
     })

--- a/docs/COMMAND_SURFACE.md
+++ b/docs/COMMAND_SURFACE.md
@@ -115,8 +115,9 @@ The intended primary surface for agents is:
   - Must expose expected/found toolchain details and policy decisions.
 
 - `uc build --plan-only`
-  - Status: planned (not yet implemented)
+  - Status: implemented
   - Emits the execution plan and expected side effects without performing the build.
+  - Reports planned backend, execution driver, fallback policy, daemon posture, and session/invalidation keys when they are determinable without running the build.
 
 - `uc explain <id>`
   - Status: planned (not yet implemented)

--- a/docs/agent/AGENT_DIAGNOSTICS.md
+++ b/docs/agent/AGENT_DIAGNOSTICS.md
@@ -4,7 +4,7 @@ This document is the stable contract for machine-readable `uc` diagnostics. Huma
 
 ## Contract
 
-Every agent-facing diagnostic emitted by `uc project inspect --format json`, `uc support native --format json`, `uc build --json`, or a build report must include:
+Every agent-facing diagnostic emitted by `uc project inspect --format json`, `uc support native --format json`, `uc build --plan-only --json`, `uc build --json`, or a build report must include:
 
 - `schema_version`: integer schema version. Current version: `1`.
 - `code`: stable diagnostic code such as `UCN1004`.

--- a/docs/agent/AGENT_FIRST_COMPILER.md
+++ b/docs/agent/AGENT_FIRST_COMPILER.md
@@ -30,6 +30,7 @@ Already in this PR or required before launch:
 
 - `uc support native --format json` emits stable support reports.
 - `uc build --json` and `--report-path` carry build diagnostics.
+- `uc build --plan-only --json` emits the chosen execution path before side effects begin.
 - `uc build --record-failure <path>` writes a redacted, replay-safe failure bundle on build errors.
 - `uc replay <bundle>` reads that bundle and is dry-run by default.
 - `uc agent eval --manifest-path <Scarb.toml>` returns a decision agents can act on before compiling.
@@ -115,11 +116,12 @@ Agents should start with support probing, not build-and-guess:
 ```sh
 uc project inspect --manifest-path Scarb.toml --format json
 uc support native --manifest-path Scarb.toml --format json
+uc build --engine uc --daemon-mode off --manifest-path Scarb.toml --plan-only --json
 uc agent eval --manifest-path Scarb.toml
 ./scripts/doctor.sh --uc-bin ./target/release/uc --manifest-path /abs/path/to/Scarb.toml
 ```
 
-Agents should treat `uc project inspect`, `uc support native`, and `uc agent eval` as the stable pre-build surfaces.
+Agents should treat `uc project inspect`, `uc support native`, `uc build --plan-only`, and `uc agent eval` as the stable pre-build surfaces.
 
 If the diagnostic says `safe_automated_action=build_helper_lane`, the agent may run:
 

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -45,6 +45,29 @@ Read:
 - `.diagnostics[].next_commands`
 - `.diagnostics[].safe_automated_action`
 
+## Build Plan
+
+```sh
+uc build --engine uc --daemon-mode off --manifest-path /abs/path/to/Scarb.toml --plan-only --json
+```
+
+Read:
+
+- `.status`
+- `.planned_compile_backend`
+- `.execution_driver`
+- `.fallback_allowed`
+- `.daemon_planned`
+- `.daemon_autostart_allowed`
+- `.session_key`
+- `.strict_invalidation_key`
+- `.side_effects[].kind`
+- `.native_support.decision_status`
+- `.diagnostics[].code`
+
+If `.status == "build_blocked"`, stop before execution and fix the reported input or
+toolchain problem. Do not infer build readiness from terminal text alone.
+
 ## Doctor Probe
 
 ```sh

--- a/docs/agent/HUMAN_QUICKSTART.md
+++ b/docs/agent/HUMAN_QUICKSTART.md
@@ -24,6 +24,12 @@ uc support native --manifest-path Scarb.toml --format json | jq
 uc build --engine uc --daemon-mode off --manifest-path Scarb.toml
 ```
 
+## Inspect The Build Plan First
+
+```sh
+uc build --engine uc --daemon-mode off --manifest-path Scarb.toml --plan-only --json | jq
+```
+
 ## Write A Build Report
 
 ```sh

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -14,7 +14,7 @@ This directory is the checked-in handoff layer for humans, coding agents, and PR
 - `HUMAN_QUICKSTART.md`: human-oriented command sequence for the same support/build surfaces.
 - `../PROJECT_MODEL_STRATEGY.md`: first-party project model direction and parity gates.
 - `../research/AGENT_FIRST_PACKAGE_MANAGER_RESEARCH_2026-04-28.md`: modern package-manager and agent-first control-plane research that sets the next product boundary.
-- `schemas/`: JSON schemas for diagnostic, project inspect, support, and build report outputs.
+- `schemas/`: JSON schemas for diagnostic, project inspect, support, build-plan, and build report outputs.
 
 ## Why This Exists
 

--- a/docs/agent/schemas/build-plan-report.schema.json
+++ b/docs/agent/schemas/build-plan-report.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/omarespejel/uc/docs/agent/schemas/build-plan-report.schema.json",
+  "title": "uc BuildPlanReport",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "generated_at_epoch_ms",
+    "status",
+    "manifest_path",
+    "workspace_root",
+    "profile",
+    "engine",
+    "daemon_mode",
+    "offline",
+    "network_intent",
+    "command",
+    "subprocess_command",
+    "planned_compile_backend",
+    "execution_driver",
+    "daemon_planned",
+    "daemon_autostart_allowed",
+    "fallback_allowed",
+    "session_key",
+    "strict_invalidation_key",
+    "native_toolchain",
+    "native_support",
+    "diagnostics",
+    "side_effects",
+    "blocked_reason"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "generated_at_epoch_ms": { "type": "integer" },
+    "status": { "enum": ["ready", "build_blocked"] },
+    "manifest_path": { "type": "string" },
+    "workspace_root": { "type": ["string", "null"] },
+    "profile": { "type": ["string", "null"] },
+    "engine": { "type": "string" },
+    "daemon_mode": { "type": "string" },
+    "offline": { "type": "boolean" },
+    "network_intent": { "enum": ["allowed", "forbidden"] },
+    "command": { "type": "array", "items": { "type": "string" } },
+    "subprocess_command": {
+      "type": ["array", "null"],
+      "items": { "type": "string" }
+    },
+    "planned_compile_backend": { "type": ["string", "null"] },
+    "execution_driver": {
+      "type": ["string", "null"],
+      "enum": ["scarb_direct", "uc_local", "uc_daemon", "external_helper", null]
+    },
+    "daemon_planned": { "type": "boolean" },
+    "daemon_autostart_allowed": { "type": "boolean" },
+    "fallback_allowed": { "type": "boolean" },
+    "session_key": { "type": ["string", "null"] },
+    "strict_invalidation_key": { "type": ["string", "null"] },
+    "native_toolchain": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "object" }
+      ]
+    },
+    "native_support": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "native-support-report.schema.json" }
+      ]
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "native-diagnostic.schema.json" }
+    },
+    "side_effects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "description"],
+        "properties": {
+          "kind": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "blocked_reason": { "type": ["string", "null"] }
+  }
+}


### PR DESCRIPTION
## Summary
- add `uc build --plan-only` as a read-only agent-facing build planning surface
- emit a structured build plan report with backend selection, execution driver, fallback policy, daemon posture, session keys, and planned side effects
- add CLI/tests/schema/docs coverage for the new build-plan contract

## Validation
- `cargo fmt --all`
- `cargo test -p uc-cli build_plan_report_from_args_ -- --nocapture`
- `cargo test -p uc-cli build_cli_accepts_plan_only_flag -- --nocapture`
- `cargo test -p uc-cli build_cli_rejects_plan_only_with_record_failure -- --nocapture`
- `cargo test -p uc-cli report_schemas_match_nullable_option_output -- --nocapture`
- `make agent-validate`
- `git diff --check`
- `make local-ci`
- manual CLI smoke: `cargo run -p uc-cli -- build --engine uc --daemon-mode off --plan-only --json --manifest-path <temp>/Scarb.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--plan-only` flag to `uc build` command to preview build execution without actually running it.
  * Build plans now report compilation backend, execution driver, network configuration, daemon settings, session keys, and detected issues.
  * Plan output supports JSON format with `--json` flag for programmatic parsing.

* **Documentation**
  * Updated guides with new build planning workflow and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->