### PR TITLE
Document native performance frontier findings

### DIFF
--- a/docs/research/NATIVE_ESTIMATE_CALLSITE_SPLIT_2026-04-29.md
+++ b/docs/research/NATIVE_ESTIMATE_CALLSITE_SPLIT_2026-04-29.md
@@ -1,0 +1,102 @@
+# Native Estimate Callsite Split (2026-04-29)
+
+## Goal
+
+Determine how much of Cairo `2.14` exact size-estimation traffic is driven by inline decisions, instead of treating all `estimate_size` activity as one undifferentiated hotspot.
+
+## Patch Shape
+
+Local helper-lane instrumentation only:
+
+- existing bounded `estimate_size` / `dummy_program_for_size_estimation` trace remained in place
+- added one new inline caller event:
+  - `estimate_size_callsite:inline_should_inline`
+- attempted specialization caller instrumentation too, but dropped it for this pass after the patch landed incorrectly in the helper lane and did not justify more time before the next product slice
+
+The helper patch remained local to the Cairo `2.14` helper lane staging tree.
+
+## Validation
+
+Helper-lane check passed with the inline-only instrumentation patch:
+
+```bash
+./scripts/build_native_toolchain_helper.sh --lane 2.14 --check-only
+./scripts/build_native_toolchain_helper.sh --lane 2.14
+```
+
+Release-helper trace runs were killed with exit code `137`, so the usable instrumentation evidence came from the debug helper binary directly:
+
+- helper: `.uc/toolchain-helper-targets/cairo-2.14/debug/uc`
+- flags: `build --engine uc --daemon-mode off --offline`
+- env:
+  - `UC_NATIVE_DISALLOW_SCARB_FALLBACK=1`
+  - `UC_CAIRO214_SIZE_TRACE=/tmp/<trace>.tsv`
+
+For braavos, the first direct debug run cache-hit and wrote no trace. The successful trace run used a fresh temp copy with `target`, `.uc`, and `.scarb` removed.
+
+## Artifacts
+
+Monero debug-helper trace:
+
+- `/tmp/uc-monero-inline-callsite-trace-debug-20260429.tsv`
+
+Braavos debug-helper trace:
+
+- `/tmp/uc-braavos-inline-callsite-trace-debug-20260429-rerun.tsv`
+
+Braavos trace contains some malformed interleaved rows from the cheap append-only tracing mechanism; those rows were skipped during aggregation.
+
+## Result
+
+### Monero
+
+Aggregated event counts:
+
+- `estimate_size`: `2741`
+- `dummy_program_for_size_estimation`: `2741`
+- `estimate_size_callsite:inline_should_inline`: `1348`
+
+Inline share of exact size-estimation traffic:
+
+- `1348 / 2741 = 0.492`
+- about `49.2%`
+
+### Braavos
+
+Aggregated event counts after skipping `69` malformed rows:
+
+- `estimate_size`: `2912`
+- `dummy_program_for_size_estimation`: `2900`
+- `estimate_size_callsite:inline_should_inline`: `1119`
+
+Inline share of exact size-estimation traffic:
+
+- `1119 / 2912 = 0.384`
+- about `38.4%`
+
+## Conclusion
+
+Inline decisions are a major, but not total, contributor to exact size-estimation churn:
+
+- roughly half on monero
+- roughly two-fifths on braavos
+
+This is enough to rule out a simplistic story like “all remaining frontend cost is inline-only”.
+
+It also supports the earlier rejection of broad inline heuristics:
+
+- inlining is important enough to matter,
+- but not dominant enough to justify shipping unstable global heuristics that regress other workloads.
+
+## Recommendation
+
+The next frontend speed work should target one of these two narrower directions:
+
+1. improve exact size-estimation cost for the repeated hot helper families without changing inline policy broadly, or
+2. add safer caller-specific instrumentation for the remaining non-inline share before changing behavior.
+
+For now, the strongest production decision remains:
+
+- keep the helper lane on the baseline trace patch,
+- keep the inline fast-path experiment rejected,
+- and do not ship a perf PR from this pass.

--- a/docs/research/NATIVE_FRONTEND_SIZECACHE_EXPERIMENT_2026-04-29.md
+++ b/docs/research/NATIVE_FRONTEND_SIZECACHE_EXPERIMENT_2026-04-29.md
@@ -1,0 +1,110 @@
+# Native Frontend Size Cache Experiment (2026-04-29)
+
+## Decision
+
+Do not ship the Cairo `2.14` helper-lane size-estimate memoization patch.
+
+The experiment added an in-process cache for exact `estimate_code_size()` results inside the
+patched `cairo-lang-compiler` helper crate. The hypothesis was that repeated inline-size checks on
+the same concrete functions would stop recompiling identical dummy Sierra/CASM fragments and reduce
+`native_frontend_compile_ms` on heavy contracts like monero and braavos.
+
+The real same-window harness did not support that hypothesis. The patch slightly improved one cold
+braavos run, but it regressed monero and glint cold builds materially and also made warm-noop
+behavior worse across most of the measured set.
+
+## Scope
+
+- `uc` worktree: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429`
+- `uc` binary: `target/release/uc`
+- Cairo lane: external helper `2.14.0`
+- Contracts:
+  - `monero_atomic_swap`
+  - `braavos_account`
+  - `zcash_relay`
+  - `glint_contracts`
+- Sample counts: `3` cold, `3` warm-noop
+- Warm settle seconds: `2.2`
+- Same host, same helper lane, same harness, sequential same-window reruns
+
+## Input Artifacts
+
+Reference rerun:
+
+- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-reference.json`
+- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-reference.md`
+
+Patched rerun:
+
+- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-patched-sizecache.json`
+- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-patched-sizecache.md`
+
+Earlier diagnostic baseline used to choose the experiment:
+
+- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429.json`
+- `/tmp/uc-monero-size-trace-20260429.tsv`
+
+## Why This Was Tried
+
+The initial targeted sweep showed:
+
+- `native_frontend_compile_ms` dominates heavy cold builds.
+- Warm-noop behavior is already very strong on monero and braavos.
+- The existing local monero trace and the refreshed `2026-04-29` trace both show repeated
+  `estimate_size` / `dummy_program_for_size_estimation` events on a small set of concrete helper
+  functions, especially:
+  - `core::byte_array::ByteArrayImpl::at`
+  - `core::bytes_31::Bytes31Impl::at`
+  - `core::Felt252PartialEq::eq`
+  - `core::bytes_31::one_shift_left_bytes_u128_nz`
+
+That made exact size-estimate memoization the cheapest plausible helper-lane experiment to test
+before touching broader lowering/inlining behavior.
+
+## Result Summary
+
+`uc` p50 deltas between the same-window reference helper and the patched helper:
+
+| Contract | Cold `uc` p50 | Patched cold `uc` p50 | Delta | Warm `uc` p50 | Patched warm `uc` p50 | Delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `monero_atomic_swap` | `9908.728 ms` | `15948.330 ms` | `+6039.602 ms` (`+60.95%`) | `54.614 ms` | `82.833 ms` | `+28.219 ms` (`+51.67%`) |
+| `braavos_account` | `3582.401 ms` | `3448.280 ms` | `-134.121 ms` (`-3.74%`) | `55.587 ms` | `133.359 ms` | `+77.772 ms` (`+139.91%`) |
+| `glint_contracts` | `2757.957 ms` | `3021.751 ms` | `+263.794 ms` (`+9.56%`) | `59.471 ms` | `59.219 ms` | `-0.252 ms` (`-0.42%`) |
+| `zcash_relay` | `603.250 ms` | `572.320 ms` | `-30.930 ms` (`-5.13%`) | `66.067 ms` | `108.962 ms` | `+42.895 ms` (`+64.93%`) |
+
+Interpretation:
+
+- The patch is not robust enough for production.
+- A slight cold improvement on one or two contracts does not compensate for severe monero
+  regression and broad warm-noop degradation.
+- The cached exact-size path likely adds enough synchronization and/or keying overhead to cancel
+  out the avoided work, while still missing the deeper lowering/inlining cost centers.
+
+## Rejected Patch Shape
+
+The rejected patch was a lane-only `cairo-lang-compiler` change that memoized the final integer
+result of `estimate_code_size()` in a process-global cache keyed by:
+
+- compiler DB instance pointer
+- concrete function internal Salsa id
+
+This patch is intentionally not checked in after the experiment.
+
+## Recommendation
+
+Do not pursue more wrapper-level or light helper-cache work for the current cold-build hotspot.
+
+The next credible speed work remains deeper Cairo `2.14` helper-lane frontend profiling and
+optimization, specifically around:
+
+1. repeated lowering/inlining size-estimation work,
+2. dummy Sierra generation churn,
+3. avoiding exact-size estimation entirely for obviously tiny core helpers only if artifact
+   equivalence and real-harness wins can both be proven.
+
+Until that deeper helper-lane work exists, the honest product story is:
+
+- `uc` already wins strongly on warm-noop heavy contracts,
+- `uc` often wins on cold supported builds,
+- the remaining monero/braavos cold bottleneck is still inside Cairo `2.14` frontend behavior,
+  not in `uc` wrapper glue.

--- a/docs/research/NATIVE_FRONTEND_SIZECACHE_EXPERIMENT_2026-04-29.md
+++ b/docs/research/NATIVE_FRONTEND_SIZECACHE_EXPERIMENT_2026-04-29.md
@@ -15,9 +15,10 @@ behavior worse across most of the measured set.
 
 ## Scope
 
-- `uc` worktree: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429`
-- `uc` binary: `target/release/uc`
-- Cairo lane: external helper `2.14.0`
+- `uc` worktree: local perf worktree `uc-perf-native-frontier-20260429`
+- `uc` binary: local `target/release/uc` in that worktree
+- Benchmark lane id: `real-repo-bench-perf-frontier-20260429` same-window helper comparison
+- Conditions: local Apple M3 Pro macOS workstation (18 GiB RAM), daemon-free `--engine uc --daemon-mode off --offline`, Cairo external-helper lane `2.14.0`
 - Contracts:
   - `monero_atomic_swap`
   - `braavos_account`
@@ -31,18 +32,18 @@ behavior worse across most of the measured set.
 
 Reference rerun:
 
-- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-reference.json`
-- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-reference.md`
+- Local artifact: `benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-reference.json`
+- Local artifact: `benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-reference.md`
 
 Patched rerun:
 
-- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-patched-sizecache.json`
-- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-patched-sizecache.md`
+- Local artifact: `benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-patched-sizecache.json`
+- Local artifact: `benchmarks/results/real-repo-bench-perf-frontier-20260429-samewindow-patched-sizecache.md`
 
 Earlier diagnostic baseline used to choose the experiment:
 
-- `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429.json`
-- `/tmp/uc-monero-size-trace-20260429.tsv`
+- Local artifact: `benchmarks/results/real-repo-bench-perf-frontier-20260429.json`
+- Local diagnostic trace: `uc-monero-size-trace-20260429.tsv`
 
 ## Why This Was Tried
 
@@ -60,6 +61,11 @@ The initial targeted sweep showed:
 
 That made exact size-estimate memoization the cheapest plausible helper-lane experiment to test
 before touching broader lowering/inlining behavior.
+
+Trace provenance:
+
+- Captured by running the local Cairo `2.14` helper with `UC_CAIRO214_SIZE_TRACE=/abs/path/to/trace.tsv` during daemon-free diagnostic builds
+- These trace files are local diagnostics only, not durable benchmark artifacts
 
 ## Result Summary
 

--- a/docs/research/NATIVE_INLINE_FASTPATH_EXPERIMENT_2026-04-29.md
+++ b/docs/research/NATIVE_INLINE_FASTPATH_EXPERIMENT_2026-04-29.md
@@ -1,0 +1,121 @@
+# Native Inline Fast-Path Experiment (2026-04-29)
+
+## Goal
+
+Test whether Cairo `2.14` helper cold-build time can improve by skipping exact CASM size estimation for obviously tiny lowered functions during inlining decisions.
+
+This was motivated by the repeated `estimate_size` / `dummy_program_for_size_estimation` traffic measured on helper-backed native builds for:
+
+- `monero_atomic_swap`
+- `braavos_account`
+- `glint_contracts`
+- `zcash_relay`
+
+## Hypothesis
+
+The hottest repeated size-estimation targets are tiny core helpers (`core::assert`, `core::Felt252PartialEq::eq`, storage reads, array append, byte-array accessors). A cheap lowered-body approximation might be good enough to early-accept these cases and avoid exact dummy Sierra plus CASM generation.
+
+## Patch Shape
+
+Local-only helper-lane experiment in Cairo `2.14`:
+
+- patch file: `toolchains/cairo-2.14/patches/cairo-lang-lowering.patch`
+- touched function: `cairo_lang_lowering::inline::should_inline_lowered`
+- strategy:
+  - compute `ApproxCasmInlineWeight` from `LoweringStage::PostBaseline`
+  - return `true` early for very small functions
+  - keep the existing exact `db.estimate_size(function_id)` path for the rest
+
+Two thresholds were tested:
+
+1. `APPROX_INLINE_FAST_PATH_THRESHOLD = 24`
+2. `APPROX_INLINE_FAST_PATH_THRESHOLD = 12`
+
+This experiment was not kept in the checked-in helper patch after measurement.
+
+## Helper Validation
+
+The experimental lane patch applied cleanly and passed helper-lane validation before measurement:
+
+```bash
+./scripts/build_native_toolchain_helper.sh --lane 2.14 --check-only
+./scripts/build_native_toolchain_helper.sh --lane 2.14
+```
+
+Reference helper was rebuilt from the unmodified lane in a separate clean worktree and copied aside for same-window comparison.
+
+## Same-Window Artifact Set
+
+### Threshold 24
+
+Reference artifact:
+
+- `benchmarks/results/real-repo-bench-inlinefast-reference-20260429.json`
+
+Patched artifact:
+
+- `benchmarks/results/real-repo-bench-inlinefast-patched-20260429.json`
+
+Measured `uc` p95 deltas versus the same-window reference helper:
+
+| Contract | Cold | Warm no-op | Result |
+| --- | ---: | ---: | --- |
+| `braavos_account` | `1.309x` faster | `0.997x` | cold win, warm neutral |
+| `glint_contracts` | `2.083x` faster | `1.795x` faster | strong win |
+| `monero_atomic_swap` | `0.899x` | `0.565x` | bad regression |
+| `zcash_relay` | `1.101x` faster | `0.989x` | small cold win, warm neutral |
+
+Decision:
+
+- reject threshold `24`
+- monero regression is too large to treat this as a real speed improvement
+
+### Threshold 12
+
+Reference artifact:
+
+- `benchmarks/results/real-repo-bench-inlinefast12-reference-20260429.json`
+
+Patched artifact:
+
+- `benchmarks/results/real-repo-bench-inlinefast12-patched-20260429.json`
+
+Measured `uc` p95 deltas versus the same-window reference helper:
+
+| Contract | Cold | Warm no-op | Result |
+| --- | ---: | ---: | --- |
+| `braavos_account` | `1.045x` faster | `0.987x` | small cold win, warm neutral |
+| `glint_contracts` | `1.082x` faster | `0.615x` | warm regression |
+| `monero_atomic_swap` | `1.011x` faster | `1.008x` | neutral |
+| `zcash_relay` | `1.054x` faster | `0.603x` | warm regression |
+
+Decision:
+
+- reject threshold `12`
+- narrowing the fast path removed the monero regression but still produced clear warm regressions on smaller helper-backed projects
+
+## Conclusion
+
+Do not ship the inline fast-path heuristic as tested here.
+
+What this experiment proved:
+
+- the repeated hot path is real
+- a coarse early-inline fast path can help some cold builds
+- but the tradeoff is unstable across workloads and degrades warm behavior enough to fail the production bar
+
+## Recommendation
+
+The next speed work should stay focused on measurement, not heuristic widening:
+
+1. keep daemon routing work separate from frontend cold-build work
+2. keep the helper lane on the baseline trace-only patch after this experiment
+3. instrument where `estimate_size` is invoked, not just what it returns
+4. look for narrower reductions in repeated size-estimation work around the specific hot helper families:
+   - `core::assert`
+   - `core::Felt252PartialEq::eq`
+   - `core::byte_array::ByteArrayImpl::at`
+   - `core::bytes_31::Bytes31Impl::at`
+   - `core::starknet::storage::StorablePointerReadAccessImpl::read`
+
+A credible next experiment would need to preserve warm-noop behavior while producing a clean same-window cold improvement on both monero and braavos.

--- a/docs/research/NATIVE_PERFORMANCE_FRONTIER_2026-04-29.md
+++ b/docs/research/NATIVE_PERFORMANCE_FRONTIER_2026-04-29.md
@@ -18,9 +18,11 @@ Current focused native-supported set:
 - `zcash_relay`
 - `glint_contracts`
 
-Diagnostic benchmark artifact:
+Diagnostic benchmark lane and artifact:
 
-- [real-repo-bench-perf-frontier-20260429.json](/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429.json)
+- Lane id: `real-repo-bench-perf-frontier-20260429`
+- Artifact location: `benchmarks/results/real-repo-bench-perf-frontier-20260429.json` in the local perf worktree
+- Conditions: local Apple M3 Pro macOS workstation (18 GiB RAM), Cairo external-helper lane `2.14.0`, `--engine uc --daemon-mode off --offline`, `3` cold runs, `3` warm-noop runs, `2.2s` warm settle, sequential same-window reruns
 
 ## Baseline Result
 
@@ -82,13 +84,11 @@ Braavos also surfaces app-level event helpers repeatedly, but the pattern is sti
 - repeated dummy-program generation,
 - concentrated in shared inlining/specialization decisions.
 
-Braavos trace file:
+Trace provenance:
 
-- `/tmp/uc-braavos-size-trace-20260429.tsv`
-
-Monero trace file:
-
-- `/tmp/uc-monero-size-trace-20260429.tsv`
+- Captured by running the local Cairo `2.14` helper with `UC_CAIRO214_SIZE_TRACE=/abs/path/to/trace.tsv` during daemon-free diagnostic builds
+- These TSV files are local diagnostics only, not durable benchmark artifacts
+- Example local filenames used during this pass: `uc-braavos-size-trace-20260429.tsv`, `uc-monero-size-trace-20260429.tsv`
 
 ## Rejected Optimization
 
@@ -142,6 +142,10 @@ This makes daemon work a separate compatibility/perf track:
 
 - useful for agent UX if fixed,
 - not currently usable for native launch claims on helper-backed lanes.
+
+Daemon-free baseline command used for correctness/perf diagnosis:
+
+- `uc build --engine uc --daemon-mode off --offline`
 
 ## Recommendation
 

--- a/docs/research/NATIVE_PERFORMANCE_FRONTIER_2026-04-29.md
+++ b/docs/research/NATIVE_PERFORMANCE_FRONTIER_2026-04-29.md
@@ -1,0 +1,176 @@
+# Native Performance Frontier (2026-04-29)
+
+## Decision
+
+The next speed work should split into two separate tracks:
+
+1. heavy-contract cold-build optimization inside the Cairo `2.14` helper frontend,
+2. small-project warm-noop latency reduction in the wrapper/daemon path.
+
+Do not mix them.
+
+## Measured Contract Set
+
+Current focused native-supported set:
+
+- `monero_atomic_swap`
+- `braavos_account`
+- `zcash_relay`
+- `glint_contracts`
+
+Diagnostic benchmark artifact:
+
+- [real-repo-bench-perf-frontier-20260429.json](/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/benchmarks/results/real-repo-bench-perf-frontier-20260429.json)
+
+## Baseline Result
+
+Cold/warm `uc` versus Scarb from the focused 4-contract sweep:
+
+| Contract | Cold speedup | Warm-noop speedup |
+| --- | ---: | ---: |
+| `monero_atomic_swap` | `1.30x` | `138.97x` |
+| `braavos_account` | `2.34x` | `168.02x` |
+| `zcash_relay` | `1.78x` | `0.61x` |
+| `glint_contracts` | `3.77x` | `2.68x` |
+
+Interpretation:
+
+- `uc` is already very strong on warm-noop heavy contracts.
+- `uc` is usually ahead on cold builds for the supported set.
+- `zcash_relay` remains the important warm-noop outlier.
+
+## Heavy Cold Path Finding
+
+Cold heavy builds are still dominated by `native_frontend_compile_ms`.
+
+Representative telemetry from the same artifact:
+
+| Contract | `compile_ms` | `native_frontend_compile_ms` |
+| --- | ---: | ---: |
+| `monero_atomic_swap` | `7441.471 ms` | `7037.784 ms` |
+| `braavos_account` | `12685.849 ms` | `11276.351 ms` |
+| `glint_contracts` | `3260.599 ms` | `3170.764 ms` |
+| `zcash_relay` | `473.007 ms` | `455.379 ms` |
+
+Conclusion:
+
+- for monero, braavos, and glint, the remaining cold cost is still overwhelmingly frontend work,
+- session prep, fingerprinting, CASM, and artifact writes are secondary.
+
+## Braavos and Monero Trace Shape
+
+The helper-lane trace points for `estimate_size` / `dummy_program_for_size_estimation` show that
+both monero and braavos repeatedly hit a relatively small shared set of core helpers.
+
+Monero hot examples:
+
+- `core::byte_array::ByteArrayImpl::at`
+- `core::bytes_31::Bytes31Impl::at`
+- `core::Felt252PartialEq::eq`
+- `core::bytes_31::one_shift_left_bytes_u128_nz`
+
+Braavos hot examples:
+
+- `core::assert`
+- `core::Felt252PartialEq::eq`
+- `core::array::ArrayImpl::append`
+- `core::starknet::storage::StorablePointerReadAccessImpl::read`
+
+Braavos also surfaces app-level event helpers repeatedly, but the pattern is still the same:
+
+- repeated size-estimation work,
+- repeated dummy-program generation,
+- concentrated in shared inlining/specialization decisions.
+
+Braavos trace file:
+
+- `/tmp/uc-braavos-size-trace-20260429.tsv`
+
+Monero trace file:
+
+- `/tmp/uc-monero-size-trace-20260429.tsv`
+
+## Rejected Optimization
+
+The exact-size memoization helper patch was tested and rejected:
+
+- [NATIVE_FRONTEND_SIZECACHE_EXPERIMENT_2026-04-29.md](/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-perf-native-frontier-20260429/docs/research/NATIVE_FRONTEND_SIZECACHE_EXPERIMENT_2026-04-29.md)
+
+That experiment showed:
+
+- a global helper cache around `estimate_code_size()` is not a safe speed win,
+- it regressed monero badly and hurt warm-noop behavior,
+- so the next frontend work must be narrower than “memoize exact size everywhere”.
+
+## Small Warm Path Finding
+
+Manual warm-noop `zcash_relay` runs show that fingerprinting is not the main remaining cost.
+
+Manual warm cache-hit result:
+
+- `elapsed_ms`: about `28.54 ms`
+- measured telemetry sum:
+  - `fingerprint_ms`: about `0.85 ms`
+  - `cache_lookup_ms`: about `0.06 ms`
+  - `cache_restore_ms`: about `0.08 ms`
+
+So most of the remaining warm-noop latency on a tiny project is outside the measured compile/cache
+phases:
+
+- process startup,
+- CLI/setup work,
+- command orchestration overhead.
+
+That means:
+
+- further fingerprint micro-optimizations are unlikely to move the needle materially on tiny warm
+  projects,
+- if we want tiny-project warm wins, the best surface is process persistence or daemon/native
+  orchestration, not hashing.
+
+## Daemon Caveat
+
+Daemon mode is not yet a clean native speed surface for external-helper Cairo `2.14` lanes.
+
+Observed behavior:
+
+- daemon startup was healthy locally,
+- but `--daemon-mode require` on external-helper `2.14` builds downgraded to `uc_scarb`,
+- so those numbers are not valid native-speed evidence.
+
+This makes daemon work a separate compatibility/perf track:
+
+- useful for agent UX if fixed,
+- not currently usable for native launch claims on helper-backed lanes.
+
+## Recommendation
+
+### Track A: heavy cold builds
+
+Focus on helper-lane frontend behavior, specifically:
+
+1. instrument the callsites that invoke `estimate_size()` inside lowering/inlining/specialization,
+2. prove which repeated calls are avoidable without changing generated Sierra/CASM,
+3. test only narrow helper-lane patches against monero and braavos in same-window reruns.
+
+Good candidates to inspect next:
+
+- `cairo-lang-lowering/src/inline/mod.rs`
+- `cairo-lang-lowering/src/specialization.rs`
+- `cairo-lang-compiler/src/db.rs`
+
+### Track B: tiny warm projects
+
+Focus on process persistence and daemon/helper correctness, not fingerprint tweaks.
+
+Specifically:
+
+1. fix daemon native routing for external-helper `2.14` lanes,
+2. re-benchmark `zcash_relay` and similar tiny projects with daemon-native warm hits,
+3. only after daemon routing is correct, compare daemon warm-noop against `daemon-mode off`.
+
+## What Not To Do Next
+
+- do not spend more time on wrapper-level cache glue for monero/braavos cold builds,
+- do not ship another helper-wide exact-size memoization experiment,
+- do not treat daemon-backed Scarb fallback as native acceleration evidence.

--- a/toolchains/cairo-2.14/patches/cairo-lang-lowering.patch
+++ b/toolchains/cairo-2.14/patches/cairo-lang-lowering.patch
@@ -55,7 +55,7 @@ diff -ruN a/src/db.rs b/src/db.rs
 +    preview
 +}
 +
-+fn uc_cairo214_size_trace_event(
++pub(crate) fn uc_cairo214_size_trace_event(
 +    db: &dyn Database,
 +    event: &str,
 +    function_id: ConcreteFunctionWithBodyId<'_>,
@@ -116,3 +116,23 @@ diff -ruN a/src/db.rs b/src/db.rs
      let code_size_estimator = lowering_group_input(db).code_size_estimator(db);
      if let Some(estimator) = code_size_estimator {
          estimator(db, function_id)
+diff -ruN a/src/inline/mod.rs b/src/inline/mod.rs
+--- a/src/inline/mod.rs	2026-04-29 12:16:00
++++ b/src/inline/mod.rs	2026-04-29 12:16:00
+@@ -15,7 +15,7 @@
+ use salsa::Database;
+ 
+ use crate::blocks::{Blocks, BlocksBuilder};
+-use crate::db::LoweringGroup;
++use crate::db::{LoweringGroup, uc_cairo214_size_trace_event};
+ use crate::diagnostic::{
+     LoweringDiagnostic, LoweringDiagnosticKind, LoweringDiagnostics, LoweringDiagnosticsBuilder,
+ };
+@@ -123,6 +123,7 @@
+     function_id: ConcreteFunctionWithBodyId<'_>,
+     inline_small_functions_threshold: usize,
+ ) -> Maybe<bool> {
++    uc_cairo214_size_trace_event(db, "estimate_size_callsite:inline_should_inline", function_id);
+     let weight_of_blocks = db.estimate_size(function_id)?;
+     Ok(weight_of_blocks < inline_small_functions_threshold.into_or_panic())
+ }


### PR DESCRIPTION
## Summary
- add the rejected Cairo 2.14 size-cache experiment note with same-window reference vs patched helper evidence
- add the native performance frontier note that separates heavy cold frontend work from tiny warm orchestration work
- capture the daemon/helper caveat for external-helper 2.14 lanes so future perf work does not misuse daemon-backed fallback as native evidence

## Validation
- make agent-validate
- pre-push local-ci gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research documentation capturing compilation optimization experiment findings and results
  * Included performance frontier analysis with benchmark data and recommendations for future optimization efforts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->