### PR TITLE
Modernize review-bot config and add agent feedback loop

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Policy: docs/agent/PR_BOT_POLICY.md
+# Note on `tools`: every CodeRabbit tool defaults to enabled. Entries below are
+# therefore either deliberate opt-OUTs, or opt-INs kept explicit because they are
+# load-bearing for this repo (a build tool that spawns subprocesses, writes caches,
+# and ships CI). Do not add `enabled: true` lines that only restate the default.
 language: "en-US"
 tone_instructions: |
   Be direct and technical. Prioritize production bugs, cache invalidation mistakes,
@@ -13,8 +19,39 @@ reviews:
   poem: false
   collapse_walkthrough: true
   changed_files_summary: true
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  # Emit the "Prompt for AI Agents" block on inline comments. Coding agents in this
+  # repo consume these directly; see docs/agent/PR_BOT_POLICY.md "Agent review loop".
+  enable_prompt_for_ai_agents: true
+  suggested_labels: true
+  auto_apply_labels: true
+  labeling_instructions:
+    - label: "native-engine"
+      instructions: |
+        Apply when the diff touches the native compile session, Salsa integration,
+        corelib resolution, journal/watcher, or third_party/cairo-lang-* patches.
+    - label: "cache-correctness"
+      instructions: |
+        Apply when the diff touches fingerprinting, cache restore/persist, session
+        keys, or invalidation logic.
+    - label: "agent-surface"
+      instructions: |
+        Apply when the diff changes JSON reports, docs/agent/schemas/**, diagnostic
+        codes, exit codes, or the MCP surface.
+    - label: "benchmark"
+      instructions: |
+        Apply when the diff touches benchmarks/** harnesses, gates, or baselines.
+    - label: "verification"
+      instructions: |
+        Apply when the diff touches build receipts, class-hash computation, or the
+        uc verify provider surface.
   path_filters:
     - "!benchmarks/results/**"
+    - "!benchmarks/baselines/**"
+    - "!Cargo.lock"
   path_instructions:
     - path: "crates/**/src/**/*.rs"
       instructions: |
@@ -22,10 +59,18 @@ reviews:
         Focus on correctness, invalidation safety, deterministic outputs,
         daemon behavior, fallback behavior, and missing regression coverage.
         Treat cache false-hits as higher severity than false-misses.
+        Non-test code must not introduce bare unwrap()/expect()/panic!; flag any that appear.
+        Mutex locks must recover from poisoning rather than propagate panics.
     - path: "crates/**/tests/**"
       instructions: |
         Ensure tests cover edge cases, invalidation behavior, and failure paths.
         Flag cases where risky production changes do not add targeted regression tests.
+    - path: "third_party/**"
+      instructions: |
+        Vendored cairo-lang crates carrying uc patches (chiefly keyed Salsa file-override
+        slots). Review patches for correctness of invalidation semantics and for drift
+        from the upstream version pinned in Cargo.toml. Flag any patch that widens or
+        narrows invalidation scope without a test.
     - path: "benchmarks/**"
       instructions: |
         Verify measurement methodology remains explicit and reproducible.
@@ -34,9 +79,16 @@ reviews:
     - path: ".github/workflows/**"
       instructions: |
         Check that workflows preserve deterministic validation and useful failure output.
+        Flag unpinned third-party actions, excessive permissions, and untrusted input
+        interpolated into run steps.
     - path: "docs/**"
       instructions: |
         Flag stale commands, stale paths, or docs that drift from code and workflow behavior.
+    - path: "docs/agent/schemas/**"
+      instructions: |
+        These are the agent contract. Changes must be additive, or bump schema_version.
+        Flag any field removal, type change, or rename that is not accompanied by a
+        schema_version bump and a note in the PR description.
     - path: "scripts/**"
       instructions: |
         Check for shell safety (`set -euo pipefail`), portability within supported environments,
@@ -45,20 +97,67 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: false
+  # Mechanical merge gating. `error` + request_changes_workflow blocks the PR until
+  # resolved, which is what lets coding agents self-serve without a human gatekeeper.
+  pre_merge_checks:
+    title:
+      mode: "error"
+      requirements: |
+        Imperative mood, no trailing period, ideally under 72 characters.
+        Should name the affected surface, e.g. "Fix stale cache hits for path dependencies".
+        Conventional-commit prefixes are allowed but not required.
+    description:
+      mode: "error"
+    issue_assessment:
+      mode: "warning"
+    # Docstring coverage is deliberately off: this repo's largest files predate the
+    # convention and a coverage gate would fail every unrelated PR. Docstring quality
+    # is handled by path_instructions and code_generation below.
+    docstrings:
+      mode: "off"
+    custom_checks:
+      - name: "Invalidation regression coverage"
+        mode: "error"
+        instructions: |
+          Applies only when the diff modifies cache, fingerprint, session-key, or native
+          compile-session reuse logic under crates/uc-cli/src/{cache.rs,fingerprint.rs,main.rs}
+          or crates/uc-core/src/{cache.rs,session.rs}.
+          PASS if the PR also adds or modifies at least one test that exercises the changed
+          invalidation or restore path, or if the PR description explains why the change
+          cannot regress correctness (pure refactor, telemetry-only, docs-only).
+          FAIL if reuse/restore logic changed with no test change and no justification.
+      - name: "No silent degradation"
+        mode: "error"
+        instructions: |
+          Applies when the diff changes build execution, daemon dispatch, fallback selection,
+          or error handling.
+          PASS if every new path that degrades behavior (scarb fallback, daemon unavailable,
+          cache disabled, offline downgrade) emits a diagnostic or report field recording that
+          it happened.
+          FAIL if a degradation path returns success without recording the degradation.
+      - name: "Agent contract stability"
+        mode: "error"
+        instructions: |
+          Applies when the diff changes any serialized report struct, diagnostic code, exit
+          code, or file under docs/agent/schemas/.
+          PASS if changes are purely additive, or the affected schema_version is bumped and the
+          PR description names the consumers affected.
+          FAIL if a field is removed, renamed, or retyped with no schema_version bump.
+      - name: "Benchmark claim integrity"
+        mode: "warning"
+        instructions: |
+          Applies when the PR description or docs state a performance number.
+          PASS if the claim names the harness, lane, sample count, and the comparison build,
+          and the numbers come from a same-window run.
+          FAIL if a performance claim is stated without its measurement conditions, or if it
+          is backed by a run where uc fell back to scarb.
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
   tools:
-    shellcheck:
-      enabled: true
-    markdownlint:
-      enabled: true
-    github-checks:
-      enabled: true
-      timeout_ms: 90000
-    yamllint:
-      enabled: true
-    gitleaks:
-      enabled: true
-    actionlint:
-      enabled: true
+    # Deliberate opt-outs: not applicable to this stack, or too noisy for the signal.
     ruff:
       enabled: false
     biome:
@@ -67,12 +166,43 @@ reviews:
       enabled: false
     checkov:
       enabled: false
+    languagetool:
+      enabled: false
     semgrep:
       enabled: false
-    ast-grep:
-      enabled: false
+    # Explicit opt-ins (already default-on) kept visible because they guard this repo's
+    # specific risk surface: shell harnesses, CI workflows, secrets, and dependency CVEs.
+    clippy:
+      enabled: true
+    shellcheck:
+      enabled: true
+    actionlint:
+      enabled: true
+    zizmor:
+      enabled: true
+    yamllint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    osvScanner:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
 chat:
   auto_reply: true
+code_generation:
+  docstrings:
+    language: "en-US"
+    path_instructions:
+      - path: "crates/**/src/**/*.rs"
+        instructions: |
+          Use `///` doc comments. Lead with a one-line summary of what the function
+          guarantees, not how it is implemented. For cache, fingerprint, and session
+          code, state the invalidation contract explicitly (what makes this stale) and
+          note whether a false hit or false miss is possible.
 knowledge_base:
   opt_out: false
   learnings:

--- a/.codex/START_HERE.md
+++ b/.codex/START_HERE.md
@@ -22,7 +22,8 @@ The product is not only "make build faster". It should let agents:
 3. `make agent-validate`
 4. Read `README.md`
 5. Read `docs/agent/README.md`
-6. Read the subsystem doc you are changing.
+6. Read `docs/agent/PR_LIFECYCLE.md` before your first commit.
+7. Read the subsystem doc you are changing.
 
 ## Immediate Priorities
 
@@ -31,10 +32,22 @@ The product is not only "make build faster". It should let agents:
 3. Preserve correctness and fallback classification.
 4. Keep acceleration work focused on native-supported modern Cairo lanes.
 
+## Shipping A Change
+
+Read `docs/agent/PR_LIFECYCLE.md`. Non-negotiables:
+
+- Branch; never commit to `main`.
+- Gate locally first, and read the gate's own exit code — a `grep` or `tail` at the end of
+  a pipeline reports its own status, not the gate's. Redirect to a file and check `$?`.
+- Verify every bot finding against the code before acting on it. Fix real ones with a
+  regression test; decline invalid ones explicitly with reasoning. Never ignore one.
+- Re-gate on the fixed head before merging.
+
 ## Common Commands
 
 - Install repo hooks: `make install-hooks`
 - Local push gate: `make local-ci`
+- Review-bot feedback as JSON: `make pr-feedback-open`
 - Format: `cargo fmt --all`
 - Fast validation: `make validate-fast`
 - Native validation: `make validate-native`
@@ -58,6 +71,9 @@ The product is not only "make build faster". It should let agents:
 
 - Product overview: `README.md`
 - Agent docs: `docs/agent/README.md`
+- PR lifecycle and bot triage: `docs/agent/PR_LIFECYCLE.md`
+- PR bot policy: `docs/agent/PR_BOT_POLICY.md`
+- CI policy: `docs/agent/CI_POLICY.md`
 - Agent diagnostics: `docs/agent/AGENT_DIAGNOSTICS.md`
 - Agent quickstart: `docs/agent/AGENT_QUICKSTART.md`
 - Human quickstart: `docs/agent/HUMAN_QUICKSTART.md`

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,3 +1,9 @@
+# Qodo Merge configuration. Policy: docs/agent/PR_BOT_POLICY.md
+#
+# Keep this file small. Durable coding standards belong in best_practices.md and
+# hard engineering gates belong in pr_compliance_checklist.yaml; Qodo reads both.
+# Only keys that Qodo actually consumes are set here — do not add speculative keys.
+
 [github_app]
 pr_commands = [
   "/agentic_describe",
@@ -8,9 +14,24 @@ pr_commands = [
 [review_agent]
 comments_location_policy = "both"
 inline_comments_severity_threshold = 3
-issues_user_guidelines = "Read AGENTS.md, .codex/START_HERE.md, docs/agent/PR_BOT_POLICY.md, and docs/agent/REPO_MAP.md first. Prioritize correctness bugs, invalidation mistakes, daemon safety, artifact drift, benchmark bias, and missing tests. Ignore formatting-only nits when existing tooling already covers them."
-compliance_user_guidelines = "Apply pr_compliance_checklist.yaml with emphasis on native compile correctness, conservative cache reuse, explicit fallback behavior, and strict benchmark methodology."
+issues_user_guidelines = """
+Read AGENTS.md, .codex/START_HERE.md, docs/agent/PR_BOT_POLICY.md, and docs/agent/REPO_MAP.md first.
+Prioritize, in order: (1) cache/fingerprint invalidation mistakes that could serve a stale artifact,
+(2) silent degradation — any fallback, daemon-unavailable, or offline downgrade that is not recorded
+in a diagnostic or report field, (3) agent-contract breaks — a JSON report or schema field removed,
+renamed, or retyped without a schema_version bump, or a failure path that exits without emitting JSON
+in --json mode, (4) daemon safety and concurrency, (5) build-receipt and class-hash correctness for
+verification work, (6) benchmark methodology bias, (7) missing regression tests on risky paths.
+Treat a cache false-hit as strictly worse than a false-miss. Ignore formatting-only nits that cargo fmt,
+clippy, or CodeRabbit already cover.
+"""
+compliance_user_guidelines = """
+Apply pr_compliance_checklist.yaml with emphasis on native compile correctness, conservative cache reuse,
+explicit fallback behavior, agent-contract stability, and strict benchmark methodology.
+A PR that changes reuse or restore logic without a regression test fails compliance unless the description
+justifies why correctness cannot regress.
+"""
 
 [pr_compliance]
 enable_global_pr_compliance = false
-extra_instructions = "Use the local pr_compliance_checklist.yaml as the repo-specific gate for native compile, benchmark, and agent-surface changes."
+extra_instructions = "Use the local pr_compliance_checklist.yaml as the repo-specific gate for native compile, benchmark, verification, and agent-surface changes."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,10 @@ Treat it as:
 - Do non-trivial work in a fresh branch or clean worktree.
 - Open a normal ready-for-review PR early; avoid draft PRs unless explicitly requested.
 - After pushing a coherent slice, start the review loop immediately.
+- Read bot feedback as JSON with `make pr-feedback-open`, not from the web UI.
 - Address useful CodeRabbit and Qodo feedback, including docs nits when they affect accuracy.
-- Merge only after all actionable feedback is addressed and the PR has been quiet for at least 6 minutes.
+- Merge only after all actionable feedback is addressed, `counts.unresolved_bot_threads` and
+  `counts.failing_checks` are both 0, and the PR has been quiet for at least 6 minutes.
 
 ## Current Priorities
 
@@ -65,6 +67,7 @@ Treat it as:
 - Bootstrap hooks: `make bootstrap` or `make install-hooks`
 - Fast repo check: `make doctor && make agent-validate`
 - Local push gate: `make local-ci`
+- Review-bot feedback as JSON: `make pr-feedback` (or `make pr-feedback-open`, `make pr-feedback PR=<n>`)
 - Format: `cargo fmt --all`
 - Fast Rust validation: `make validate-fast`
 - Native-focused validation: `make validate-native`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,20 +24,29 @@ Treat it as:
 ## Read First
 
 1. `.codex/START_HERE.md`
-2. `README.md`
-3. `docs/agent/README.md`
-4. `docs/agent/AGENT_FIRST_COMPILER.md`
-5. `docs/agent/AGENT_QUICKSTART.md`
-6. `docs/agent/AGENT_DIAGNOSTICS.md`
-7. `docs/NATIVE_TOOLCHAIN_HELPERS.md`
+2. `docs/agent/PR_LIFECYCLE.md` — how to take a change to `main`; read before your first commit
+3. `README.md`
+4. `docs/agent/README.md`
+5. `docs/agent/AGENT_FIRST_COMPILER.md`
+6. `docs/agent/AGENT_QUICKSTART.md`
+7. `docs/agent/AGENT_DIAGNOSTICS.md`
+8. `docs/NATIVE_TOOLCHAIN_HELPERS.md`
 
 ## PR-First Rule
 
-- Do non-trivial work in a fresh branch or clean worktree.
+Full procedure: `docs/agent/PR_LIFECYCLE.md`. The short version:
+
+- Do non-trivial work in a fresh branch or clean worktree. Never commit to `main`.
+- Gate locally before opening the PR, and read the gate's own exit code — not the exit
+  code of a `grep`/`tail` at the end of a pipeline. Redirect to a file and check `$?`.
 - Open a normal ready-for-review PR early; avoid draft PRs unless explicitly requested.
 - After pushing a coherent slice, start the review loop immediately.
 - Read bot feedback as JSON with `make pr-feedback-open`, not from the web UI.
-- Address useful CodeRabbit and Qodo feedback, including docs nits when they affect accuracy.
+- Triage **every** bot finding: verify it against the code before acting. If real, fix it
+  minimally and add a regression test. If invalid, decline it explicitly with verified
+  reasoning in a reply — never silently ignore one. Bots are adversarial reviewers to be
+  checked, not authorities to obey.
+- Re-run the gate on the fixed head; the previous green run does not carry over.
 - Merge only after all actionable feedback is addressed, `counts.unresolved_bot_threads` and
   `counts.failing_checks` are both 0, and the PR has been quiet for at least 6 minutes.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/sh
 
-.PHONY: bootstrap install-hooks doctor agent-map agent-validate validate-local-ci validate-scripts validate-helper-lane validate-bench-scripts validate-fast validate-native local-ci benchmark-local benchmark-uc benchmark-smoke benchmark-delta benchmark-strict-smoke benchmark-strict-research perf-fast perf-fast-semantic compare-local
+.PHONY: bootstrap install-hooks doctor agent-map agent-validate validate-local-ci validate-scripts validate-helper-lane validate-bench-scripts validate-fast validate-native local-ci pr-feedback pr-feedback-open benchmark-local benchmark-uc benchmark-smoke benchmark-delta benchmark-strict-smoke benchmark-strict-research perf-fast perf-fast-semantic compare-local
 
 bootstrap:
 	@mkdir -p benchmarks/results benchmarks/baselines
@@ -58,6 +58,14 @@ validate-native:
 
 local-ci:
 	@./scripts/local_ci_gate.sh
+
+# Review-bot feedback as JSON for the current branch's PR (see docs/agent/PR_BOT_POLICY.md).
+pr-feedback:
+	@./scripts/pr_feedback.sh $(PR)
+
+# Only the threads still needing action.
+pr-feedback-open:
+	@./scripts/pr_feedback.sh $(PR) --unresolved-only
 
 benchmark-local:
 	@./benchmarks/scripts/run_local_benchmarks.sh --matrix research --tool scarb

--- a/best_practices.md
+++ b/best_practices.md
@@ -3,18 +3,35 @@
 ## Rust changes
 - Favor deterministic behavior over cleverness.
 - In non-test code, do not add `unwrap()` or `expect()` unless the panic is explicitly part of a fail-fast invariant.
+- Recover from mutex poisoning (`unwrap_or_else(|p| p.into_inner())`) instead of propagating a panic across a lock.
 - Native compile, cache, daemon, and benchmark code should log enough context to debug production failures without rerunning under a debugger.
 
 ## Native compile and cache changes
 - If a persisted-state format changes, keep a migration or legacy-read path unless there is a deliberate breaking decision documented in the PR.
 - Invalidation logic must be conservative under uncertainty. A false miss is acceptable; a false hit is not.
+- Bounds and caps (depth, file count, size, timeout) must fail loudly and disable caching for that build. A cap that silently drops inputs from a fingerprint is a false-hit bug.
+- Fingerprint inputs must cover every path that can change compiled output, including sources outside the workspace root reached through path dependencies.
 - New restore fast paths must prove correctness with targeted regression tests.
+
+## Agent surface changes
+- Machine-readable output is the contract. In `--json` mode every exit path emits exactly one JSON document on stdout, including failures.
+- Schema changes are additive by default. Removing, renaming, or retyping a field requires a `schema_version` bump and a note naming affected consumers.
+- Exit codes carry meaning; see `docs/agent/AGENT_DIAGNOSTICS.md`. Do not collapse a retryable infrastructure failure and a genuine correctness failure into the same code.
+- Every degradation is recorded. Scarb fallback, daemon-unavailable, cache-disabled, and offline downgrades must surface a diagnostic, not just a quieter result.
+- Diagnostics should answer: what happened, why, retryable or not, expected vs found, fallback used, replay command, schema version.
+
+## Verification and artifacts
+- Build receipts and class hashes are correctness surfaces, not telemetry. Treat a wrong `class_hash` like a wrong artifact.
+- Artifact bytes must not depend on whether a build was cold, warm, daemon-backed, or fallback-backed. Any setting that changes emitted bytes belongs in the fingerprint and the receipt.
+- Never mutate a user's manifest or sources as part of producing something to verify. If an input is unsuitable, fail loudly and say why.
 
 ## Benchmark changes
 - Keep lane conditions explicit: daemon mode, offline/online, CPU pinning, sample counts, and gate file.
 - Do not reduce samples or loosen thresholds to hide noise.
 - Do not change benchmark fixtures or baselines without documenting why.
+- A performance claim must name the harness, lane, sample count, and comparison build, and must come from a same-window run. Runs where uc fell back to scarb are not native wins.
 
 ## Docs and commands
 - If a command surface or repo bootstrap step changes, update `AGENTS.md`, `.codex/START_HERE.md`, and `docs/agent/REPO_MAP.md` in the same PR.
-- Local validation is authoritative. Keep the repo-managed hook and `scripts/local_ci_gate.sh` aligned with the documented commands whenever workflows, tests, or benchmark lanes change.
+- Local validation remains the fast path. Keep the repo-managed hook and `scripts/local_ci_gate.sh` aligned with the documented commands whenever workflows, tests, or benchmark lanes change.
+- CI covers correctness lanes only (see `docs/agent/CI_POLICY.md`). Benchmarks stay local and pinned.

--- a/docs/agent/CI_POLICY.md
+++ b/docs/agent/CI_POLICY.md
@@ -1,0 +1,47 @@
+# CI Policy
+
+## The split
+
+**CI runs correctness. Local runs performance.**
+
+| Lane | Where | Why |
+|---|---|---|
+| Format, lint (clippy), unit tests, native smoke tests, artifact parity | GitHub Actions, on push to `main` and on every PR | Deterministic, cheap, and must never regress unnoticed |
+| Benchmarks (`make benchmark-strict-*`, `make perf-fast`) | Local only, pinned host | Shared runners have unstable CPU allocation; a number from a noisy runner is worse than no number |
+
+## Why this changed
+
+This repo previously ran **no** automatic GitHub Actions: validation was local-first through
+`make local-ci` and the repo-managed pre-push hook, and the single workflow was
+`workflow_dispatch`-only. That policy was adopted to bound GitHub spend, and it worked while the
+repo was under daily development.
+
+It failed in a specific way worth recording. Between 2026-05-02 and 2026-08-01 `main` received no
+commits, and during that window nothing verified that `main` still built or that its tests still
+passed. Local-first gates only protect branches that a human is actively pushing. A dormant branch
+under local-only validation is an unverified branch.
+
+The correctness lanes are therefore now automatic. The cost is bounded: the jobs are the same ones
+`make validate-fast` already runs, plus a parity check, on two platforms.
+
+## What CI must not become
+
+- **No benchmark lanes.** Timing on shared runners is not evidence. Performance claims come from
+  `benchmarks/scripts/run_stability_benchmarks.sh` on a pinned local host, same-window, per
+  `benchmarks/README.md`.
+- **No lane that cannot fail deterministically.** A flaky required check trains everyone to ignore
+  required checks.
+- **Not a replacement for the local gate.** `make local-ci` and the pre-push hook stay authoritative
+  for the fast inner loop; CI is the backstop, not the first line.
+
+## Changing this policy
+
+CI scope changes require updating this file in the same PR. The compliance checklist item
+"Validation split is respected" enforces that.
+
+## Current workflows
+
+| Workflow | Trigger | Contents |
+|---|---|---|
+| `.github/workflows/ci.yml` | push to `main`, pull_request | fmt, clippy, `validate-fast`, native tests, artifact parity smoke |
+| `.github/workflows/agent-surface.yml` | `workflow_dispatch` | agent surface validation, run on demand |

--- a/docs/agent/PR_BOT_POLICY.md
+++ b/docs/agent/PR_BOT_POLICY.md
@@ -7,12 +7,61 @@
 - Make the repository easy for both review bots and coding agents to bootstrap correctly.
 - Keep GitHub spend bounded by using PR bots for review, while running routine tests and benchmarks locally.
 
+## Agent review loop
+
+Agents must not scrape the PR web UI. Read bot feedback as JSON:
+
+```sh
+make pr-feedback            # everything, for the current branch's PR
+make pr-feedback-open       # only unresolved threads
+make pr-feedback PR=73      # a specific PR
+```
+
+The output contains `counts.unresolved_bot_threads`, `counts.failing_checks`, per-thread
+`path`/`line`/`body`/`resolved`, and the check rollup. The loop is:
+
+1. Push a coherent slice, open a ready-for-review PR.
+2. Poll `make pr-feedback-open` until the bots have posted.
+3. Fix real findings; reply or resolve with rationale where a finding is wrong.
+4. Re-run until `unresolved_bot_threads` is 0 and `failing_checks` is 0.
+5. Merge after the quiet period below.
+
+CodeRabbit inline comments include a "Prompt for AI Agents" block
+(`reviews.enable_prompt_for_ai_agents`) — a ready-made codegen instruction for the finding.
+Use it as input, not as authority: verify the claim against the code before applying.
+
+## Pre-merge checks
+
+`.coderabbit.yaml` defines pre-merge checks that gate the PR when they fail in `error` mode
+(paired with `request_changes_workflow: true`):
+
+| Check | Mode | Gate |
+|---|---|---|
+| Title | error | imperative mood, names the surface, under ~72 chars |
+| Description | error | follows the PR template |
+| Invalidation regression coverage | error | reuse/restore changes ship with a test or a justification |
+| No silent degradation | error | every degradation path records a diagnostic |
+| Agent contract stability | error | schema changes additive or `schema_version` bumped |
+| Benchmark claim integrity | warning | perf numbers state harness, lane, samples, comparison build |
+| Linked issue assessment | warning | advisory |
+| Docstring coverage | off | deliberately disabled; see the comment in `.coderabbit.yaml` |
+
+Do not silence a failing check by weakening it. Either fix the PR or, if the check is wrong for
+this change, say so in the PR and let a human override.
+
 ## CodeRabbit
 
 - Use repo-local `.coderabbit.yaml` as the primary configuration source.
 - Keep path instructions narrow and file-type specific.
 - Prefer checked-in code-guideline files (`AGENTS.md`, `.codex/START_HERE.md`) for broad repo rules.
 - Do not overuse custom checks; they should be reserved for crisp pass/fail rules because they run in a read-only sandbox and cannot execute the full test suite.
+- Every CodeRabbit tool defaults to **enabled**. Only write an entry under `reviews.tools` to turn
+  something off, or to keep a security-relevant tool explicitly visible. Do not add `enabled: true`
+  lines that merely restate the default.
+- `ast-grep` has no `enabled` key — it is configured with `rule_dirs`/`packages`. Writing
+  `ast-grep: {enabled: false}` is a schema error that silently invalidates that block.
+- Validate config changes against the published schema before pushing:
+  `curl -sL https://coderabbit.ai/integrations/schema.v2.json` and check with any JSON-Schema validator.
 
 ## Qodo
 
@@ -31,7 +80,7 @@
 - Fix real correctness or regression findings first.
 - If two bots disagree, verify in code and tests rather than following either blindly.
 - Resolve comments only when the code or rationale is clearly complete.
-- Merge only after a 3-minute quiet period with no new useful AI feedback.
+- Merge only after a 6-minute quiet period with no new useful AI feedback, matching `AGENTS.md`.
 
 ## Repo-Specific Focus
 

--- a/docs/agent/PR_BOT_POLICY.md
+++ b/docs/agent/PR_BOT_POLICY.md
@@ -7,6 +7,10 @@
 - Make the repository easy for both review bots and coding agents to bootstrap correctly.
 - Keep GitHub spend bounded by using PR bots for review, while running routine tests and benchmarks locally.
 
+> Full end-to-end procedure, including bot-finding triage rules and the standing gotchas:
+> **`docs/agent/PR_LIFECYCLE.md`**. This file covers bot *configuration*; that one covers
+> how to *work* with them.
+
 ## Agent review loop
 
 Agents must not scrape the PR web UI. Read bot feedback as JSON:

--- a/docs/agent/PR_LIFECYCLE.md
+++ b/docs/agent/PR_LIFECYCLE.md
@@ -1,0 +1,129 @@
+# PR Lifecycle
+
+How a change gets from an idea to `main` in this repo. Applies to humans and coding
+agents alike; agents should treat it as executable procedure.
+
+Bots (CodeRabbit, Qodo) review every PR. **Treat their findings as an adversarial
+reviewer whose claims you must verify — not as ground truth to obey, and not as noise to
+ignore.**
+
+## 1. Branch
+
+- Never commit to `main`.
+- One feature branch per logical change; one logical change per commit.
+- Imperative commit subjects, no trailing period, ideally under 72 characters.
+- Prefer a fresh worktree for parallel work.
+
+## 2. Gate locally, and read the real exit code
+
+Run the gate on your branch head **before** opening a PR:
+
+```sh
+make local-ci
+```
+
+Scoped lanes while iterating: `make validate-fast`, `make validate-native`,
+`cargo test -p uc-cli --bin uc`, `make agent-validate`.
+
+**Read the gate's own status, not a pipeline's tail.** This is the single most common way
+an agent convinces itself a red gate is green:
+
+```sh
+# WRONG — reports grep's status, and prints nothing useful when the build failed
+cargo test -p uc-cli 2>&1 | grep -E "^error" | head -20
+
+# RIGHT — capture the command's own exit code
+cargo test -p uc-cli > /tmp/uc_test.log 2>&1; echo "EXIT=$?"
+grep -E "^error" -A 8 /tmp/uc_test.log | head -40
+```
+
+`${PIPESTATUS[0]}` also works in bash, but only immediately after the pipeline and only
+under bash — it silently yields nothing under `sh`. Redirect to a file and check `$?`.
+
+Backgrounded commands report the status of the *last* command in the chain, not your
+gate. Record the gate's status explicitly if you background it.
+
+## 3. Open the PR
+
+Fill the template: Summary, Linked Issue, Change Type, Validation (what you ran and that
+it passed), Risks, Rollback Plan. Open it ready-for-review, not draft — the bots need a
+reviewable state.
+
+Pre-merge checks gate the title and description (see `PR_BOT_POLICY.md`). Write the title
+in imperative mood naming the surface.
+
+## 4. Triage every bot finding
+
+This is the core of the job. For **each** finding:
+
+1. **Read it in full** — body, code location, suggested fix. Not just the title or the
+   severity badge. Severity labels are frequently miscalibrated.
+2. **Verify it independently against the actual code.** Reproduce the claimed failure:
+   construct the exact input or tamper the bot describes and confirm it really breaks.
+   Bots produce false positives, misattributions ("you introduced X" when X predates the
+   PR), and findings that are true in general but not in this codebase.
+3. **Check the history** when a bot claims your PR introduced something:
+   `git log -S '<snippet>' -- <path>` or `git blame`.
+4. **If real:** fix it minimally and add a regression test that reproduces the exact issue
+   described. Re-verify the fix closes it and that the honest path still passes.
+5. **If invalid or out of scope:** decline it explicitly, as a PR reply, with specific
+   verified reasoning. Never silently ignore a finding. Good declines name the reason:
+   "pre-existing, not introduced here (see `<sha>`)"; "this bound is deliberately loud —
+   see the comment above it"; "the flagged line is a test fixture, not production".
+6. **Recognize recurring false-positive patterns.** Some rules fire on every PR of a given
+   shape. Decline consistently with the same reasoning rather than re-litigating.
+7. **A security or critical badge on a security-sensitive change deserves extra rigor, not
+   reflexive dismissal.** Those are exactly where a real gap hides. Prove it is wrong
+   before declining it.
+
+Read findings as JSON rather than scraping the UI:
+
+```sh
+make pr-feedback-open    # unresolved threads only
+make pr-feedback         # everything, plus the check rollup
+```
+
+### Repo-specific priorities when triaging
+
+A finding that touches these is presumed real until you prove otherwise:
+
+- Cache or fingerprint reuse that could serve a stale artifact (**a false hit is always
+  worse than a false miss**).
+- A degradation path — fallback, daemon-unavailable, offline downgrade — that does not
+  record a diagnostic.
+- A JSON report or schema field removed, renamed, or retyped without a `schema_version`
+  bump, or a failure path that exits without emitting JSON in `--json` mode.
+- A performance claim not backed by a same-window strict-harness run.
+
+## 5. Re-gate, dispose, merge
+
+- After pushing fixes, **re-run the gate on the new head** and confirm green. Do not rely
+  on the previous run.
+- Bot inline comments on lines you changed become "outdated" automatically. A thread still
+  live is usually one you declined — fine, if it is dispositioned with reasoning.
+- Merge only when **all** hold:
+  - gate PASS on the fixed head,
+  - no unresolved substantive threads (declined ones answered),
+  - `mergeable` is clean,
+  - `counts.failing_checks` is 0,
+  - the PR has been quiet for at least 6 minutes (bots review on push and may lag).
+- Post a final comment summarizing dispositions: "Finding A fixed in `<sha>` + regression;
+  Finding B declined because …; gate PASS."
+- Merge, then delete the branch.
+
+## 6. Standing gotchas
+
+- **A PR-diff gate run after merge sees an empty diff** (HEAD == base) and can pass or
+  fail benignly. Validate on the PR head, not the merged tip.
+- **Pre-commit and pre-push hooks may reject compound commands** (`git push … && <reply>`).
+  Split them.
+- **Schema and fixture pins cascade.** If a change makes a checked-in digest, schema, or
+  golden fixture stale, regenerate it, then diff and confirm *only* what you intended
+  changed. An unexpected flip means unintended drift — investigate it rather than
+  accepting the new value. After updating, grep for the old value to confirm no stale
+  copies remain. Never edit a pin to make a check pass without understanding what the
+  check protects.
+- **Never fabricate.** No invented benchmark numbers, commit hashes, issue numbers, or
+  citations. If a value is unconfirmable, say so.
+- **Confirm before irreversible or outward-facing steps** — merging to a shared branch,
+  force-pushing, publishing. Approval for one action does not extend to the next.

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -8,7 +8,9 @@ This directory is the checked-in handoff layer for coding agents, humans, and PR
 - `AGENT_DIAGNOSTICS.md`: stable diagnostic-code contract for JSON consumers.
 - `AGENT_QUICKSTART.md`: command sequence agents should prefer before build, fix, or benchmark work.
 - `HUMAN_QUICKSTART.md`: compact human command sequence for the same surfaces.
-- `PR_BOT_POLICY.md`: how CodeRabbit and Qodo should be interpreted.
+- `PR_LIFECYCLE.md`: how to take a change to `main` — branching, gating, bot-finding triage, merge criteria. Read before your first commit.
+- `PR_BOT_POLICY.md`: how CodeRabbit and Qodo are configured and how their output should be interpreted.
+- `CI_POLICY.md`: what runs in GitHub Actions versus locally, and why.
 - `REPO_MAP.md`: generated map of current repo entrypoints and hot files.
 - `schemas/`: JSON schemas for diagnostic, project inspect, support, resolve, fetch, toolchain, source-store, build-plan, and build outputs.
 

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -5,11 +5,29 @@ pr_compliances:
     success_criteria: The PR includes focused regression tests for the affected invalidation or restore path and the code falls back conservatively on uncertainty.
     failure_criteria: Native cache or restore logic changed without regression coverage, or the code can reuse stale state when validation is ambiguous.
 
+  - title: Fingerprint bounds fail loudly
+    compliance_label: true
+    objective: Limits on fingerprint traversal must never silently shrink the set of inputs that determine cache identity.
+    success_criteria: Any depth, file-count, size, or timeout bound that is exceeded surfaces a diagnostic and disables cache reuse for that build, and fingerprint coverage includes sources reachable through path dependencies outside the workspace root.
+    failure_criteria: A bound silently excludes files from the fingerprint, or fingerprint traversal ignores inputs that can change compiled output.
+
+  - title: Agent contract stability
+    compliance_label: true
+    objective: Machine-readable output is a versioned contract that coding agents and CI depend on.
+    success_criteria: JSON report changes are additive, or bump the relevant `schema_version` and name affected consumers; every failure path in `--json` mode still emits exactly one JSON document; exit codes keep their documented meanings.
+    failure_criteria: A report field is removed, renamed, or retyped with no version bump; a failure path emits no JSON in `--json` mode; or distinct failure classes collapse onto one exit code.
+
+  - title: Verification artifacts are correctness surfaces
+    compliance_label: true
+    objective: Build receipts, class hashes, and emitted artifacts must be reproducible and honest about how they were produced.
+    success_criteria: Receipt and class-hash changes carry tests; artifact bytes stay identical across cold, warm, daemon, and fallback execution for the same inputs; any setting that changes emitted bytes is part of the fingerprint and the receipt; user manifests and sources are never mutated to make verification succeed.
+    failure_criteria: Artifact or receipt output varies with execution mode for identical inputs, a hash is computed from unpinned inputs, or the tool rewrites user sources or manifests before verifying them.
+
   - title: Benchmark rigor is preserved
     compliance_label: true
     objective: Performance-sensitive PRs must keep benchmark methodology reproducible.
-    success_criteria: Benchmark-related changes preserve explicit daemon mode, pinning behavior, sample counts, and gate configuration, and any methodology change is documented.
-    failure_criteria: The PR loosens benchmark conditions, hides lane settings, or changes perf gates without explanation.
+    success_criteria: Benchmark-related changes preserve explicit daemon mode, pinning behavior, sample counts, and gate configuration, and any methodology change is documented. Performance claims name the harness, lane, sample count, and comparison build.
+    failure_criteria: The PR loosens benchmark conditions, hides lane settings, changes perf gates without explanation, or states a performance number backed by a fallback run or an unstated lane.
 
   - title: Bot and agent entrypoints stay in sync
     compliance_label: true
@@ -17,14 +35,14 @@ pr_compliances:
     success_criteria: PRs that change repo bootstrap, commands, docs, or review tooling update the relevant files under `AGENTS.md`, `.codex/`, and `docs/agent/`.
     failure_criteria: Repo entrypoints drift or become stale after a command, path, or workflow change.
 
-  - title: Local validation stays authoritative
+  - title: Validation split is respected
     compliance_label: true
-    objective: Routine validation should run locally instead of spending GitHub Actions minutes by default.
-    success_criteria: Workflow-trigger or validation-surface PRs keep repo-managed hooks, local validation scripts, and agent docs aligned, and do not reintroduce automatic GitHub CI without an explicit documented decision.
-    failure_criteria: Automatic GitHub CI is reintroduced casually, or local hook/gate/documentation paths drift so agents can push without the intended local checks.
+    objective: Correctness gates run in CI; performance measurement stays local and pinned. This split was adopted deliberately (see docs/agent/CI_POLICY.md) after the repo's main branch went unvalidated for three months under local-only gates.
+    success_criteria: Workflow changes keep CI scoped to deterministic correctness lanes (format, lint, unit/native tests, artifact parity) and keep repo-managed hooks and local validation scripts aligned with the documented commands. Benchmark lanes remain local.
+    failure_criteria: Benchmark or timing-sensitive lanes are moved into GitHub Actions where they produce unreliable numbers, CI is expanded without updating `docs/agent/CI_POLICY.md`, or local hook and gate paths drift so agents can push without the intended checks.
 
   - title: Daemon and fallback behavior remain explicit
     compliance_label: true
     objective: Build execution should not fail or fall back silently in ways that hide risk.
-    success_criteria: Daemon, native compile, and fallback changes preserve actionable logging and respect explicit disallow-fallback modes.
+    success_criteria: Daemon, native compile, and fallback changes preserve actionable logging, record every degradation in a diagnostic or report field, and respect explicit disallow-fallback modes.
     failure_criteria: The PR introduces silent fallback, weakens error reporting, or obscures why a native path was not used.

--- a/scripts/pr_feedback.sh
+++ b/scripts/pr_feedback.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Collect review-bot feedback for a PR as a single JSON document.
+#
+# Coding agents use this instead of scraping the PR web UI: it merges CodeRabbit and
+# Qodo review comments, general comments, and the pre-merge/commit check states into one
+# machine-readable object, and reports which threads are still unresolved.
+#
+# Usage:
+#   scripts/pr_feedback.sh [PR_NUMBER] [--unresolved-only]
+#
+# With no PR number, resolves the PR for the current branch.
+# Requires: gh (authenticated), jq.
+
+set -euo pipefail
+
+PR_NUMBER=""
+UNRESOLVED_ONLY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --unresolved-only) UNRESOLVED_ONLY=1 ;;
+    -h|--help)
+      sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      if [[ "$arg" =~ ^[0-9]+$ ]]; then
+        PR_NUMBER="$arg"
+      else
+        echo "unknown argument: $arg" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+for bin in gh jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "required tool not found: $bin" >&2
+    exit 3
+  fi
+done
+
+if [[ -z "$PR_NUMBER" ]]; then
+  PR_NUMBER="$(gh pr view --json number --jq .number 2>/dev/null || true)"
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "no PR number given and no PR found for the current branch" >&2
+    exit 2
+  fi
+fi
+
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+
+# Review threads carry the resolution state, which the plain comments API does not expose.
+# shellcheck disable=SC2016  # GraphQL variables are literal, not shell expansions.
+THREADS="$(gh api graphql -f query='
+  query($owner:String!, $name:String!, $pr:Int!) {
+    repository(owner:$owner, name:$name) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes {
+            isResolved
+            isOutdated
+            path
+            line
+            comments(first:20) {
+              nodes { author { login } body url createdAt }
+            }
+          }
+        }
+      }
+    }
+  }' \
+  -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F pr="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes')"
+
+BOTS='["coderabbitai","coderabbitai[bot]","qodo-code-review","qodo-code-review[bot]","qodo-merge-pro","greptile-apps","greptile-apps[bot]"]'
+
+STATUS="$(gh pr view "$PR_NUMBER" --json statusCheckRollup,mergeable,reviewDecision,title,url \
+  --jq '{title,url,mergeable,reviewDecision,checks:[.statusCheckRollup[]? | {name:(.name // .context), status:(.status // "COMPLETED"), conclusion:(.conclusion // .state)}]}')"
+
+# `gh --jq` takes only an expression, so filter with a real jq invocation to pass --argjson.
+GENERAL="$(gh pr view "$PR_NUMBER" --json comments \
+  | jq --argjson bots "$BOTS" \
+      '[.comments[] | select(.author.login as $a | $bots | index($a)) | {author:.author.login, createdAt, body}]')"
+
+jq -n \
+  --argjson threads "$THREADS" \
+  --argjson status "$STATUS" \
+  --argjson general "$GENERAL" \
+  --argjson bots "$BOTS" \
+  --arg pr "$PR_NUMBER" \
+  --argjson unresolved_only "$UNRESOLVED_ONLY" '
+  {
+    pr: ($pr | tonumber),
+    title: $status.title,
+    url: $status.url,
+    review_decision: $status.reviewDecision,
+    mergeable: $status.mergeable,
+    checks: $status.checks,
+    bot_threads: [
+      $threads[]
+      | select(.comments.nodes[0].author.login as $a | $bots | index($a))
+      | select($unresolved_only == 0 or .isResolved == false)
+      | {
+          resolved: .isResolved,
+          outdated: .isOutdated,
+          path: .path,
+          line: .line,
+          bot: .comments.nodes[0].author.login,
+          url: .comments.nodes[0].url,
+          body: .comments.nodes[0].body,
+          replies: [.comments.nodes[1:][] | {author: .author.login, body: .body}]
+        }
+    ],
+    bot_summaries: $general
+  }
+  | . + {
+      counts: {
+        unresolved_bot_threads: ([.bot_threads[] | select(.resolved == false)] | length),
+        total_bot_threads: (.bot_threads | length),
+        failing_checks: ([.checks[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length)
+      }
+    }
+  '


### PR DESCRIPTION
## Summary

Deep audit of the repo's review-bot setup against the published CodeRabbit schema v2 and the current Qodo surface, plus the tooling that makes the review loop drivable by coding agents.

**Real bug fixed.** `ast-grep` has no `enabled` key in the CodeRabbit schema (it takes `rule_dirs`/`util_dirs`/`essential_rules`/`packages`). The existing `ast-grep: {enabled: false}` block was a schema error. Removed.

**Corrected assumption.** Every CodeRabbit tool defaults to `enabled: true`. The previous `enabled: true` entries were no-ops, and clippy was already running despite never being named. The config now only writes an entry to opt *out*, or to keep a security-relevant tool explicitly visible, with a comment saying so.

**The actual gap: `pre_merge_checks` was entirely unconfigured**, so every check sat at its default `warning` — including docstring coverage at 80%, which would flag unrelated PRs given this repo's largest files predate the convention. Now configured deliberately:

| Check | Mode |
|---|---|
| Title (imperative, names surface, <72 chars) | error |
| Description (follows template) | error |
| Invalidation regression coverage | error |
| No silent degradation | error |
| Agent contract stability (schema_version) | error |
| Benchmark claim integrity | warning |
| Docstring coverage | **off**, deliberately |

The three custom checks encode gates this repo already states in prose but could not enforce: reuse/restore changes ship with a test, degradation paths record a diagnostic, schema changes are additive or bump `schema_version`. Paired with `request_changes_workflow: true` these block the PR, which is what lets an agent self-serve without a human gatekeeper.

**Agent feedback loop.** `scripts/pr_feedback.sh` + `make pr-feedback[-open]` returns bot review threads with resolution state, reply chains, and the check rollup as one JSON document, so agents stop scraping the PR UI. Verified live against #73. Also enables `reviews.enable_prompt_for_ai_agents` so inline comments carry codegen instructions.

**Other changes:** labeling instructions with auto-apply; `third_party/**` and `docs/agent/schemas/**` path instructions (vendored patch review and schema-contract review had none); `Cargo.lock`/baselines excluded from review; Qodo guidelines rewritten as an explicit priority order; `best_practices.md` and `pr_compliance_checklist.yaml` extended with agent-contract and verification rules; `docs/agent/CI_POLICY.md` records the correctness-in-CI / benchmarks-local split ahead of the workflow PR.

Fixed a doc drift while here: `AGENTS.md` said a 6-minute merge quiet period, `PR_BOT_POLICY.md` said 3. Aligned at 6.

## Linked Issue

Refs #77 (bot setup precondition for the phased plan)

## Change Type
- [ ] feature
- [ ] bugfix
- [x] refactor
- [x] docs
- [ ] benchmark-only

## Validation
- [x] `.coderabbit.yaml` validated against `https://coderabbit.ai/integrations/schema.v2.json` with jsonschema — valid
- [x] `shellcheck scripts/pr_feedback.sh` clean
- [x] `scripts/pr_feedback.sh 73` returns correct live data
- [x] `make agent-validate` passes
- [ ] benchmark rerun — n/a, no code paths touched
- [x] docs updated

## Risks

Pre-merge checks in `error` mode will start blocking PRs that previously merged freely. That is the intent, but the first few PRs may hit the title/description gates. Custom check instructions are prose evaluated by a model, so they are advisory-grade, not deterministic — they are set to fail toward "explain in the PR description" rather than hard-blocking ambiguous cases.

`auto_apply_labels` will create labels that do not exist yet in the repo.

## Rollback Plan

Revert the commit. All changes are configuration and docs; no code paths are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive pull request lifecycle, CI, review-bot, and contribution guidance.
  * Clarified validation requirements, benchmark reporting, fallback behavior, cache diagnostics, and contract stability expectations.
  * Updated the documentation index and onboarding checklist with the new procedures.

* **Chores**
  * Added commands to retrieve all or unresolved pull-request review feedback.
  * Added automated collection of review comments, metadata, and check results in a structured report.
  * Expanded compliance and review configuration to support consistent quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->