### PR TITLE
Fix helper daemon routing for native builds

### DIFF
--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -743,7 +743,8 @@ pub(crate) fn build_plan_report_from_args(args: &BuildArgs) -> Result<BuildPlanR
                                 args.daemon_mode,
                                 None,
                                 Some(&helper_display),
-                            );
+                            )
+                            .expect("external helper build plan command should be constructible");
                             command_vec
                         })
                 } else {
@@ -1669,7 +1670,7 @@ pub(crate) fn run_build(args: BuildArgs) -> Result<()> {
                             daemon_mode,
                             helper_report_path.as_deref(),
                             Some(&helper_display),
-                        );
+                        )?;
                         let run = run_command(command, command_vec, write_report)?;
                         if !emit_json {
                             replay_output(&run.stdout, &run.stderr)?;

--- a/crates/uc-cli/src/commands/build.rs
+++ b/crates/uc-cli/src/commands/build.rs
@@ -729,24 +729,22 @@ pub(crate) fn build_plan_report_from_args(args: &BuildArgs) -> Result<BuildPlanR
 
             let subprocess_command =
                 if matches!(execution_driver, BuildPlanExecutionDriver::ExternalHelper) {
-                    native_toolchain
+                    let helper_path = native_toolchain
                         .as_ref()
                         .and_then(|toolchain| toolchain.binary_path.as_deref())
                         .map(PathBuf::from)
-                        .map(|helper_path| {
-                            let helper_display = helper_path.display().to_string();
-                            let (_command, command_vec) = build_uc_build_command(
-                                &helper_path,
-                                &args.common,
-                                &manifest_path,
-                                EngineArg::Uc,
-                                args.daemon_mode,
-                                None,
-                                Some(&helper_display),
-                            )
-                            .expect("external helper build plan command should be constructible");
-                            command_vec
-                        })
+                        .context("external helper build plan missing helper binary path")?;
+                    let helper_display = helper_path.display().to_string();
+                    let (_command, command_vec) = build_uc_build_command(
+                        &helper_path,
+                        &args.common,
+                        &manifest_path,
+                        EngineArg::Uc,
+                        args.daemon_mode,
+                        None,
+                        Some(&helper_display),
+                    )?;
+                    Some(command_vec)
                 } else {
                     None
                 };

--- a/crates/uc-cli/src/daemon.rs
+++ b/crates/uc-cli/src/daemon.rs
@@ -11,6 +11,22 @@ pub(super) fn daemon_socket_path(override_path: Option<PathBuf>) -> Result<PathB
     Ok(PathBuf::from(home).join(".uc/daemon/uc.sock"))
 }
 
+pub(super) fn daemon_socket_path_for_external_helper(helper_path: &Path) -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").context("HOME is not set; provide --socket-path")?;
+    let helper_canonical = helper_path.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize helper path {}",
+            helper_path.display()
+        )
+    })?;
+    let helper_key = blake3::hash(helper_canonical.as_os_str().as_encoded_bytes())
+        .to_hex()
+        .to_string();
+    Ok(PathBuf::from(home)
+        .join(".uc/daemon/helpers")
+        .join(format!("{}.sock", &helper_key[..16])))
+}
+
 pub(super) fn daemon_log_path(socket_path: &Path) -> PathBuf {
     socket_path.with_extension("log")
 }

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -10448,11 +10448,14 @@ fn ensure_daemon_native_toolchain_request_supported(manifest_path: &Path) -> Res
     match selection {
         Ok(selection) => {
             if let Some(helper_path) = selection.helper_path {
-                let current_exe_matches_helper = std::env::current_exe()
-                    .ok()
-                    .and_then(|path| path.canonicalize().ok())
-                    .zip(helper_path.canonicalize().ok())
-                    .is_some_and(|(current_exe, helper)| current_exe == helper);
+                let current_exe = std::env::current_exe()
+                    .context("failed to resolve current daemon binary path")?
+                    .canonicalize()
+                    .context("failed to canonicalize current daemon binary path")?;
+                let helper_path = helper_path
+                    .canonicalize()
+                    .context("failed to canonicalize selected external helper path")?;
+                let current_exe_matches_helper = current_exe == helper_path;
                 if current_exe_matches_helper {
                     return Ok(());
                 }
@@ -18376,8 +18379,10 @@ fn build_uc_build_command(
     if let Some(path) = helper_path_override {
         command.env("UC_NATIVE_TOOLCHAIN_HELPER_ACTIVE", "1");
         command.env("UC_NATIVE_TOOLCHAIN_HELPER_PATH", path);
-        let helper_socket_path = daemon_socket_path_for_external_helper(Path::new(path))?;
-        command.env("UC_DAEMON_SOCKET_PATH", &helper_socket_path);
+        if !matches!(daemon_mode, DaemonModeArg::Off) {
+            let helper_socket_path = daemon_socket_path_for_external_helper(Path::new(path))?;
+            command.env("UC_DAEMON_SOCKET_PATH", &helper_socket_path);
+        }
     }
 
     Ok((command, command_vec))

--- a/crates/uc-cli/src/main.rs
+++ b/crates/uc-cli/src/main.rs
@@ -10448,11 +10448,19 @@ fn ensure_daemon_native_toolchain_request_supported(manifest_path: &Path) -> Res
     match selection {
         Ok(selection) => {
             if let Some(helper_path) = selection.helper_path {
+                let current_exe_matches_helper = std::env::current_exe()
+                    .ok()
+                    .and_then(|path| path.canonicalize().ok())
+                    .zip(helper_path.canonicalize().ok())
+                    .is_some_and(|(current_exe, helper)| current_exe == helper);
+                if current_exe_matches_helper {
+                    return Ok(());
+                }
                 let message = format!(
                     concat!(
                         "daemon native build requires external native toolchain helper {}; ",
-                        "daemon requests cannot safely carry helper metadata yet; ",
-                        "run with --daemon-mode off or allow scarb fallback"
+                        "daemon requests must run on the matching helper daemon binary; ",
+                        "run the helper with its scoped daemon socket or allow scarb fallback"
                     ),
                     helper_path.display()
                 );
@@ -18296,7 +18304,7 @@ fn build_uc_build_command(
     daemon_mode: DaemonModeArg,
     report_path: Option<&Path>,
     helper_path_override: Option<&str>,
-) -> (Command, Vec<String>) {
+) -> Result<(Command, Vec<String>)> {
     let mut command = Command::new(exe);
     let mut command_vec = vec![exe.display().to_string(), "build".to_string()];
 
@@ -18368,9 +18376,11 @@ fn build_uc_build_command(
     if let Some(path) = helper_path_override {
         command.env("UC_NATIVE_TOOLCHAIN_HELPER_ACTIVE", "1");
         command.env("UC_NATIVE_TOOLCHAIN_HELPER_PATH", path);
+        let helper_socket_path = daemon_socket_path_for_external_helper(Path::new(path))?;
+        command.env("UC_DAEMON_SOCKET_PATH", &helper_socket_path);
     }
 
-    (command, command_vec)
+    Ok((command, command_vec))
 }
 
 fn run_uc_build_subprocess(
@@ -18387,7 +18397,7 @@ fn run_uc_build_subprocess(
         DaemonModeArg::Off,
         None,
         None,
-    );
+    )?;
     run_command_capture(command, command_vec)
 }
 

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -3812,6 +3812,55 @@ fn build_uc_build_command_sets_helper_scoped_daemon_socket_override() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn build_uc_build_command_skips_helper_socket_override_when_daemon_is_off() {
+    let dir = unique_test_dir("uc-helper-build-command-daemon-off");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let helper_path = dir.join("uc-helper-bin");
+    fs::write(&helper_path, "#!/bin/sh\n").expect("write helper");
+    let (command, _command_vec) = build_uc_build_command(
+        &helper_path,
+        &BuildCommonArgs {
+            manifest_path: Some(PathBuf::from("/tmp/workspace/Scarb.toml")),
+            package: None,
+            workspace: false,
+            features: Vec::new(),
+            offline: true,
+            release: false,
+            profile: None,
+        },
+        Path::new("/tmp/workspace/Scarb.toml"),
+        EngineArg::Uc,
+        DaemonModeArg::Off,
+        None,
+        Some(helper_path.to_str().expect("helper path should be utf-8")),
+    )
+    .expect("helper build command should be constructible");
+    let envs = command
+        .get_envs()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().to_string(),
+                value.map(|entry| entry.to_string_lossy().to_string()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(
+        envs.get("UC_NATIVE_TOOLCHAIN_HELPER_ACTIVE"),
+        Some(&Some("1".to_string()))
+    );
+    assert_eq!(
+        envs.get("UC_NATIVE_TOOLCHAIN_HELPER_PATH"),
+        Some(&Some(helper_path.display().to_string()))
+    );
+    assert!(
+        !envs.contains_key("UC_DAEMON_SOCKET_PATH"),
+        "daemon-off helper subprocesses should not compute a helper-scoped socket override"
+    );
+}
+
 #[cfg(feature = "native-compile")]
 #[test]
 fn native_compile_session_heap_estimate_scales_with_tracked_source_bytes() {

--- a/crates/uc-cli/src/main_tests.rs
+++ b/crates/uc-cli/src/main_tests.rs
@@ -3722,8 +3722,8 @@ starknet = "={requested_version}"
         "error should reject daemon helper routing: {rendered}"
     );
     assert!(
-        rendered.contains(&helper_path.display().to_string()),
-        "error should name the helper that cannot be carried into the daemon request: {rendered}"
+        rendered.contains("matching helper daemon binary"),
+        "error should require the matching helper daemon binary: {rendered}"
     );
     assert!(
         native_error_allows_scarb_fallback(&err),
@@ -3731,6 +3731,85 @@ starknet = "={requested_version}"
     );
 
     fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_socket_path_for_external_helper_is_stable_and_helper_scoped() {
+    let _guard = integration_env_lock().lock().unwrap();
+    let dir = unique_test_dir("uc-helper-daemon-socket");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let helper_a = dir.join("uc-helper-a");
+    let helper_b = dir.join("uc-helper-b");
+    fs::write(&helper_a, "#!/bin/sh\n").expect("write helper a");
+    fs::write(&helper_b, "#!/bin/sh\n").expect("write helper b");
+    let socket_a_first =
+        daemon_socket_path_for_external_helper(&helper_a).expect("helper socket path");
+    let socket_a_second =
+        daemon_socket_path_for_external_helper(&helper_a).expect("helper socket path");
+    let socket_b = daemon_socket_path_for_external_helper(&helper_b).expect("helper socket path");
+
+    assert_eq!(socket_a_first, socket_a_second);
+    assert_ne!(socket_a_first, socket_b);
+    assert!(
+        socket_a_first
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|value| value == "sock"),
+        "helper daemon socket should use a unix socket suffix: {}",
+        socket_a_first.display()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn build_uc_build_command_sets_helper_scoped_daemon_socket_override() {
+    let dir = unique_test_dir("uc-helper-build-command");
+    let _cleanup = TestDirCleanup::new(&dir);
+    let helper_path = dir.join("uc-helper-bin");
+    fs::write(&helper_path, "#!/bin/sh\n").expect("write helper");
+    let expected_socket =
+        daemon_socket_path_for_external_helper(&helper_path).expect("helper socket path");
+    let (command, _command_vec) = build_uc_build_command(
+        &helper_path,
+        &BuildCommonArgs {
+            manifest_path: Some(PathBuf::from("/tmp/workspace/Scarb.toml")),
+            package: None,
+            workspace: false,
+            features: Vec::new(),
+            offline: true,
+            release: false,
+            profile: None,
+        },
+        Path::new("/tmp/workspace/Scarb.toml"),
+        EngineArg::Uc,
+        DaemonModeArg::Require,
+        None,
+        Some(helper_path.to_str().expect("helper path should be utf-8")),
+    )
+    .expect("helper build command should be constructible");
+    let envs = command
+        .get_envs()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().to_string(),
+                value.map(|entry| entry.to_string_lossy().to_string()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(
+        envs.get("UC_NATIVE_TOOLCHAIN_HELPER_ACTIVE"),
+        Some(&Some("1".to_string()))
+    );
+    assert_eq!(
+        envs.get("UC_NATIVE_TOOLCHAIN_HELPER_PATH"),
+        Some(&Some(helper_path.display().to_string()))
+    );
+    assert_eq!(
+        envs.get("UC_DAEMON_SOCKET_PATH"),
+        Some(&Some(expected_socket.display().to_string()))
+    );
 }
 
 #[cfg(feature = "native-compile")]

--- a/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
+++ b/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
@@ -1,0 +1,64 @@
+# Helper Daemon Routing Experiment 2026-04-29
+
+## Goal
+
+Allow external-helper native lanes, especially Cairo `2.14`, to use daemon mode safely without
+talking to the wrong daemon binary or silently downgrading to Scarb.
+
+## Change
+
+Two changes were required:
+
+1. External helper subprocesses now get a helper-scoped `UC_DAEMON_SOCKET_PATH` derived from the
+   canonical helper binary path.
+2. Daemon native requests that resolve to an external helper are allowed only when the daemon
+   process is the matching helper binary itself. Non-matching binaries still reject the request.
+
+This keeps the original safety property against cross-binary daemon reuse while unlocking the
+valid self-hosted helper-daemon case.
+
+## Validation
+
+Targeted tests:
+
+- `cargo test -p uc-cli execute_daemon_build_rejects_external_helper_native_request -- --nocapture`
+- `cargo test -p uc-cli daemon_socket_path_for_external_helper_is_stable_and_helper_scoped -- --nocapture`
+- `cargo test -p uc-cli build_uc_build_command_sets_helper_scoped_daemon_socket_override -- --nocapture`
+
+Artifacts:
+
+- warm comparison source: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-daemon-external-helper-native-20260429/benchmarks/results/daemon-helper-warm-20260429.json`
+- explicit helper-daemon rerun: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-daemon-external-helper-native-20260429/benchmarks/results/daemon-helper-require-warm-20260429.json`
+- additional helper-backed case: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-daemon-external-helper-native-20260429/benchmarks/results/daemon-helper-glint-20260429.json`
+
+Helper lane rebuilt from this branch before measurement:
+
+- `/Users/espejelomar/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`
+
+## Result
+
+With the helper daemon explicitly started on its scoped socket, second-run warm builds stayed on
+`uc_native_external_helper` with `daemon_used=true` and `cache_hit=true` for all measured cases.
+
+Warm second-run results:
+
+- `monero_atomic_swap`: `33.117ms` off vs `32.122ms` require (`1.03x`)
+- `braavos_account`: `43.997ms` off vs `42.904ms` require (`1.03x`)
+- `glint_contracts`: `30.862ms` off vs `29.035ms` require (`1.06x`)
+- `zcash_relay`: `27.732ms` off vs `41.289ms` require (`0.67x`)
+
+## Conclusion
+
+This is worth shipping as a correctness and daemon-availability fix for external-helper lanes.
+
+It is **not** a clean performance PR by itself:
+
+- heavier helper-backed contracts see small warm wins,
+- tiny helper-backed workloads can still regress because the daemon request overhead is larger than
+  the local cache-hit path.
+
+## Recommendation
+
+Merge the routing fix as a daemon correctness improvement, then do any follow-up performance work
+behind a separate slice focused on reducing helper-daemon request overhead for very small warm
+builds.

--- a/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
+++ b/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
@@ -27,20 +27,29 @@ Targeted tests:
 
 Artifacts:
 
-- warm comparison source: `benchmarks/results/daemon-helper-warm-20260429.json`
-- explicit helper-daemon rerun: `benchmarks/results/daemon-helper-require-warm-20260429.json`
-- additional helper-backed case: `benchmarks/results/daemon-helper-glint-20260429.json`
+- lane `daemon-helper-warm-20260429`: `benchmarks/results/daemon-helper-warm-20260429.json`
+- lane `daemon-helper-require-warm-20260429`: `benchmarks/results/daemon-helper-require-warm-20260429.json`
+- lane `daemon-helper-glint-20260429`: `benchmarks/results/daemon-helper-glint-20260429.json`
 
 Helper lane rebuilt from this branch before measurement:
 
 - `<HOME>/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`
+
+Run conditions:
+
+- host class: local macOS Apple Silicon workstation (`Darwin arm64`, `Apple M3 Pro`)
+- native mode: `UC_NATIVE_BUILD_MODE=require`
+- toolchain lane: external helper Cairo `2.14`
+- scenario: helper-backed native builds on fresh temp copies with second-run warm comparisons
+- daemon comparison: `--daemon-mode off` vs `--daemon-mode require`
 
 ## Result
 
 With the helper daemon explicitly started on its scoped socket, second-run warm builds stayed on
 `uc_native_external_helper` with `daemon_used=true` and `cache_hit=true` for all measured cases.
 
-Warm second-run results:
+Warm second-run results under lane `daemon-helper-require-warm-20260429` versus the `daemon-helper-warm-20260429`
+source comparison:
 
 - `monero_atomic_swap`: `33.117ms` off vs `32.122ms` require (`1.03x`)
 - `braavos_account`: `43.997ms` off vs `42.904ms` require (`1.03x`)

--- a/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
+++ b/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
@@ -28,8 +28,14 @@ Targeted tests:
 Artifacts:
 
 - lane `daemon-helper-warm-20260429`: `benchmarks/results/daemon-helper-warm-20260429.json`
+  baseline helper-backed warm lane with `--daemon-mode off`; measures second-run cache-hit behavior on
+  fresh temp copies.
 - lane `daemon-helper-require-warm-20260429`: `benchmarks/results/daemon-helper-require-warm-20260429.json`
+  helper-daemon warm lane with `--daemon-mode require`; compares the same second-run helper-backed
+  cache-hit scenario against the baseline lane.
 - lane `daemon-helper-glint-20260429`: `benchmarks/results/daemon-helper-glint-20260429.json`
+  focused single-case follow-up lane for `glint_contracts`; confirms the helper-daemon warm path on
+  an additional helper-backed workload.
 
 Helper lane rebuilt from this branch before measurement:
 
@@ -53,7 +59,8 @@ source comparison:
 
 - `monero_atomic_swap`: `33.117ms` off vs `32.122ms` require (`1.03x`)
 - `braavos_account`: `43.997ms` off vs `42.904ms` require (`1.03x`)
-- `glint_contracts`: `30.862ms` off vs `29.035ms` require (`1.06x`)
+- `glint_contracts`: `30.862ms` off vs `29.035ms` require (`1.06x`) from the focused
+  `daemon-helper-glint-20260429` follow-up lane
 - `zcash_relay`: `27.732ms` off vs `41.289ms` require (`0.67x`)
 
 ## Conclusion

--- a/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
+++ b/docs/research/HELPER_DAEMON_ROUTING_EXPERIMENT_2026-04-29.md
@@ -27,13 +27,13 @@ Targeted tests:
 
 Artifacts:
 
-- warm comparison source: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-daemon-external-helper-native-20260429/benchmarks/results/daemon-helper-warm-20260429.json`
-- explicit helper-daemon rerun: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-daemon-external-helper-native-20260429/benchmarks/results/daemon-helper-require-warm-20260429.json`
-- additional helper-backed case: `/Users/espejelomar/StarkNet/compiler-starknet/_pr_work/uc-daemon-external-helper-native-20260429/benchmarks/results/daemon-helper-glint-20260429.json`
+- warm comparison source: `benchmarks/results/daemon-helper-warm-20260429.json`
+- explicit helper-daemon rerun: `benchmarks/results/daemon-helper-require-warm-20260429.json`
+- additional helper-backed case: `benchmarks/results/daemon-helper-glint-20260429.json`
 
 Helper lane rebuilt from this branch before measurement:
 
-- `/Users/espejelomar/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`
+- `<HOME>/.uc/toolchain-helpers/uc-cairo214-helper/bin/uc`
 
 ## Result
 


### PR DESCRIPTION
## Summary
- route external helper builds onto helper-scoped daemon sockets instead of the shared default socket
- keep daemon native requests safe by only allowing external-helper requests when the daemon binary matches the helper itself
- add regression tests and a research note with warm-path measurements on helper-backed repos

## Validation
- cargo fmt --all
- cargo test -p uc-cli execute_daemon_build_rejects_external_helper_native_request -- --nocapture
- cargo test -p uc-cli daemon_socket_path_for_external_helper_is_stable_and_helper_scoped -- --nocapture
- cargo test -p uc-cli build_uc_build_command_sets_helper_scoped_daemon_socket_override -- --nocapture
- make agent-validate
- git diff --check
- make local-ci

## Benchmark notes
Warm second-run helper-backed results after explicitly starting the helper daemon:
- monero_atomic_swap: 33.117ms off vs 32.122ms require (1.03x)
- braavos_account: 43.997ms off vs 42.904ms require (1.03x)
- glint_contracts: 30.862ms off vs 29.035ms require (1.06x)
- zcash_relay: 27.732ms off vs 41.289ms require (0.67x)

This should be reviewed as a daemon correctness fix with mixed warm-path impact, not as a clean perf win.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External-helper errors now stop plan generation or run execution instead of proceeding with an implicit/empty subprocess command; daemon routing requires the matching helper daemon and sets a helper-scoped daemon socket for subprocesses when needed.
* **Tests**
  * Updated tests and new Unix-only integration tests verify deterministic, unique per-helper socket paths, socket filename format, and daemon-routing behavior.
* **Documentation**
  * Added research notes describing the daemon-routing and helper-scoped socket approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->