### PR TITLE
Harden fetch and source-store agent contracts

### DIFF
--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -54,6 +54,9 @@ It must let agents:
 - Read-only project inspection: `uc project inspect --manifest-path /abs/path/to/Scarb.toml --format json`
 - Agent support decision: `uc support native --manifest-path /abs/path/to/Scarb.toml --format json`
 - Locked resolve report: `uc resolve --locked --manifest-path /abs/path/to/Scarb.toml --format json`
+- Locked fetch report: `uc fetch --locked --manifest-path /abs/path/to/Scarb.toml --format json`
+- Source-store inventory: `uc cache status --format json`
+- Source-store prune: `uc cache prune --format json`
 - Explicit toolchain ensure: `uc toolchain ensure --manifest-path /abs/path/to/Scarb.toml --format json`
 - Dry-run safe remediation: `uc agent safe-action build-helper-lane --lane 2.14`
 - Replayable build failure capture: `uc build --engine uc --daemon-mode off --manifest-path /abs/path/to/Scarb.toml --record-failure /abs/path/to/uc-failure.json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ Do not treat it as a human-only CLI wrapper around Scarb.
 - Read-only project inspection: `uc project inspect --manifest-path /abs/path/to/Scarb.toml --format json`
 - Agent support decision: `uc support native --manifest-path /abs/path/to/Scarb.toml --format json`
 - Locked resolve report: `uc resolve --locked --manifest-path /abs/path/to/Scarb.toml --format json`
+- Locked fetch report: `uc fetch --locked --manifest-path /abs/path/to/Scarb.toml --format json`
+- Source-store inventory: `uc cache status --format json`
+- Source-store prune: `uc cache prune --format json`
 - Explicit toolchain ensure: `uc toolchain ensure --manifest-path /abs/path/to/Scarb.toml --format json`
 - Dry-run safe remediation: `uc agent safe-action build-helper-lane --lane 2.14`
 - Record replayable build failure: `uc build --engine uc --daemon-mode off --manifest-path /abs/path/to/Scarb.toml --record-failure /abs/path/to/uc-failure.json`

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -6863,8 +6863,8 @@ fn run_mcp(args: McpArgs) -> Result<()> {
     }
 }
 
-fn run_mcp_serve(args: McpServeArgs) -> Result<()> {
-    let report = McpCatalogReport {
+fn mcp_catalog_report() -> Result<McpCatalogReport> {
+    Ok(McpCatalogReport {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         generated_at_epoch_ms: epoch_ms_u64()?,
         readonly: true,
@@ -6951,6 +6951,37 @@ fn run_mcp_serve(args: McpServeArgs) -> Result<()> {
                 schema: "docs/agent/schemas/fetch-report.schema.json".to_string(),
             },
             McpToolDescriptor {
+                name: "uc.cache_status".to_string(),
+                description:
+                    "Inspect the shared uc source-store inventory and budget state.".to_string(),
+                command: vec![
+                    "uc".to_string(),
+                    "cache".to_string(),
+                    "status".to_string(),
+                    "--format".to_string(),
+                    "json".to_string(),
+                ],
+                mutates_state: false,
+                schema: "docs/agent/schemas/source-store-status-report.schema.json"
+                    .to_string(),
+            },
+            McpToolDescriptor {
+                name: "uc.cache_prune".to_string(),
+                description:
+                    "Prune the shared uc source store back under the configured byte budget."
+                        .to_string(),
+                command: vec![
+                    "uc".to_string(),
+                    "cache".to_string(),
+                    "prune".to_string(),
+                    "--format".to_string(),
+                    "json".to_string(),
+                ],
+                mutates_state: true,
+                schema: "docs/agent/schemas/source-store-prune-report.schema.json"
+                    .to_string(),
+            },
+            McpToolDescriptor {
                 name: "uc.toolchain_ensure".to_string(),
                 description: "Ensure the selected Cairo/helper lane exists locally before build.".to_string(),
                 command: vec![
@@ -7012,7 +7043,11 @@ fn run_mcp_serve(args: McpServeArgs) -> Result<()> {
                 schema: "AGENTS.md".to_string(),
             },
         ],
-    };
+    })
+}
+
+fn run_mcp_serve(args: McpServeArgs) -> Result<()> {
+    let report = mcp_catalog_report()?;
     emit_json_value(args.report_path.as_deref(), &report)
 }
 

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -1074,6 +1074,8 @@ struct SourceStoreStatusReport {
     #[serde(default = "uc_agent_json_schema_version")]
     schema_version: u32,
     generated_at_epoch_ms: u64,
+    readonly: bool,
+    mutation_status: String,
     root: Option<String>,
     available: bool,
     writable: bool,
@@ -1084,6 +1086,12 @@ struct SourceStoreStatusReport {
     what_happened: String,
     why: String,
     retryable: bool,
+    expected: Option<String>,
+    found: Option<String>,
+    fallback_used: bool,
+    replay_command: String,
+    artifact_path: Option<String>,
+    log_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1091,6 +1099,8 @@ struct SourceStorePruneReport {
     #[serde(default = "uc_agent_json_schema_version")]
     schema_version: u32,
     generated_at_epoch_ms: u64,
+    readonly: bool,
+    mutation_status: String,
     root: Option<String>,
     available: bool,
     writable: bool,
@@ -1105,6 +1115,12 @@ struct SourceStorePruneReport {
     what_happened: String,
     why: String,
     retryable: bool,
+    expected: Option<String>,
+    found: Option<String>,
+    fallback_used: bool,
+    replay_command: String,
+    artifact_path: Option<String>,
+    log_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -5861,6 +5877,8 @@ fn source_store_status_report() -> Result<SourceStoreStatusReport> {
         return Ok(SourceStoreStatusReport {
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             generated_at_epoch_ms: epoch_ms_u64().unwrap_or(0),
+            readonly: true,
+            mutation_status: "none".to_string(),
             root: None,
             available: false,
             writable: false,
@@ -5871,6 +5889,12 @@ fn source_store_status_report() -> Result<SourceStoreStatusReport> {
             what_happened: "uc source store root is not configured.".to_string(),
             why: "HOME and UC_SOURCE_STORE_DIR were both unavailable.".to_string(),
             retryable: false,
+            expected: Some("a configured uc source-store root".to_string()),
+            found: Some("no HOME or UC_SOURCE_STORE_DIR value".to_string()),
+            fallback_used: false,
+            replay_command: "uc cache status --format json".to_string(),
+            artifact_path: None,
+            log_path: None,
         });
     };
     let _lock = acquire_cache_lock(&root)?;
@@ -5878,6 +5902,8 @@ fn source_store_status_report() -> Result<SourceStoreStatusReport> {
     Ok(SourceStoreStatusReport {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         generated_at_epoch_ms: epoch_ms_u64()?,
+        readonly: true,
+        mutation_status: "none".to_string(),
         root: Some(root.display().to_string()),
         available: scan.available,
         writable: scan.writable,
@@ -5891,6 +5917,15 @@ fn source_store_status_report() -> Result<SourceStoreStatusReport> {
         ),
         why: "The source store keeps fetched registry and git package roots available for later locked offline work.".to_string(),
         retryable: true,
+        expected: Some("source-store inventory with a known byte budget".to_string()),
+        found: Some(format!(
+            "entry_count={}, total_bytes={}, invalid_entry_count={}",
+            scan.entry_count, scan.total_bytes, scan.invalid_entry_count
+        )),
+        fallback_used: false,
+        replay_command: "uc cache status --format json".to_string(),
+        artifact_path: None,
+        log_path: None,
     })
 }
 
@@ -5899,6 +5934,8 @@ fn source_store_prune_report(max_bytes_override: Option<u64>) -> Result<SourceSt
         return Ok(SourceStorePruneReport {
             schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
             generated_at_epoch_ms: epoch_ms_u64().unwrap_or(0),
+            readonly: false,
+            mutation_status: "none".to_string(),
             root: None,
             available: false,
             writable: false,
@@ -5915,6 +5952,15 @@ fn source_store_prune_report(max_bytes_override: Option<u64>) -> Result<SourceSt
                     .to_string(),
             why: "HOME and UC_SOURCE_STORE_DIR were both unavailable.".to_string(),
             retryable: false,
+            expected: Some("a configured uc source-store root before pruning".to_string()),
+            found: Some("no HOME or UC_SOURCE_STORE_DIR value".to_string()),
+            fallback_used: false,
+            replay_command: match max_bytes_override {
+                Some(max_bytes) => format!("uc cache prune --format json --max-bytes {max_bytes}"),
+                None => "uc cache prune --format json".to_string(),
+            },
+            artifact_path: None,
+            log_path: None,
         });
     };
     fs::create_dir_all(source_store_entries_root(&root))
@@ -5942,6 +5988,12 @@ fn source_store_prune_report(max_bytes_override: Option<u64>) -> Result<SourceSt
     Ok(SourceStorePruneReport {
         schema_version: UC_AGENT_JSON_SCHEMA_VERSION,
         generated_at_epoch_ms: epoch_ms_u64()?,
+        readonly: false,
+        mutation_status: if removed_keys.is_empty() {
+            "none".to_string()
+        } else {
+            "source_store_pruned".to_string()
+        },
         root: Some(root.display().to_string()),
         available: true,
         writable: true,
@@ -5960,6 +6012,18 @@ fn source_store_prune_report(max_bytes_override: Option<u64>) -> Result<SourceSt
         ),
         why: "The source store is shared across workspaces and needs bounded size for deterministic local operation.".to_string(),
         retryable: true,
+        expected: Some(format!("source-store total bytes at or below {max_bytes}")),
+        found: Some(format!(
+            "entry_count_before={}, entry_count_after={}, total_bytes_before={}, total_bytes_after={}, removed_bytes={}",
+            before.entry_count, entry_count_after, before.total_bytes, total_after, removed_bytes
+        )),
+        fallback_used: false,
+        replay_command: match max_bytes_override {
+            Some(max_bytes) => format!("uc cache prune --format json --max-bytes {max_bytes}"),
+            None => "uc cache prune --format json".to_string(),
+        },
+        artifact_path: None,
+        log_path: None,
     })
 }
 

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -574,6 +574,26 @@ fn mcp_catalog_report_includes_source_store_tools() {
             .any(|resource| resource.uri == "uc://source-store/status"),
         "mcp catalog should keep the source-store status resource"
     );
+    let cache_status = report
+        .tools
+        .iter()
+        .find(|tool| tool.name == "uc.cache_status")
+        .expect("mcp catalog should expose cache_status descriptor");
+    assert!(!cache_status.mutates_state);
+    assert_eq!(
+        cache_status.schema,
+        "docs/agent/schemas/source-store-status-report.schema.json"
+    );
+    let cache_prune = report
+        .tools
+        .iter()
+        .find(|tool| tool.name == "uc.cache_prune")
+        .expect("mcp catalog should expose cache_prune descriptor");
+    assert!(cache_prune.mutates_state);
+    assert_eq!(
+        cache_prune.schema,
+        "docs/agent/schemas/source-store-prune-report.schema.json"
+    );
 }
 
 #[test]
@@ -974,11 +994,43 @@ fn report_schemas_match_nullable_option_output() {
         serde_json::json!(["string", "null"])
     );
     assert_eq!(
+        cache_status_schema["properties"]["expected"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_status_schema["properties"]["found"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_status_schema["properties"]["artifact_path"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_status_schema["properties"]["log_path"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
         cache_status_schema["additionalProperties"],
         serde_json::json!(false)
     );
     assert_eq!(
         cache_prune_schema["properties"]["root"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_prune_schema["properties"]["expected"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_prune_schema["properties"]["found"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_prune_schema["properties"]["artifact_path"]["type"],
+        serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_prune_schema["properties"]["log_path"]["type"],
         serde_json::json!(["string", "null"])
     );
     assert_eq!(

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -552,6 +552,31 @@ fn mcp_serve_cli_accepts_report_path() {
 }
 
 #[test]
+fn mcp_catalog_report_includes_source_store_tools() {
+    let report = mcp_catalog_report().expect("mcp catalog should build");
+    let tool_names = report
+        .tools
+        .iter()
+        .map(|tool| tool.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        tool_names.contains(&"uc.cache_status"),
+        "mcp catalog should expose source-store status"
+    );
+    assert!(
+        tool_names.contains(&"uc.cache_prune"),
+        "mcp catalog should expose source-store prune"
+    );
+    assert!(
+        report
+            .resources
+            .iter()
+            .any(|resource| resource.uri == "uc://source-store/status"),
+        "mcp catalog should keep the source-store status resource"
+    );
+}
+
+#[test]
 fn project_inspect_cli_accepts_json_format_and_report_path() {
     let cli = Cli::try_parse_from([
         "uc",
@@ -933,12 +958,32 @@ fn report_schemas_match_nullable_option_output() {
         serde_json::json!(["string", "null"])
     );
     assert_eq!(
+        fetch_schema["additionalProperties"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        fetch_schema["properties"]["source_store"]["additionalProperties"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        fetch_schema["$defs"]["fetchEntry"]["additionalProperties"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
         cache_status_schema["properties"]["root"]["type"],
         serde_json::json!(["string", "null"])
     );
     assert_eq!(
+        cache_status_schema["additionalProperties"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
         cache_prune_schema["properties"]["root"]["type"],
         serde_json::json!(["string", "null"])
+    );
+    assert_eq!(
+        cache_prune_schema["additionalProperties"],
+        serde_json::json!(false)
     );
 }
 

--- a/docs/COMMAND_SURFACE.md
+++ b/docs/COMMAND_SURFACE.md
@@ -84,11 +84,30 @@
   - top-level `status` (`ready` or `build_blocked`)
   - top-level `blocked_reason` (`null` when fully hydrated; otherwise the authoritative blocked cause)
   - `network_intent` (`allowed` online, `forbidden` offline)
-  - `execution_driver` (`scarb_direct` in the current implementation)
+  - `execution_driver` (`uc_local` for local no-op hydration; otherwise `scarb_direct` when Scarb performed fetch or offline metadata replay)
   - `source_store` summary
   - `fetched_entries` and `missing_entries`
   - `offline_readiness_before` and `offline_readiness_after`
 - `uc fetch` currently requires `--locked`; there is no implicit mutable resolution mode yet.
+
+1. `uc cache status`
+- Reads the current shared source-store inventory.
+- Supports: `--format json`, `--json`, `--report-path`.
+- Emits:
+  - source-store root
+  - availability / writability
+  - entry counts and total bytes
+  - invalid entry count
+  - configured byte budget
+
+1. `uc cache prune`
+- Prunes the shared source store to the configured byte budget.
+- Supports: `--max-bytes`, `--format json`, `--json`, `--report-path`.
+- Emits:
+  - pre/post entry counts
+  - pre/post byte totals
+  - removed entry count and keys
+  - configured byte budget used for pruning
 
 1. `uc toolchain ensure`
 - Ensures the native Cairo/helper lane selected from the manifest is locally available.
@@ -130,8 +149,8 @@
 
 1. `uc mcp serve`
 - Emits the read-only MCP command/resource catalog as JSON.
-- Covers `doctor`, `project_inspect`, `support_native`, `toolchain_ensure`, `explain_diagnostic`, `select_toolchain`, `benchmark_report`, and `profile_native_frontend`.
-- This is intentionally read-only: mutable actions stay behind `uc agent safe-action --execute`.
+- Covers `doctor`, `project_inspect`, `support_native`, `explain_diagnostic`, `select_toolchain`, `fetch`, `cache_status`, `cache_prune`, `toolchain_ensure`, `benchmark_report`, and `profile_native_frontend`.
+- The catalog itself is read-only; adapters must honor each tool's `mutates_state` flag before executing mutable surfaces such as `fetch`, `cache prune`, or `toolchain ensure`.
 
 1. `uc daemon`
 - `start`: launches local background daemon (`~/.uc/daemon/uc.sock` by default).
@@ -160,6 +179,14 @@ The intended primary surface for agents is:
   - Status: implemented for `--locked`
   - Explicit source acquisition into the shared store.
   - Reports what was materialized, what was reused, and what is still missing.
+
+- `uc cache status`
+  - Status: implemented
+  - Read-only inventory of the shared source store.
+
+- `uc cache prune`
+  - Status: implemented
+  - Explicit source-store budget enforcement.
 
 - `uc toolchain ensure`
   - Status: implemented

--- a/docs/COMMAND_SURFACE.md
+++ b/docs/COMMAND_SURFACE.md
@@ -94,20 +94,34 @@
 - Reads the current shared source-store inventory.
 - Supports: `--format json`, `--json`, `--report-path`.
 - Emits:
+  - `schema_version`
+  - `generated_at_epoch_ms`
+  - `readonly`
+  - `mutation_status`
   - source-store root
   - availability / writability
   - entry counts and total bytes
   - invalid entry count
   - configured byte budget
+  - `what_happened`, `why`, and `retryable`
+  - `expected`, `found`, `fallback_used`, `replay_command`, `artifact_path`, `log_path`
 
 1. `uc cache prune`
 - Prunes the shared source store to the configured byte budget.
 - Supports: `--max-bytes`, `--format json`, `--json`, `--report-path`.
 - Emits:
+  - `schema_version`
+  - `generated_at_epoch_ms`
+  - `readonly`
+  - `mutation_status`
+  - source-store root
+  - availability / writability
+  - configured byte budget used for pruning
   - pre/post entry counts
   - pre/post byte totals
-  - removed entry count and keys
-  - configured byte budget used for pruning
+  - removed entry count, bytes, and keys
+  - `what_happened`, `why`, and `retryable`
+  - `expected`, `found`, `fallback_used`, `replay_command`, `artifact_path`, `log_path`
 
 1. `uc toolchain ensure`
 - Ensures the native Cairo/helper lane selected from the manifest is locally available.
@@ -149,7 +163,7 @@
 
 1. `uc mcp serve`
 - Emits the read-only MCP command/resource catalog as JSON.
-- Covers `doctor`, `project_inspect`, `support_native`, `explain_diagnostic`, `select_toolchain`, `fetch`, `cache_status`, `cache_prune`, `toolchain_ensure`, `benchmark_report`, and `profile_native_frontend`.
+- Covers `uc.doctor`, `uc.project_inspect`, `uc.support_native`, `uc.explain_diagnostic`, `uc.select_toolchain`, `uc.fetch`, `uc.cache_status`, `uc.cache_prune`, `uc.toolchain_ensure`, `uc.benchmark_report`, and `uc.profile_native_frontend`.
 - The catalog itself is read-only; adapters must honor each tool's `mutates_state` flag before executing mutable surfaces such as `fetch`, `cache prune`, or `toolchain ensure`.
 
 1. `uc daemon`

--- a/docs/agent/AGENT_FIRST_COMPILER.md
+++ b/docs/agent/AGENT_FIRST_COMPILER.md
@@ -31,6 +31,8 @@ Already in this PR or required before launch:
 - `uc support native --format json` emits stable support reports.
 - `uc build --json` and `--report-path` carry build diagnostics.
 - `uc build --plan-only --json` emits the chosen execution path before side effects begin.
+- `uc fetch --locked --format json` hydrates locked package roots into the shared `uc` source store with explicit driver and offline-readiness reporting.
+- `uc cache status --format json` and `uc cache prune --format json` expose the source-store inventory and budget lifecycle directly to agents.
 - `uc toolchain ensure --format json` explicitly ensures the selected builtin/helper lane before build time.
 - `uc build --record-failure <path>` writes a redacted, replay-safe failure bundle on build errors.
 - `uc replay <bundle>` reads that bundle and is dry-run by default.
@@ -56,8 +58,8 @@ Already in this PR or required before launch:
    - Add bundle schema validation in the replay path.
 
 2. `uc-mcp-stdio`
-   - Wrap the read-only catalog in a real stdio MCP JSON-RPC server.
-   - Keep mutable actions out of MCP until permission gates are explicit.
+   - Wrap the catalog in a real stdio MCP JSON-RPC server.
+   - Preserve `mutates_state` signaling so adapters can gate mutable actions explicitly.
 
 3. `agent-eval-fixtures`
    - Check in fixture manifests for missing helper lanes, unsupported manifests, fallback activation, stale cache, and benchmark unsupported cases.
@@ -77,9 +79,12 @@ Already in this PR or required before launch:
 
 ## MCP Shape
 
-Read-only MCP tools should eventually expose:
+MCP tools should eventually expose:
 
 - `uc.doctor`
+- `uc.fetch`
+- `uc.cache_status`
+- `uc.cache_prune`
 - `uc.support_native`
 - `uc.explain_diagnostic`
 - `uc.select_toolchain`
@@ -92,6 +97,7 @@ MCP resources should expose:
 - `uc://support/native-matrix/latest`
 - `uc://benchmarks/latest`
 - `uc://toolchains/native`
+- `uc://source-store/status`
 - `uc://repo/policy`
 
 ## Human Workflow

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -102,7 +102,7 @@ uc cache status --format json
 uc cache prune --format json
 ```
 
-Read:
+Read from `uc cache status`:
 
 - `.root`
 - `.available`
@@ -111,6 +111,15 @@ Read:
 - `.total_bytes`
 - `.max_bytes`
 - `.invalid_entry_count`
+
+Read from `uc cache prune`:
+
+- `.entry_count_before`
+- `.entry_count_after`
+- `.total_bytes_before`
+- `.total_bytes_after`
+- `.removed_entry_count`
+- `.removed_bytes`
 
 Use `uc cache status` before forcing offline fetch/build flows. Use
 `uc cache prune` only as an explicit maintenance step; do not assume pruning is

--- a/docs/agent/AGENT_QUICKSTART.md
+++ b/docs/agent/AGENT_QUICKSTART.md
@@ -95,6 +95,27 @@ state first. Use `.missing_entries` and `.source_store` directly instead of
 guessing from terminal output whether the local dependency graph is actually
 hydrated.
 
+## Source Store Inventory
+
+```sh
+uc cache status --format json
+uc cache prune --format json
+```
+
+Read:
+
+- `.root`
+- `.available`
+- `.writable`
+- `.entry_count`
+- `.total_bytes`
+- `.max_bytes`
+- `.invalid_entry_count`
+
+Use `uc cache status` before forcing offline fetch/build flows. Use
+`uc cache prune` only as an explicit maintenance step; do not assume pruning is
+safe in the middle of a benchmark or active build investigation.
+
 ## Toolchain Ensure
 
 ```sh

--- a/docs/agent/HUMAN_QUICKSTART.md
+++ b/docs/agent/HUMAN_QUICKSTART.md
@@ -29,6 +29,11 @@ uc resolve --locked --manifest-path Scarb.toml --format json | jq
 ```sh
 uc fetch --locked --manifest-path Scarb.toml --format json | jq
 uc cache status --format json | jq
+```
+
+## Optional Cache Maintenance
+
+```sh
 uc cache prune --format json | jq
 ```
 

--- a/docs/agent/HUMAN_QUICKSTART.md
+++ b/docs/agent/HUMAN_QUICKSTART.md
@@ -29,6 +29,7 @@ uc resolve --locked --manifest-path Scarb.toml --format json | jq
 ```sh
 uc fetch --locked --manifest-path Scarb.toml --format json | jq
 uc cache status --format json | jq
+uc cache prune --format json | jq
 ```
 
 ## Ensure Native Toolchain

--- a/docs/agent/schemas/fetch-report.schema.json
+++ b/docs/agent/schemas/fetch-report.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/omarespejel/uc/docs/agent/schemas/fetch-report.schema.json",
   "title": "uc FetchReport",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": [
     "schema_version",
     "generated_at_epoch_ms",
@@ -62,6 +62,7 @@
     "toolchain": { "type": "object" },
     "source_store": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "root",
         "available",
@@ -118,6 +119,7 @@
   "$defs": {
     "fetchEntry": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "name",
         "version",

--- a/docs/agent/schemas/source-store-prune-report.schema.json
+++ b/docs/agent/schemas/source-store-prune-report.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/omarespejel/uc/docs/agent/schemas/source-store-prune-report.schema.json",
   "title": "uc SourceStorePruneReport",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": [
     "schema_version",
     "generated_at_epoch_ms",

--- a/docs/agent/schemas/source-store-prune-report.schema.json
+++ b/docs/agent/schemas/source-store-prune-report.schema.json
@@ -7,6 +7,8 @@
   "required": [
     "schema_version",
     "generated_at_epoch_ms",
+    "readonly",
+    "mutation_status",
     "root",
     "available",
     "writable",
@@ -20,11 +22,19 @@
     "removed_keys",
     "what_happened",
     "why",
-    "retryable"
+    "retryable",
+    "expected",
+    "found",
+    "fallback_used",
+    "replay_command",
+    "artifact_path",
+    "log_path"
   ],
   "properties": {
     "schema_version": { "const": 1 },
     "generated_at_epoch_ms": { "type": "integer" },
+    "readonly": { "type": "boolean" },
+    "mutation_status": { "type": "string" },
     "root": { "type": ["string", "null"] },
     "available": { "type": "boolean" },
     "writable": { "type": "boolean" },
@@ -41,6 +51,12 @@
     },
     "what_happened": { "type": "string" },
     "why": { "type": "string" },
-    "retryable": { "type": "boolean" }
+    "retryable": { "type": "boolean" },
+    "expected": { "type": ["string", "null"] },
+    "found": { "type": ["string", "null"] },
+    "fallback_used": { "type": "boolean" },
+    "replay_command": { "type": "string" },
+    "artifact_path": { "type": ["string", "null"] },
+    "log_path": { "type": ["string", "null"] }
   }
 }

--- a/docs/agent/schemas/source-store-status-report.schema.json
+++ b/docs/agent/schemas/source-store-status-report.schema.json
@@ -7,6 +7,8 @@
   "required": [
     "schema_version",
     "generated_at_epoch_ms",
+    "readonly",
+    "mutation_status",
     "root",
     "available",
     "writable",
@@ -16,11 +18,19 @@
     "invalid_entry_count",
     "what_happened",
     "why",
-    "retryable"
+    "retryable",
+    "expected",
+    "found",
+    "fallback_used",
+    "replay_command",
+    "artifact_path",
+    "log_path"
   ],
   "properties": {
     "schema_version": { "const": 1 },
     "generated_at_epoch_ms": { "type": "integer" },
+    "readonly": { "type": "boolean" },
+    "mutation_status": { "type": "string" },
     "root": { "type": ["string", "null"] },
     "available": { "type": "boolean" },
     "writable": { "type": "boolean" },
@@ -30,6 +40,12 @@
     "invalid_entry_count": { "type": "integer" },
     "what_happened": { "type": "string" },
     "why": { "type": "string" },
-    "retryable": { "type": "boolean" }
+    "retryable": { "type": "boolean" },
+    "expected": { "type": ["string", "null"] },
+    "found": { "type": ["string", "null"] },
+    "fallback_used": { "type": "boolean" },
+    "replay_command": { "type": "string" },
+    "artifact_path": { "type": ["string", "null"] },
+    "log_path": { "type": ["string", "null"] }
   }
 }

--- a/docs/agent/schemas/source-store-status-report.schema.json
+++ b/docs/agent/schemas/source-store-status-report.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/omarespejel/uc/docs/agent/schemas/source-store-status-report.schema.json",
   "title": "uc SourceStoreStatusReport",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": [
     "schema_version",
     "generated_at_epoch_ms",


### PR DESCRIPTION
## Summary
- harden the fetch and source-store JSON schemas for agent-facing stability
- expose `uc.cache_status` and `uc.cache_prune` in the MCP catalog
- align docs and quickstarts with the actual fetch/source-store contract

## Validation
- `cargo fmt --all`
- `cargo test -p uc-cli mcp_catalog_report_includes_source_store_tools -- --nocapture`
- `cargo test -p uc-cli report_schemas_match_nullable_option_output -- --nocapture`
- `make agent-map`
- `make agent-validate`
- `git diff --check`
- `make local-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `uc cache status` command to inspect source store inventory and metrics.
  * Added `uc cache prune` command for budget-based cache maintenance.
  * Expanded MCP catalog with new cache management tools.

* **Documentation**
  * Updated command surface and agent integration guides with new cache commands and MCP tool coverage.

* **Improvements**
  * Strengthened JSON schema validation with stricter field constraints across catalog schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->